### PR TITLE
feat(grok): continue Agent Turns over ACP resume

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -273,6 +273,7 @@
       "name": "@ready-for-agent/grok",
       "version": "0.0.1",
       "dependencies": {
+        "@ready-for-agent/acp-client": "workspace:*",
         "@ready-for-agent/agent-backend": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",

--- a/packages/acp-client/src/lib/acp-client.ts
+++ b/packages/acp-client/src/lib/acp-client.ts
@@ -1,5 +1,5 @@
 import { type ChildProcess, spawn } from "node:child_process"
-import { Readable, Writable } from "node:stream"
+import { Writable } from "node:stream"
 import * as acp from "@agentclientprotocol/sdk"
 import { Context, Effect, Layer, Schema, type Scope } from "effect"
 import {
@@ -24,6 +24,7 @@ import type {
   AcpSessionResult,
 } from "./types.js"
 import { AcpSessionId, AcpStopReason } from "./types.js"
+import { readableToWebBytes } from "./web-streams.js"
 
 export type AcpClientShape = {
   readonly connect: (
@@ -76,6 +77,7 @@ const waitForSpawn = (
 type SessionBuffers = {
   readonly collecting: Set<string>
   readonly chunks: Map<string, string[]>
+  readonly reported: Map<string, string>
 }
 
 const attachConnection = (
@@ -205,6 +207,7 @@ const attachConnection = (
   ) {
     buffers.collecting.add(input.sessionId)
     buffers.chunks.delete(input.sessionId)
+    buffers.reported.delete(input.sessionId)
     const result = yield* request("session/prompt", () =>
       sdk.agent.request(acp.methods.agent.session.prompt, {
         sessionId: input.sessionId,
@@ -230,7 +233,9 @@ const attachConnection = (
       ),
     )
     const completed: AcpPromptResult = {
-      sessionId: input.sessionId,
+      sessionId: AcpSessionId.make(
+        buffers.reported.get(input.sessionId) ?? input.sessionId,
+      ),
       assistantText: takeText(input.sessionId),
       stopReason,
       ...responseMeta(result._meta),
@@ -302,20 +307,28 @@ const connect = Effect.fn("AcpClient.connect")(function* (
   const buffers: SessionBuffers = {
     collecting: new Set<string>(),
     chunks: new Map<string, string[]>(),
+    reported: new Map<string, string>(),
   }
   const collectSessionUpdate = (notification: acp.SessionNotification) => {
+    const update = notification.update
+    if (
+      update.sessionUpdate !== "agent_message_chunk" ||
+      update.content.type !== "text"
+    ) {
+      return
+    }
+    for (const requested of buffers.collecting) {
+      if (buffers.reported.get(requested) === requested) {
+        continue
+      }
+      buffers.reported.set(requested, notification.sessionId)
+    }
     if (!buffers.collecting.has(notification.sessionId)) {
       return
     }
-    const update = notification.update
-    if (
-      update.sessionUpdate === "agent_message_chunk" &&
-      update.content.type === "text"
-    ) {
-      const existing = buffers.chunks.get(notification.sessionId) ?? []
-      existing.push(update.content.text)
-      buffers.chunks.set(notification.sessionId, existing)
-    }
+    const existing = buffers.chunks.get(notification.sessionId) ?? []
+    existing.push(update.content.text)
+    buffers.chunks.set(notification.sessionId, existing)
   }
 
   const sdk = yield* Effect.acquireRelease(
@@ -323,7 +336,7 @@ const connect = Effect.fn("AcpClient.connect")(function* (
       try: () => {
         const stream = acp.ndJsonStream(
           Writable.toWeb(stdin),
-          Readable.toWeb(stdout),
+          readableToWebBytes(stdout),
         )
         return acp
           .client({ name: "ready-for-agent" })

--- a/packages/acp-client/src/lib/fake-acp-agent.ts
+++ b/packages/acp-client/src/lib/fake-acp-agent.ts
@@ -1,6 +1,7 @@
-import { Readable, Writable } from "node:stream"
+import { Writable } from "node:stream"
 import { fileURLToPath } from "node:url"
 import * as acp from "@agentclientprotocol/sdk"
+import { readableToWebBytes } from "./web-streams.js"
 
 export const fakeAcpAgentPath = fileURLToPath(import.meta.url)
 
@@ -8,6 +9,9 @@ export const FAKE_ACP_ENV = {
   requireAuth: "FAKE_ACP_REQUIRE_AUTH",
   authMethodId: "FAKE_ACP_AUTH_METHOD_ID",
   assistantText: "FAKE_ACP_ASSISTANT_TEXT",
+  echoPrompt: "FAKE_ACP_ECHO_PROMPT",
+  reportedSessionId: "FAKE_ACP_REPORTED_SESSION_ID",
+  alsoSessionId: "FAKE_ACP_ALSO_SESSION_ID",
   resumeFail: "FAKE_ACP_RESUME_FAIL",
   loadFail: "FAKE_ACP_LOAD_FAIL",
   promptDelayMs: "FAKE_ACP_PROMPT_DELAY_MS",
@@ -18,8 +22,25 @@ const defaultAuthMethodId = "token"
 
 const envFlag = (name: string): boolean => process.env[name] === "1"
 
-const assistantText = (): string =>
-  process.env[FAKE_ACP_ENV.assistantText] ?? defaultAssistantText
+const promptText = (params: acp.PromptRequest): string => {
+  const parts: string[] = []
+  for (const block of params.prompt) {
+    if (block.type === "text") {
+      parts.push(block.text)
+    }
+  }
+  return parts.join("")
+}
+
+const assistantText = (params: acp.PromptRequest): string => {
+  if (envFlag(FAKE_ACP_ENV.echoPrompt)) {
+    return promptText(params)
+  }
+  return process.env[FAKE_ACP_ENV.assistantText] ?? defaultAssistantText
+}
+
+const reportedSessionId = (requested: string): string =>
+  process.env[FAKE_ACP_ENV.reportedSessionId] ?? requested
 
 const authMethodId = (): string =>
   process.env[FAKE_ACP_ENV.authMethodId] ?? defaultAuthMethodId
@@ -162,17 +183,31 @@ class FakeAcpAgent {
 
     try {
       await delay(promptDelayMs(), signal)
-      for (const chunk of textChunks(assistantText())) {
+      const sessionId = reportedSessionId(params.sessionId)
+      for (const chunk of textChunks(assistantText(params))) {
         if (signal.aborted) {
           return { stopReason: "cancelled", ...optionalMeta(params._meta) }
         }
         await client.notify(acp.methods.client.session.update, {
-          sessionId: params.sessionId,
+          sessionId,
           update: {
             sessionUpdate: "agent_message_chunk",
             content: {
               type: "text",
               text: chunk,
+            },
+          },
+        })
+      }
+      const extraSessionId = process.env[FAKE_ACP_ENV.alsoSessionId]
+      if (extraSessionId !== undefined && extraSessionId.length > 0) {
+        await client.notify(acp.methods.client.session.update, {
+          sessionId: extraSessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: {
+              type: "text",
+              text: "subagent",
             },
           },
         })
@@ -225,7 +260,7 @@ const delay = (ms: number, signal: AbortSignal): Promise<void> => {
 
 export const runFakeAcpAgent = (): void => {
   const input = Writable.toWeb(process.stdout)
-  const output = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+  const output = readableToWebBytes(process.stdin)
   const stream = acp.ndJsonStream(input, output)
   const agent = new FakeAcpAgent()
 

--- a/packages/acp-client/src/lib/web-streams.ts
+++ b/packages/acp-client/src/lib/web-streams.ts
@@ -1,0 +1,6 @@
+import { Readable } from "node:stream"
+
+export const readableToWebBytes = (
+  stream: Readable,
+): ReadableStream<Uint8Array> =>
+  Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>

--- a/packages/acp-client/test/acp-client.spec.ts
+++ b/packages/acp-client/test/acp-client.spec.ts
@@ -167,6 +167,51 @@ describe("Effect ACP client", () => {
     expect(result.prompt._meta).toEqual(meta)
   })
 
+  it("returns the Session ID the agent reported on prompt chunks", async () => {
+    const requested = AcpSessionId.make("sess_requested")
+    const reported = "sess_reported"
+    const result = await run(
+      (connection) =>
+        Effect.gen(function* () {
+          yield* connection.initialize()
+          yield* connection.resumeSession({
+            sessionId: requested,
+            cwd: process.cwd(),
+          })
+          return yield* connection.prompt({
+            sessionId: requested,
+            prompt: "continue",
+          })
+        }),
+      { [FAKE_ACP_ENV.reportedSessionId]: reported },
+    )
+
+    expect(result.sessionId).toBe(reported)
+    expect(result.assistantText).toBe("")
+  })
+
+  it("keeps the requested Session ID when a later chunk uses another Session", async () => {
+    const requested = AcpSessionId.make("sess_requested")
+    const result = await run(
+      (connection) =>
+        Effect.gen(function* () {
+          yield* connection.initialize()
+          yield* connection.resumeSession({
+            sessionId: requested,
+            cwd: process.cwd(),
+          })
+          return yield* connection.prompt({
+            sessionId: requested,
+            prompt: "continue",
+          })
+        }),
+      { [FAKE_ACP_ENV.alsoSessionId]: "sess_subagent" },
+    )
+
+    expect(result.sessionId).toBe(requested)
+    expect(result.assistantText).toBe("hello from fake agent")
+  })
+
   it("fails with a tagged protocol error when resume is refused", async () => {
     const result = await run(
       (connection) =>

--- a/packages/grok/package.json
+++ b/packages/grok/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "@ready-for-agent/acp-client": "workspace:*",
     "@ready-for-agent/agent-backend": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0"

--- a/packages/grok/src/lib/build-args.ts
+++ b/packages/grok/src/lib/build-args.ts
@@ -78,3 +78,19 @@ export const buildRunArgs = (input: {
 
   return args
 }
+
+export const buildAcpContinueArgs = (input: {
+  readonly model: string
+  readonly thinkingLevel: string | null
+}): ReadonlyArray<string> => [
+  "--no-auto-update",
+  "agent",
+  "--no-leader",
+  "--always-approve",
+  "-m",
+  input.model,
+  ...(input.thinkingLevel !== null
+    ? ["--reasoning-effort", input.thinkingLevel]
+    : []),
+  "stdio",
+]

--- a/packages/grok/src/lib/grok.ts
+++ b/packages/grok/src/lib/grok.ts
@@ -2,19 +2,31 @@ import { randomUUID } from "node:crypto"
 import { Duration, Effect, FileSystem, Layer } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import {
+  AcpClient,
+  type AcpClientError,
+  AcpProcessExitError,
+  AcpProtocolError,
+  AcpSessionId,
+  AcpSpawnError,
+} from "@ready-for-agent/acp-client"
+import {
   AGENT_BACKEND_IDS,
   AgentBackend,
   AgentBackendConfigError,
   type AgentBackendError,
   AgentBackendExitError,
+  AgentBackendNotInstalledError,
+  AgentBackendTimeoutError,
   type ContinueTurnInput,
   type InspectInput,
   type StartTurnInput,
+  formatAgentCliNotFoundRemediation,
   malformedOutput,
   runCliCapture,
   runCliTurn,
 } from "@ready-for-agent/agent-backend"
 import {
+  buildAcpContinueArgs,
   buildPromptBody,
   buildRunArgs,
   shouldUsePromptFile,
@@ -47,9 +59,46 @@ export class Grok {
       Effect.gen(function* () {
         const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
         const fs = yield* FileSystem.FileSystem
+        const acp = yield* AcpClient
         const binary = options.binary ?? DEFAULT_BINARY
         const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
         const environment = makeGrokEnvironment()
+
+        const mapAcpError =
+          (input: { readonly cwd: string; readonly sessionId: string }) =>
+          (error: AcpClientError | AgentBackendError): AgentBackendError => {
+            if (error instanceof AcpSpawnError) {
+              if (error.message.includes("not found")) {
+                return new AgentBackendNotInstalledError({
+                  message: formatAgentCliNotFoundRemediation({
+                    backendLabel: GROK_BACKEND.label,
+                    binary,
+                  }),
+                  backend: GROK_BACKEND,
+                  binary,
+                  cause: error,
+                })
+              }
+              return AgentBackendExitError.new({
+                exitCode: 1,
+                cwd: input.cwd,
+                sessionId: input.sessionId,
+                message: error.message,
+              })
+            }
+            if (error instanceof AcpProcessExitError) {
+              return AgentBackendExitError.new({
+                exitCode: error.exitCode ?? 1,
+                cwd: input.cwd,
+                sessionId: input.sessionId,
+                message: error.message,
+              })
+            }
+            if (error instanceof AcpProtocolError) {
+              return malformedOutput(input.cwd, error.message)
+            }
+            return error
+          }
 
         const inspect = Effect.fn("Grok.inspect")(function* (
           input: InspectInput,
@@ -108,7 +157,6 @@ export class Grok {
           readonly model: string
           readonly thinkingLevel: string | null
           readonly sessionId: string
-          readonly resume: boolean
           readonly command?: string
           readonly timeout?: Duration.Input
           readonly onSessionId?: StartTurnInput["onSessionId"]
@@ -119,7 +167,7 @@ export class Grok {
           // Scoped so an oversized prompt file lives only as long as the turn.
           Effect.scoped(
             Effect.gen(function* () {
-              if (!input.resume && input.onSessionId !== undefined) {
+              if (input.onSessionId !== undefined) {
                 yield* input.onSessionId(input.sessionId).pipe(
                   Effect.catch((error) =>
                     Effect.logWarning("Grok onSessionId observer failed", {
@@ -144,9 +192,7 @@ export class Grok {
                 cwd: input.cwd,
                 model: input.model,
                 thinkingLevel: input.thinkingLevel,
-                ...(input.resume
-                  ? { resumeSessionId: input.sessionId }
-                  : { sessionId: input.sessionId }),
+                sessionId: input.sessionId,
                 ...(promptFile !== undefined ? { promptFile } : {}),
               })
 
@@ -237,20 +283,85 @@ export class Grok {
             runTurn({
               ...input,
               sessionId: randomUUID(),
-              resume: false,
             }),
           ),
           continueTurn: Effect.fn("Grok.continueTurn")(
-            (input: ContinueTurnInput) =>
-              runTurn({
-                ...input,
-                sessionId: input.sessionId,
-                resume: true,
-              }),
+            (input: ContinueTurnInput) => {
+              const timeout = input.timeout ?? defaultTimeout
+              const timeoutMs = Duration.toMillis(timeout)
+              return Effect.scoped(
+                Effect.gen(function* () {
+                  const connection = yield* acp.connect({
+                    command: binary,
+                    args: buildAcpContinueArgs({
+                      model: input.model,
+                      thinkingLevel: input.thinkingLevel,
+                    }),
+                    cwd: input.cwd,
+                    env: environment,
+                  })
+                  const initialized = yield* connection.initialize()
+                  if (
+                    initialized.authMethods.some(
+                      (method) => method.id === "cached_token",
+                    )
+                  ) {
+                    yield* connection.authenticate({
+                      methodId: "cached_token",
+                    })
+                  }
+                  const sessionId = AcpSessionId.make(input.sessionId)
+                  yield* connection.resumeSession({
+                    sessionId,
+                    cwd: input.cwd,
+                    _meta: { yoloMode: true },
+                  })
+                  const prompt = yield* connection.prompt({
+                    sessionId,
+                    prompt: buildPromptBody({
+                      prompt: input.prompt,
+                      ...(input.command !== undefined
+                        ? { command: input.command }
+                        : {}),
+                    }),
+                    _meta: { yoloMode: true },
+                  })
+                  if (prompt.sessionId !== input.sessionId) {
+                    return yield* malformedOutput(
+                      input.cwd,
+                      `(session id mismatch: expected ${input.sessionId}, got ${prompt.sessionId})`,
+                    )
+                  }
+                  if (prompt.stopReason !== "end_turn") {
+                    return yield* AgentBackendExitError.new({
+                      exitCode: 1,
+                      cwd: input.cwd,
+                      sessionId: input.sessionId,
+                      message: `Grok Build stopped: ${prompt.stopReason}`,
+                    })
+                  }
+                  return {
+                    sessionId: input.sessionId,
+                    assistantText: prompt.assistantText,
+                  }
+                }),
+              ).pipe(
+                Effect.mapError(mapAcpError(input)),
+                Effect.timeoutOrElse({
+                  duration: timeout,
+                  orElse: () =>
+                    new AgentBackendTimeoutError({
+                      cwd: input.cwd,
+                      timeoutMs,
+                      sessionId: input.sessionId,
+                    }),
+                }),
+              )
+            },
           ),
         })
       }),
-    )
+    ).pipe(Layer.provide(AcpClient.layer))
 
   static layerForTests = () => Grok.layer({})
 }

--- a/packages/grok/test/build-args.spec.ts
+++ b/packages/grok/test/build-args.spec.ts
@@ -1,5 +1,9 @@
 import { PROMPT_ARGV_BYTE_LIMIT } from "@ready-for-agent/agent-backend"
-import { buildRunArgs, shouldUsePromptFile } from "../src/index.js"
+import {
+  buildAcpContinueArgs,
+  buildRunArgs,
+  shouldUsePromptFile,
+} from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
 describe("buildRunArgs", () => {
@@ -117,6 +121,42 @@ describe("buildRunArgs", () => {
     })
     expect(args[args.indexOf("-p") + 1]).toBe(prompt)
     expect(args).not.toContain("--prompt-file")
+  })
+
+  it("builds unattended ACP stdio args without headless resume", () => {
+    expect(
+      buildAcpContinueArgs({
+        model: "grok-code-fast-1",
+        thinkingLevel: "high",
+      }),
+    ).toEqual([
+      "--no-auto-update",
+      "agent",
+      "--no-leader",
+      "--always-approve",
+      "-m",
+      "grok-code-fast-1",
+      "--reasoning-effort",
+      "high",
+      "stdio",
+    ])
+  })
+
+  it("omits ACP reasoning effort when thinkingLevel is null", () => {
+    expect(
+      buildAcpContinueArgs({
+        model: "grok-4.5",
+        thinkingLevel: null,
+      }),
+    ).toEqual([
+      "--no-auto-update",
+      "agent",
+      "--no-leader",
+      "--always-approve",
+      "-m",
+      "grok-4.5",
+      "stdio",
+    ])
   })
 
   it("counts the /review prefix toward the argv byte limit", () => {

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { FAKE_ACP_ENV, fakeAcpAgentPath } from "@ready-for-agent/acp-client"
 import {
   AgentBackend,
   AgentBackendConfigError,
@@ -43,6 +44,38 @@ const captureSessionScript = [
 ].join("\n")
 
 const endEvent = `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"EndTurn\\",\\"sessionId\\":\\"$sid\\"}"`
+
+const withAcpGrok = async <A>(
+  use: (path: string) => Promise<A>,
+  script = `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fakeAcpAgentPath)}`,
+): Promise<A> => withExecutable(script, use)
+
+const SESSION_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+const continueTurn = (
+  binary: string,
+  input: {
+    readonly sessionId?: string
+    readonly prompt?: string
+    readonly model?: string
+    readonly thinkingLevel?: string | null
+    readonly command?: string
+    readonly timeout?: string
+  } = {},
+) =>
+  Effect.gen(function* () {
+    const backend = yield* AgentBackend
+    return yield* backend.continueTurn({
+      cwd: process.cwd(),
+      sessionId: input.sessionId ?? SESSION_ID,
+      prompt: input.prompt ?? "second",
+      model: input.model ?? "grok-code-fast-1",
+      thinkingLevel:
+        input.thinkingLevel === undefined ? "high" : input.thinkingLevel,
+      timeout: input.timeout ?? "5 seconds",
+      ...(input.command !== undefined ? { command: input.command } : {}),
+    })
+  }).pipe(Effect.provide(provide(binary)))
 
 const startTurn = (
   binary: string,
@@ -160,38 +193,73 @@ describe("Grok AgentBackend adapter", () => {
   })
 
   it("resumes exact session and can switch model/effort", async () => {
-    await withExecutable(
-      [
-        captureSessionScript,
-        `printf '%s\\n' '{"type":"text","data":"ok"}'`,
-        endEvent,
-      ].join("\n"),
-      async (binary) => {
-        const outcome = await Effect.runPromise(
-          Effect.gen(function* () {
-            const backend = yield* AgentBackend
-            const started = yield* backend.startTurn({
-              cwd: process.cwd(),
-              prompt: "first",
-              model: "grok-4.5",
-              thinkingLevel: "low",
-              timeout: "2 seconds",
-            })
-            const continued = yield* backend.continueTurn({
-              cwd: process.cwd(),
-              sessionId: started.sessionId,
-              prompt: "second",
-              model: "grok-code-fast-1",
-              thinkingLevel: "high",
-              timeout: "2 seconds",
-            })
-            return { started, continued }
-          }).pipe(Effect.provide(provide(binary))),
-        )
+    await withAcpGrok(async (binary) => {
+      const continued = await Effect.runPromise(continueTurn(binary))
+      expect(continued.sessionId).toBe(SESSION_ID)
+      expect(continued.assistantText).toBe("hello from fake agent")
+    })
+  })
 
-        expect(outcome.continued.sessionId).toBe(outcome.started.sessionId)
-        expect(outcome.continued.assistantText).toBe("ok")
+  it("rejects a Session ID mismatch from the ACP agent", async () => {
+    const reported = "00000000-0000-4000-8000-000000000099"
+    await withAcpGrok(
+      async (binary) => {
+        const error = await Effect.runPromise(
+          continueTurn(binary).pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
       },
+      [
+        `export ${FAKE_ACP_ENV.reportedSessionId}=${JSON.stringify(reported)}`,
+        `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fakeAcpAgentPath)}`,
+      ].join("\n"),
+    )
+  })
+
+  it("prefixes /review into the ACP prompt on continueTurn", async () => {
+    await withAcpGrok(
+      async (binary) => {
+        const continued = await Effect.runPromise(
+          continueTurn(binary, {
+            command: "/review",
+            prompt: "Review uncommitted worktree changes.",
+          }),
+        )
+        expect(continued.sessionId).toBe(SESSION_ID)
+        expect(continued.assistantText).toBe(
+          "/review\nReview uncommitted worktree changes.",
+        )
+      },
+      [
+        `export ${FAKE_ACP_ENV.echoPrompt}=1`,
+        `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fakeAcpAgentPath)}`,
+      ].join("\n"),
+    )
+  })
+
+  it("passes model, thinking level, and always-approve on the ACP spawn", async () => {
+    await withAcpGrok(
+      async (binary) => {
+        const continued = await Effect.runPromise(
+          continueTurn(binary, {
+            model: "grok-code-fast-1",
+            thinkingLevel: "high",
+          }),
+        )
+        expect(continued.sessionId).toBe(SESSION_ID)
+      },
+      [
+        'case " $* " in *" --no-auto-update "*) ;; *) exit 20 ;; esac',
+        'case " $* " in *" agent "*) ;; *) exit 21 ;; esac',
+        'case " $* " in *" --no-leader "*) ;; *) exit 22 ;; esac',
+        'case " $* " in *" --always-approve "*) ;; *) exit 23 ;; esac',
+        'case " $* " in *" -m grok-code-fast-1 "*) ;; *) exit 24 ;; esac',
+        'case " $* " in *" --reasoning-effort high "*) ;; *) exit 25 ;; esac',
+        'case " $* " in *" stdio "*) ;; *) exit 26 ;; esac',
+        'case " $* " in *" --resume "*) exit 27 ;; esac',
+        'case " $* " in *" -p "*) exit 28 ;; esac',
+        `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(fakeAcpAgentPath)}`,
+      ].join("\n"),
     )
   })
 

--- a/packages/grok/tsconfig.lib.json
+++ b/packages/grok/tsconfig.lib.json
@@ -11,6 +11,9 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../acp-client/tsconfig.lib.json"
+    },
+    {
       "path": "../agent-backend/tsconfig.lib.json"
     }
   ]


### PR DESCRIPTION
Headless Grok `--resume` + `-p` never emits stdout on a real Implement
Session, so Review and every later continue hang. Continue now speaks ACP
(`grok agent stdio` → `session/resume` → `session/prompt`) and returns
the same Session ID plus ordered assistant text.

`startTurn`, `grok models` inspect, and Jump stay on the existing CLI.
Lifecycle still calls `continueTurn`. Turns stay unattended
(`--always-approve`, `--no-leader`, `_meta.yoloMode`). `/review` is still
prompt-prefixed; model and Thinking Level still go on the spawn.

Tests drive `continueTurn` through a fake ACP `grok`: same Session ID,
chunked assistant text, mismatch rejected. A matching Session ID is not
overwritten by a later foreign chunk (subagent). Load fallback and
startup-hang classification remain #1121.

Closes #1120