### PR TITLE
feat(github-service): add helper-backed user-attachment uploads

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -370,6 +370,12 @@ export const ambientGitHubLayer = (options: {
               service.rerunWorkflowRun(repository, workflowRunId),
             ),
         ),
+        uploadUserAttachment: Effect.fn("AmbientGitHub.uploadUserAttachment")(
+          (repository, input) =>
+            authenticated("lifecycle", repository, (service) =>
+              service.uploadUserAttachment(repository, input),
+            ),
+        ),
         ensureIssueCompletedWithSummary: Effect.fn(
           "AmbientGitHub.ensureIssueCompletedWithSummary",
         )((repository, issueNumber, workItemId, summaryMarkdown) =>

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -25,6 +25,7 @@ import {
   INCOMPLETE_AUTOMATED_REVIEW_SIGNATURE,
   formatGitHubHelperShellCommand,
   formatTlsTrustRemediation,
+  isGitHubUserAttachmentUrl,
   parseGitHubHelperControl,
   resolveGitHubHelperChildSpawn,
 } from "@ready-for-agent/github-service"
@@ -799,6 +800,32 @@ export const keymaxxerGitHubLayer = (options: {
               describe: "rerun workflow run",
               args: [encodeArgument(String(workflowRunId))],
               decode: decodeVoid,
+            }),
+        ),
+        uploadUserAttachment: Effect.fn("KeymaxxerGitHub.uploadUserAttachment")(
+          (repository, input) =>
+            callHelper({
+              operation: "upload-user-attachment",
+              repository,
+              describe: "upload user attachment",
+              args: [
+                encodeArgument(
+                  JSON.stringify({
+                    name: input.name,
+                    contentType: input.contentType,
+                    filePath: input.filePath,
+                  }),
+                ),
+              ],
+              decode: (stdout) => {
+                const url = stdout.trim()
+                if (!isGitHubUserAttachmentUrl(url)) {
+                  return Effect.fail(
+                    requestError(repository, "decode user attachment URL"),
+                  )
+                }
+                return Effect.succeed(url)
+              },
             }),
         ),
         ensureIssueCompletedWithSummary: Effect.fn(

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -52,6 +52,7 @@ const serviceWithList = (
   markPullRequestReadyForReview: () => Effect.die("not used"),
   mergePullRequest: () => Effect.die("not used"),
   rerunWorkflowRun: () => Effect.void,
+  uploadUserAttachment: () => Effect.die("not used"),
   ensureIssueCompletedWithSummary: () => Effect.die("not used"),
 })
 

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -214,6 +214,10 @@ const defaultGithubLayer = Layer.merge(
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
     rerunWorkflowRun: () => Effect.void,
+    uploadUserAttachment: () =>
+      Effect.succeed(
+        "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+      ),
     ensureIssueCompletedWithSummary: () => Effect.void,
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     listReadyIssues: () => Effect.succeed([]),
@@ -776,6 +780,10 @@ describe("Job worker", () => {
         markPullRequestReadyForReview: () => Effect.void,
         mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
         rerunWorkflowRun: () => Effect.void,
+        uploadUserAttachment: () =>
+          Effect.succeed(
+            "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+          ),
         ensureIssueCompletedWithSummary: () => Effect.void,
         getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
         listReadyIssues: () =>

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1179,6 +1179,50 @@ describe("Keymaxxer-backed GitHub layer", () => {
     }),
   )
 
+  it.effect(
+    "uploads a user attachment through the configured repository token",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        const attachmentUrl =
+          "https://github.com/user-attachments/assets/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: attachmentUrl,
+              stderr: successfulHelperControl,
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const url = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github.uploadUserAttachment(acmeWidgets, {
+            name: "before.png",
+            contentType: "image/png",
+            filePath: "/tmp/before.png",
+          })
+        }).pipe(Effect.provide(layer))
+
+        expect(url).toBe(attachmentUrl)
+        expect(runs).toHaveLength(1)
+        expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+        expect(runs[0]?.command).toContain("upload-user-attachment.ts")
+        expect(runs[0]?.command).toContain('"--conditions"')
+        expect(runs[0]?.command).not.toContain("ghp_")
+      }),
+  )
+
   it.effect("rejects malformed Ready Issue fields through Schema", () =>
     Effect.gen(function* () {
       const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
@@ -1748,6 +1792,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           markPullRequestReadyForReview: () => Effect.die("not used"),
           mergePullRequest: () => Effect.die("not used"),
           rerunWorkflowRun: () => Effect.die("not used"),
+          uploadUserAttachment: () => Effect.die("not used"),
           ensureIssueCompletedWithSummary: () => Effect.die("not used"),
         } satisfies GitHubServiceShape
         const scope = yield* Effect.scope
@@ -1851,6 +1896,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           markPullRequestReadyForReview: () => Effect.die("not used"),
           mergePullRequest: () => Effect.die("not used"),
           rerunWorkflowRun: () => Effect.die("not used"),
+          uploadUserAttachment: () => Effect.die("not used"),
           ensureIssueCompletedWithSummary: () => Effect.die("not used"),
         } satisfies GitHubServiceShape
         const scope = yield* Effect.scope

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -101,6 +101,10 @@ const defaultGithub: GitHubServiceShape = {
   markPullRequestReadyForReview: () => Effect.void,
   mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
   rerunWorkflowRun: () => Effect.void,
+  uploadUserAttachment: () =>
+    Effect.succeed(
+      "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+    ),
   ensureIssueCompletedWithSummary: () => Effect.void,
   listReadyIssues: () => Effect.succeed([]),
 }

--- a/packages/github-service/src/bin/upload-user-attachment.ts
+++ b/packages/github-service/src/bin/upload-user-attachment.ts
@@ -1,0 +1,46 @@
+import { Effect, Schema } from "effect"
+import { GitHubService } from "../lib/github-service.js"
+import {
+  CliArgumentError,
+  decodeArgument,
+  githubRepository,
+  runGitHubCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+const UploadUserAttachmentPayload = Schema.Struct({
+  name: Schema.String,
+  contentType: Schema.String,
+  filePath: Schema.String,
+})
+
+export const uploadUserAttachmentProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const forge = yield* decodeArgument(args[0], "forge")
+    const forgeHost = yield* decodeArgument(args[1], "forge host")
+    const projectPath = yield* decodeArgument(args[2], "project path")
+    const payloadJson = yield* decodeArgument(args[3], "upload payload")
+    const payload = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(UploadUserAttachmentPayload),
+    )(payloadJson).pipe(
+      Effect.mapError(
+        () =>
+          new CliArgumentError({
+            message: `Invalid upload user attachment payload: ${payloadJson}`,
+          }),
+      ),
+    )
+    const github = yield* GitHubService
+    const url = yield* github.uploadUserAttachment(
+      githubRepository(forge, forgeHost, projectPath),
+      {
+        name: payload.name,
+        contentType: payload.contentType,
+        filePath: payload.filePath,
+      },
+    )
+    yield* writeStandardOutput(url)
+  })
+
+if (import.meta.main)
+  runGitHubCli(uploadUserAttachmentProgram(process.argv.slice(2)))

