### PR TITLE
fix(github-service): send Content-Type on user-attachment uploads

### DIFF
--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -3195,6 +3195,8 @@ const makeUploadUserAttachment =
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/json",
+        // Bun fetch leaves Buffer bodies without Content-Type; uploads.github.com then 400s.
+        "Content-Type": input.contentType,
       },
       body: input.body,
       signal,

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -1924,6 +1924,7 @@ describe("GitHubService live implementation", () => {
         expect(init.headers).toMatchObject({
           Authorization: "Bearer token",
           Accept: "application/json",
+          "Content-Type": "image/png",
         })
         expect(init.body).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]))
         return new Response(


### PR DESCRIPTION
Commit rewrite already uploaded in-directory screenshots through
`uploadUserAttachment`, but the live POST never set `Content-Type`.
Bun `fetch` leaves a `Buffer` body without that header, so
`uploads.github.com` returned `400 Invalid Content-Type'`. Keymaxxer
helpers exited 1, best-effort left
`/tmp/ready-for-agent/pr-attachments/…` links, and Create PR published
them. The Forge token was not the problem: the same PAT returns 201 via
curl, or via Bun once the header is set.

**What changed**
- `makeUploadUserAttachment` now sends `Content-Type` matching the
  image MIME already used as the `content_type` query param. Keymaxxer
  and ambient `GITHUB_TOKEN` both go through this helper.
- The existing github-service upload unit test asserts that header on
  the mocked `fetch`, so a missing `Content-Type` fails without hitting
  GitHub.

No new Lifecycle Step. Implement capture and publication-copy prompts
are unchanged. Failed uploads still leave local links and Commit still
succeeds.

**Verification**
- Upload unit test failed without the header, then passed with it.
- `nx test github-service` — 159 passed; typecheck passed. Review of
  the uncommitted diff found no issues.
- Live Bun `fetch` of a real PNG: no header → 400
  `Invalid Content-Type'`; `Content-Type: image/png` → 201 and a
  `https://github.com/user-attachments/assets/…` URL.

Does not retroactively rewrite meredithsolutions PR #23. GitLab uploads
are out of scope. Fixes the upload 400 from #1135.

Closes #1135