--- a/packages/github-service/src/lib/github-helper-process.ts
+++ b/packages/github-service/src/lib/github-helper-process.ts
@@ -16,6 +16,7 @@ import { mergePullRequestProgram } from "../bin/merge-pull-request.js"
 import { observeAutomatedReviewEvidenceProgram } from "../bin/observe-automated-review-evidence.js"
 import { rerunWorkflowRunProgram } from "../bin/rerun-workflow-run.js"
 import { updateOpenDraftPullRequestCopyProgram } from "../bin/update-open-draft-pull-request-copy.js"
+import { uploadUserAttachmentProgram } from "../bin/upload-user-attachment.js"
 import { githubServiceBinScriptPath } from "../bin-script-path.js"
 import type { GitHubService } from "./github-service.js"
 
@@ -39,6 +40,7 @@ export const GITHUB_HELPER_OPERATIONS = [
   "mark-pr-ready-for-review",
   "merge-pull-request",
   "rerun-workflow-run",
+  "upload-user-attachment",
   "ensure-issue-completed-with-summary",
 ] as const
 
@@ -152,6 +154,7 @@ const programs: Record<
   "mark-pr-ready-for-review": markPrReadyForReviewProgram,
   "merge-pull-request": mergePullRequestProgram,
   "rerun-workflow-run": rerunWorkflowRunProgram,
+  "upload-user-attachment": uploadUserAttachmentProgram,
   "ensure-issue-completed-with-summary": ensureIssueCompletedWithSummaryProgram,
 }
 

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import {
   Config,
@@ -52,24 +53,27 @@ import {
   formatTlsTrustRemediation,
   githubApiHost,
 } from "./tls-trust.js"
-import type {
-  GitHubIssueReference,
-  GitHubIssueState,
-  GitHubPullRequestLifecycleState,
-  GitHubPullRequestReference,
-  GitHubRepository,
-  MergePullRequestResult,
-  PrStatusCheckDiagnostic,
-  PrStatusCheckDiagnosticSource,
-  PrStatusCheckDiagnosticsOptions,
-  PrStatusCheckDiagnosticsRequest,
-  PullRequestCheckStatus,
-  ReadyLabeledIssue,
-  TerminalPrStatusCheck,
+import {
+  type GitHubIssueReference,
+  type GitHubIssueState,
+  type GitHubPullRequestLifecycleState,
+  type GitHubPullRequestReference,
+  type GitHubRepository,
+  type MergePullRequestResult,
+  type PrStatusCheckDiagnostic,
+  type PrStatusCheckDiagnosticSource,
+  type PrStatusCheckDiagnosticsOptions,
+  type PrStatusCheckDiagnosticsRequest,
+  type PullRequestCheckStatus,
+  type ReadyLabeledIssue,
+  type TerminalPrStatusCheck,
+  isGitHubUserAttachmentUrl,
 } from "./types.js"
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 const GITHUB_API_URL = "https://api.github.com"
+const GITHUB_USER_ATTACHMENTS_URL =
+  "https://uploads.github.com/user-attachments/assets"
 
 class GitHubApiRepositoryUnavailableError extends Schema.TaggedErrorClass<GitHubApiRepositoryUnavailableError>()(
   "GitHubApiRepositoryUnavailableError",
@@ -402,6 +406,17 @@ export type RerunWorkflowRun = (
   workflowRunId: number,
   signal?: AbortSignal,
 ) => Promise<void>
+
+/** Upload file bytes as a GitHub user attachment and return the CDN URL. */
+export type UploadUserAttachment = (
+  repository: { owner: string; name: string },
+  input: {
+    readonly name: string
+    readonly contentType: string
+    readonly body: Uint8Array
+  },
+  signal?: AbortSignal,
+) => Promise<string>
 
 /** Observe automated-review evidence for a green Status Check Handoff. */
 export type ObserveAutomatedReviewEvidence = (
@@ -1223,6 +1238,7 @@ const makeGitHubApiService = (
   loadPrStatusCheckDiagnostics?: LoadPrStatusCheckDiagnostics,
   rerunWorkflowRunImpl?: RerunWorkflowRun,
   observeAutomatedReviewEvidenceImpl?: ObserveAutomatedReviewEvidence,
+  uploadUserAttachmentImpl?: UploadUserAttachment,
 ): GitHubApiServiceShape => ({
   getAuthenticatedUserLogin: Effect.fn(
     "GitHubService.getAuthenticatedUserLogin",
@@ -2215,6 +2231,43 @@ const makeGitHubApiService = (
       )
     },
   ),
+  uploadUserAttachment: Effect.fn("GitHubService.uploadUserAttachment")(
+    function* (repository, input) {
+      const name = input.name.trim()
+      const contentType = input.contentType.trim()
+      const filePath = input.filePath.trim()
+      if (name === "" || contentType === "" || filePath === "") {
+        return yield* new GitHubRequestError({
+          message: `Invalid user attachment input for ${repository.owner}/${repository.name}`,
+          retryable: false,
+        })
+      }
+      if (uploadUserAttachmentImpl === undefined) {
+        return yield* new GitHubRequestError({
+          message: `User attachment upload is not configured for ${repository.owner}/${repository.name}`,
+          retryable: false,
+        })
+      }
+      const body = yield* Effect.tryPromise({
+        try: () => readFile(filePath),
+        catch: (cause) =>
+          new GitHubRequestError({
+            message: `Failed to read attachment file for ${repository.owner}/${repository.name}`,
+            cause,
+            retryable: false,
+          }),
+      })
+      return yield* githubRequest(
+        `Failed to upload user attachment for ${repository.owner}/${repository.name}`,
+        (signal) =>
+          uploadUserAttachmentImpl(
+            repository,
+            { name, contentType, body },
+            signal,
+          ),
+      )
+    },
+  ),
   ensureIssueCompletedWithSummary: Effect.fn(
     "GitHubService.ensureIssueCompletedWithSummary",
   )(function* (repository, issueNumber, workItemId, summaryMarkdown) {
@@ -2909,6 +2962,7 @@ export const makeGitHubService = (
   loadPrStatusCheckDiagnostics?: LoadPrStatusCheckDiagnostics,
   rerunWorkflowRunImpl?: RerunWorkflowRun,
   observeAutomatedReviewEvidenceImpl?: ObserveAutomatedReviewEvidence,
+  uploadUserAttachmentImpl?: UploadUserAttachment,
 ): GitHubServiceShape => {
   const service = makeGitHubApiService(
     client,
@@ -2916,6 +2970,7 @@ export const makeGitHubService = (
     loadPrStatusCheckDiagnostics,
     rerunWorkflowRunImpl,
     observeAutomatedReviewEvidenceImpl,
+    uploadUserAttachmentImpl,
   )
   const adapt = adaptRepository(service)
   return {
@@ -2940,6 +2995,7 @@ export const makeGitHubService = (
     markPullRequestReadyForReview: adapt(service.markPullRequestReadyForReview),
     mergePullRequest: adapt(service.mergePullRequest),
     rerunWorkflowRun: adapt(service.rerunWorkflowRun),
+    uploadUserAttachment: adapt(service.uploadUserAttachment),
     ensureIssueCompletedWithSummary: adapt(
       service.ensureIssueCompletedWithSummary,
     ),
@@ -3106,6 +3162,58 @@ const makeRerunWorkflowRun =
         message: `Failed to rerun workflow run ${workflowRunId} for ${repository.owner}/${repository.name}: ${response.statusText}: ${await response.text()}`,
       })
     }
+  }
+
+const makeUploadUserAttachment =
+  (token: string, fetchImpl: GitHubFetch): UploadUserAttachment =>
+  async (repository, input, signal) => {
+    const repoResponse = await fetchImpl(
+      `${GITHUB_API_URL}/repos/${repository.owner}/${repository.name}`,
+      {
+        headers: githubRestHeaders(token),
+        signal,
+      },
+    )
+    const repoBody = await readGitHubJson<{ readonly id?: unknown }>(
+      repoResponse,
+      `Failed to resolve repository id for ${repository.owner}/${repository.name}`,
+    )
+    const repositoryId = repoBody.id
+    if (!Number.isSafeInteger(repositoryId) || Number(repositoryId) <= 0) {
+      throw new GitHubHttpError({
+        statusCode: 0,
+        headers: new Headers(),
+        message: `GitHub returned an invalid repository id for ${repository.owner}/${repository.name}`,
+      })
+    }
+    const uploadUrl = new URL(GITHUB_USER_ATTACHMENTS_URL)
+    uploadUrl.searchParams.set("name", input.name)
+    uploadUrl.searchParams.set("content_type", input.contentType)
+    uploadUrl.searchParams.set("repository_id", String(repositoryId))
+    const uploadResponse = await fetchImpl(uploadUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+      },
+      body: input.body,
+      signal,
+    })
+    const uploaded = await readGitHubJson<{ readonly url?: unknown }>(
+      uploadResponse,
+      `Failed to upload user attachment for ${repository.owner}/${repository.name}`,
+    )
+    if (
+      typeof uploaded.url !== "string" ||
+      !isGitHubUserAttachmentUrl(uploaded.url)
+    ) {
+      throw new GitHubHttpError({
+        statusCode: uploadResponse.status,
+        headers: uploadResponse.headers,
+        message: `GitHub returned an invalid user attachment URL for ${repository.owner}/${repository.name}`,
+      })
+    }
+    return uploaded.url
   }
 
 const loginFromAuthor = (author: unknown): string | null => {
@@ -3764,6 +3872,7 @@ export const makeGitHubServiceFromToken = (
     makeLoadPrStatusCheckDiagnostics(token, observingFetch, fs),
     makeRerunWorkflowRun(token, observingFetch),
     makeObserveAutomatedReviewEvidence(token, observingFetch),
+    makeUploadUserAttachment(token, observingFetch),
   )
 }
 

--- a/packages/github-service/src/lib/github-service-test.ts
+++ b/packages/github-service/src/lib/github-service-test.ts
@@ -3,8 +3,11 @@ import {
   GitHubRepositoryUnavailableError,
   type GitHubRequestError,
 } from "./errors.js"
-import { GitHubService } from "./github-service.js"
+import { GitHubService, type GitHubServiceShape } from "./github-service.js"
 import type { GitHubRepository, ReadyLabeledIssue } from "./types.js"
+
+const TEST_USER_ATTACHMENT_URL =
+  "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001"
 
 interface GitHubServiceTestFixtureBase {
   readonly repository: GitHubRepository
@@ -31,6 +34,9 @@ const repositoryKey = ({ forge, forgeHost, projectPath }: GitHubRepository) =>
 
 export const makeGitHubServiceTest = (
   fixtures: readonly GitHubServiceTestFixture[],
+  options: {
+    readonly uploadUserAttachment?: GitHubServiceShape["uploadUserAttachment"]
+  } = {},
 ): Layer.Layer<GitHubService> => {
   const fixturesByRepository = new Map(
     fixtures.map((fixture) => [repositoryKey(fixture.repository), fixture]),
@@ -65,6 +71,9 @@ export const makeGitHubServiceTest = (
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
     rerunWorkflowRun: () => Effect.void,
+    uploadUserAttachment:
+      options.uploadUserAttachment ??
+      (() => Effect.succeed(TEST_USER_ATTACHMENT_URL)),
     ensureIssueCompletedWithSummary: () => Effect.void,
     listReadyIssues: (repository) => {
       const fixture = fixturesByRepository.get(repositoryKey(repository))

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -13,6 +13,7 @@ import type {
   PullRequestCheckStatus,
   PullRequestLifecycleStatus,
   ReadyLabeledIssue,
+  UploadUserAttachmentInput,
 } from "./types.js"
 
 /**
@@ -137,6 +138,15 @@ export interface GitHubServiceShape {
     repository: GitHubRepository,
     workflowRunId: number,
   ) => Effect.Effect<void, GitHubServiceError>
+  /**
+   * Upload a local file as a GitHub user attachment and return the
+   * `https://github.com/user-attachments/assets/…` CDN URL. A pull request
+   * does not need to exist. Uses the same credential path as other mutations.
+   */
+  readonly uploadUserAttachment: (
+    repository: GitHubRepository,
+    input: UploadUserAttachmentInput,
+  ) => Effect.Effect<string, GitHubServiceError>
   /**
    * Ensure a No-Change Outcome summary is posted once (hidden Work Item marker)
    * and the Issue is closed with state reason COMPLETED. Idempotent across

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -4,6 +4,30 @@ export interface GitHubRepository {
   readonly projectPath: string
 }
 
+/** Local file the harness uploads as a GitHub user attachment. */
+export interface UploadUserAttachmentInput {
+  readonly name: string
+  readonly contentType: string
+  readonly filePath: string
+}
+
+const USER_ATTACHMENT_PATH_PREFIX = "/user-attachments/assets/"
+
+/** True when `value` is a GitHub user-attachment CDN URL. */
+export const isGitHubUserAttachmentUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return (
+      url.protocol === "https:" &&
+      url.hostname === "github.com" &&
+      url.pathname.startsWith(USER_ATTACHMENT_PATH_PREFIX) &&
+      url.pathname.length > USER_ATTACHMENT_PATH_PREFIX.length
+    )
+  } catch {
+    return false
+  }
+}
+
 export type TerminalPrStatusCheckOutcome = "green" | "red"
 
 /**

--- a/packages/github-service/test/github-helper-process.spec.ts
+++ b/packages/github-service/test/github-helper-process.spec.ts
@@ -185,6 +185,49 @@ describe("GitHub helper process boundary", () => {
     expect(stderr.length).toBeGreaterThan(0)
   })
 
+  test("upload-user-attachment helper fails safely without a token (write path)", async () => {
+    const child = spawn(
+      bunExecutable(),
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        harnessServerEntry,
+        INTERNAL_GITHUB_HELPER_ARG,
+        "upload-user-attachment",
+        encode("github"),
+        encode("github.com"),
+        encode("acme/widgets"),
+        encode(
+          JSON.stringify({
+            name: "before.png",
+            contentType: "image/png",
+            filePath: "/tmp/before.png",
+          }),
+        ),
+      ],
+      {
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+    children.push(child)
+
+    const stderrChunks: Buffer[] = []
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code))
+    })
+
+    expect(exitCode).not.toBe(0)
+    expect(exitCode).not.toBe(2)
+    const stderr = Buffer.concat(stderrChunks).toString("utf8")
+    expect(stderr.length).toBeGreaterThan(0)
+    expect(stderr).not.toMatch(/ghp_[A-Za-z0-9]+/)
+  })
+
   test("rejects unknown helper operations", async () => {
     const child = spawn(
       bunExecutable(),

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -1,4 +1,7 @@
 import { spawnSync } from "node:child_process"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "@effect/vitest"
 import { Effect, Fiber, Result } from "effect"
 import { TestClock } from "effect/testing"
@@ -1894,6 +1897,113 @@ describe("GitHubService live implementation", () => {
     expect(calls).toEqual([
       "POST https://api.github.com/repos/acme/widgets/actions/runs/29906669357/rerun",
     ])
+  })
+
+  it("uploads a user attachment and returns the GitHub CDN URL", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "rfa-upload-"))
+    const filePath = join(dir, "before.png")
+    await writeFile(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    const calls: string[] = []
+    const service = makeGitHubServiceFromToken("token", async (input, init) => {
+      const url = String(input)
+      calls.push(`${init?.method ?? "GET"} ${url}`)
+      if (url === "https://api.github.com/repos/acme/widgets") {
+        return new Response(JSON.stringify({ id: 424242 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      if (
+        url.startsWith("https://uploads.github.com/user-attachments/assets?") &&
+        init?.method === "POST"
+      ) {
+        const uploaded = new URL(url)
+        expect(uploaded.searchParams.get("name")).toBe("before.png")
+        expect(uploaded.searchParams.get("content_type")).toBe("image/png")
+        expect(uploaded.searchParams.get("repository_id")).toBe("424242")
+        expect(init.headers).toMatchObject({
+          Authorization: "Bearer token",
+          Accept: "application/json",
+        })
+        expect(init.body).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+        return new Response(
+          JSON.stringify({
+            url: "https://github.com/user-attachments/assets/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+          }),
+          { status: 201, headers: { "content-type": "application/json" } },
+        )
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" })
+    })
+
+    try {
+      const url = await Effect.runPromise(
+        service.uploadUserAttachment(repository, {
+          name: "before.png",
+          contentType: "image/png",
+          filePath,
+        }),
+      )
+      expect(url).toBe(
+        "https://github.com/user-attachments/assets/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      )
+      expect(calls).toEqual([
+        "GET https://api.github.com/repos/acme/widgets",
+        "POST https://uploads.github.com/user-attachments/assets?name=before.png&content_type=image%2Fpng&repository_id=424242",
+      ])
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("surfaces a 404 user-attachment upload as a request error", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "rfa-upload-"))
+    const filePath = join(dir, "after.png")
+    await writeFile(filePath, Buffer.from("png"))
+    const service = makeGitHubServiceFromToken("token", async (input) => {
+      const url = String(input)
+      if (url === "https://api.github.com/repos/acme/widgets") {
+        return new Response(JSON.stringify({ id: 7 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      return new Response("Not Found", { status: 404, statusText: "Not Found" })
+    })
+
+    try {
+      const error = await Effect.runPromise(
+        service
+          .uploadUserAttachment(repository, {
+            name: "after.png",
+            contentType: "image/png",
+            filePath,
+          })
+          .pipe(Effect.flip),
+      )
+      expect(error).toBeInstanceOf(GitHubRequestError)
+      expect(error.statusCode).toBe(404)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("fails when the attachment file cannot be read", async () => {
+    const service = makeGitHubServiceFromToken("token", async () => {
+      throw new Error("should not call GitHub when the file is missing")
+    })
+
+    const error = await Effect.runPromise(
+      service
+        .uploadUserAttachment(repository, {
+          name: "missing.png",
+          contentType: "image/png",
+          filePath: join(tmpdir(), "rfa-missing-attachment.png"),
+        })
+        .pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.retryable).toBe(false)
   })
 
   it("loads Actions job log diagnostics for actions-job external ids", async () => {
@@ -4595,5 +4705,58 @@ describe("makeGitHubServiceTest", () => {
     expect(result).toEqual(
       Result.fail(new GitHubRepositoryUnavailableError(repository)),
     )
+  })
+
+  it("can succeed or fail a user-attachment upload", async () => {
+    const successUrl =
+      "https://github.com/user-attachments/assets/11111111-2222-3333-4444-555555555555"
+    const successLayer = makeGitHubServiceTest([{ repository, issues: [] }])
+    const defaultUrl = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.uploadUserAttachment(repository, {
+          name: "before.png",
+          contentType: "image/png",
+          filePath: "/tmp/before.png",
+        })
+      }).pipe(Effect.provide(successLayer)),
+    )
+    expect(
+      defaultUrl.startsWith("https://github.com/user-attachments/assets/"),
+    ).toBe(true)
+
+    const uploadError = new GitHubRequestError({
+      message: "upload failed",
+      statusCode: 404,
+    })
+    const failureLayer = makeGitHubServiceTest([{ repository, issues: [] }], {
+      uploadUserAttachment: () => Effect.fail(uploadError),
+    })
+    const failed = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.uploadUserAttachment(repository, {
+          name: "before.png",
+          contentType: "image/png",
+          filePath: "/tmp/before.png",
+        })
+      }).pipe(Effect.provide(failureLayer), Effect.result),
+    )
+    expect(failed).toEqual(Result.fail(uploadError))
+
+    const overrideLayer = makeGitHubServiceTest([{ repository, issues: [] }], {
+      uploadUserAttachment: () => Effect.succeed(successUrl),
+    })
+    const overridden = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.uploadUserAttachment(repository, {
+          name: "before.png",
+          contentType: "image/png",
+          filePath: "/tmp/before.png",
+        })
+      }).pipe(Effect.provide(overrideLayer)),
+    )
+    expect(overridden).toBe(successUrl)
   })
 })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -214,6 +214,10 @@ const defaultGithub: GitHubServiceShape = {
   markPullRequestReadyForReview: () => Effect.void,
   mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
   rerunWorkflowRun: () => Effect.void,
+  uploadUserAttachment: () =>
+    Effect.succeed(
+      "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+    ),
   ensureIssueCompletedWithSummary: () => Effect.void,
   listReadyIssues: () => Effect.succeed([]),
 }

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -204,6 +204,10 @@ const makeGitHubLayer = (
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
     rerunWorkflowRun: () => Effect.void,
+    uploadUserAttachment: () =>
+      Effect.succeed(
+        "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+      ),
     ensureIssueCompletedWithSummary: () => Effect.void,
     listReadyIssues: ({ projectPath }) => {
       actions.push(`github:${projectPath}`)

--- a/packages/work-item-lifecycle/src/lib/github-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/github-service-test.ts
@@ -45,6 +45,10 @@ export const stubGitHubServiceLayer = (
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
       ...overrides,
     }),

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -86,6 +86,10 @@ const unusedGithub = {
   markPullRequestReadyForReview: () => Effect.void,
   mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
   rerunWorkflowRun: () => Effect.void,
+  uploadUserAttachment: () =>
+    Effect.succeed(
+      "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+    ),
   ensureIssueCompletedWithSummary: () => Effect.void,
 } satisfies GitHubServiceShape
 

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -124,6 +124,10 @@ const stubGitHub = (
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
       listReadyIssues: () => Effect.succeed([]),

--- a/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
+++ b/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
@@ -79,6 +79,10 @@ describe("markPrReadyForReview", () => {
       },
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -121,6 +125,10 @@ describe("markPrReadyForReview", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 

--- a/packages/work-item-lifecycle/test/merge-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/merge-pr.spec.ts
@@ -78,6 +78,10 @@ describe("mergePr", () => {
         requestedBranch = branch
         return Effect.succeed({ _tag: "merged" as const })
       },
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -118,6 +122,10 @@ describe("mergePr", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -186,6 +186,10 @@ const githubWith = (
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
     rerunWorkflowRun: () => Effect.void,
+    uploadUserAttachment: () =>
+      Effect.succeed(
+        "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+      ),
     ensureIssueCompletedWithSummary: () => Effect.void,
     ...overrides,
   } satisfies GitHubServiceShape)
@@ -270,6 +274,10 @@ describe("PR status check steps", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -449,6 +457,10 @@ describe("PR status check steps", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -545,6 +557,10 @@ describe("PR status check steps", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -704,6 +720,10 @@ describe("PR status check steps", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -805,6 +825,10 @@ describe("PR status check steps", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
@@ -865,6 +889,10 @@ describe("PR status check steps", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -125,6 +125,10 @@ const stubGitHub = (
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
     rerunWorkflowRun: () => Effect.void,
+    uploadUserAttachment: () =>
+      Effect.succeed(
+        "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+      ),
     ensureIssueCompletedWithSummary: () => Effect.void,
     ...overrides,
   } satisfies GitHubServiceShape)

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -132,6 +132,10 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
+      uploadUserAttachment: () =>
+        Effect.succeed(
+          "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
+        ),
       ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 


### PR DESCRIPTION
GitHub’s user-attachment endpoint can mint
`https://github.com/user-attachments/assets/…` URLs before a pull request
exists. This change exposes that mutation on GitHubService so later Commit
work (#1126 / parent #1125) can rewrite local screenshot paths without
putting a Forge token in an Agent Turn.

**What changed**
- `GitHubService.uploadUserAttachment` reads a local file and POSTs it to
  `https://uploads.github.com/user-attachments/assets` with `name`,
  URL-encoded `content_type`, and `repository_id`.
- Live, ambient, and Keymaxxer helper-process paths match other GitHub
  mutations.
- Existing GitHubService test doubles include the operation;
  `makeGitHubServiceTest` can succeed or fail so Commit tests can inject
  either outcome.

**Not in this change**
Commit and Create PR still do not upload. Path sandbox and the image MIME
allow-list stay with the later rewrite step.

**Verification**
- `nx test github-service` (159 passed), including live upload, 404,
  missing file, helper write-path, and succeed/fail doubles
- Harness Keymaxxer layer test that the helper is invoked without a raw
  token
- Commit / Create PR tests still pass with no upload calls
- Typecheck of github-service, harness, work-item-lifecycle, graphql-api,
  and issue-reconciler
- Review of the uncommitted diff found no blocking issues

Closes #1126