### PR TITLE
feat(lifecycle-model): generate Step Run reason codes from the ontology

### DIFF
--- a/.agents/skills/ontology-change/SKILL.md
+++ b/.agents/skills/ontology-change/SKILL.md
@@ -1,17 +1,20 @@
 ---
 name: ontology-change
-description: Change the Ready for Agent domain model — lifecycle states, transitions, guards, Step Run reason codes, or CONTEXT.md glossary terms. Use whenever a task adds, renames, or removes a Work Item state or transition, touches ontology/*.ttl, edits the CONTEXT.md glossary, or fails the lifecycle-model parity or check-generated targets. The ontology is the source of truth; TypeScript, GraphQL, and DB enums are generated from it.
+description: Change the Ready for Agent domain model — lifecycle states, transitions, guards, every Step Run reason code (transition and operational), or CONTEXT.md glossary terms. Use whenever a task adds, renames, or removes a Work Item state, transition, or Step Run reason, touches ontology/*.ttl, edits the CONTEXT.md glossary, or fails the lifecycle-model parity or check-generated targets. The ontology owns the complete reason vocabulary; TypeScript, GraphQL, and DB enums are generated from it.
 ---
 
 # Changing the domain ontology
 
 The domain model lives in `ontology/` as RDF (Turtle) and is the single
-source of truth per ADR-0044 (`docs/adr/0044-ontology-derived-lifecycle-model.md`).
+source of truth per ADR-0044
+(`docs/adr/0044-ontology-derived-lifecycle-model.md`) and ADR-0058
+(`docs/adr/0058-ontology-owns-step-run-reason-codes.md`).
 Read `ontology/README.md` for the full model and diagrams before editing.
 
 **Never hand-edit generated artifacts.** These are derived and CI-checked:
 
 - `packages/lifecycle-model/src/generated/work-item-state.ts`
+  (state space, transition relation, and the complete `STEP_RUN_REASON` table)
 - `packages/graphql-schema/src/type-defs.gen.ts`
 - Any state enum in `db-schema` or SDL that lists Work Item states — they
   import from `@ready-for-agent/lifecycle-model`.
@@ -29,8 +32,12 @@ Read `ontology/README.md` for the full model and diagrams before editing.
      (`rfa:WorkItemShape`).
    - New transition: declare an `rfa:Transition` individual in `rfa.ttl`
      with exactly one `rfa:fromStep`, `rfa:toStep`, `rfa:guard` (non-empty
-     string), and `rfa:reasonCode` (an `rfa:StepRunReason`; declare a new
-     reason with a `skos:notation` if none fits).
+     string), and `rfa:reasonCode` (an `rfa:StepRunReason`).
+   - New Step Run reason (transition or operational): declare an
+     `rfa:StepRunReason` individual in `rfa.ttl` with one `skos:notation`
+     (the runtime snake_case or kebab-case string) and one English
+     `skos:definition`. `STEP_RUN_REASON` is generated from these
+     individuals.
 2. **Keep the glossary in parity.** If the term is (or becomes) a CONTEXT.md
    glossary entry, update the glossary in `CONTEXT.md` and mirror it in
    `ontology/context.ttl` (`rfa:ContextTerm` with matching

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,14 @@ Single-context layout (root CONTEXT.md + docs/adr/). See `docs/agents/domain.md`
 
 ### Domain ontology
 
-The Work Item lifecycle and the CONTEXT.md glossary are derived from a
-versioned ontology under `ontology/` (see `ontology/README.md` and
-`docs/adr/0044-ontology-derived-lifecycle-model.md`). Domain changes start
-with an ontology edit and flow through codegen — never edit
+The Work Item lifecycle, every Step Run reason code, and the CONTEXT.md
+glossary are derived from a versioned ontology under `ontology/` (see
+`ontology/README.md`, `docs/adr/0044-ontology-derived-lifecycle-model.md`,
+and `docs/adr/0058-ontology-owns-step-run-reason-codes.md`). Domain changes
+start with an ontology edit and flow through codegen — never edit
 `packages/lifecycle-model/src/generated/work-item-state.ts` or the state
 enums directly. Use the `ontology-change` skill when adding or changing
-lifecycle states, transitions, or glossary terms.
+lifecycle states, transitions, Step Run reason codes, or glossary terms.
 
 <!-- effect-solutions:start -->
 

--- a/docs/adr/0058-ontology-owns-step-run-reason-codes.md
+++ b/docs/adr/0058-ontology-owns-step-run-reason-codes.md
@@ -1,0 +1,7 @@
+# The ontology owns every Step Run reason code
+
+The ontology already declared the reason codes that appear on lifecycle transitions, plus a few later operational additions, while the harness persisted a larger hand-written `STEP_RUN_REASON` table. The two lists drifted, and the docs implied the ontology owned reason codes when it did not. The ontology now owns the complete vocabulary — transition reasons and operational mid-run reasons — and `STEP_RUN_REASON` is generated from `rfa:StepRunReason` the same way the state space is generated. `check-generated` fails if the checked-in table and `ontology/rfa.ttl` diverge.
+
+**Considered Options.** Restricting the ontology to transition reasons only would have required moving `github_throttled` and the other operational individuals back out and documenting a split that every new code would have to re-learn. Generating the table from the complete ontology is the smaller rule: one place to add a reason, one check that it cannot drift.
+
+**Consequences.** Adding or renaming a reason starts in `ontology/rfa.ttl` (`skos:notation` plus `skos:definition`) and flows through `lifecycle-model:generate`. Do not edit `packages/lifecycle-model/src/generated/work-item-state.ts` or restore a hand-written table in `work-item-lifecycle`.

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -43,7 +43,7 @@ flowchart LR
 
   subgraph lm["packages/lifecycle-model"]
     gen["scripts/generate-lifecycle-state.ts<br/>(n3 Turtle parser)"]
-    generated["src/generated/work-item-state.ts<br/>Effect Schema literals +<br/>LIFECYCLE_TRANSITIONS +<br/>isDeclaredLifecycleTransition"]
+    generated["src/generated/work-item-state.ts<br/>Effect Schema literals +<br/>STEP_RUN_REASON +<br/>LIFECYCLE_TRANSITIONS +<br/>isDeclaredLifecycleTransition"]
     tests["test/ontology.test.ts<br/>SHACL validation, OWL consistency,<br/>CONTEXT.md parity"]
   end
 
@@ -71,6 +71,8 @@ emits `packages/lifecycle-model/src/generated/work-item-state.ts`:
   space, keyed by each term's `skos:notation` (the runtime string, e.g.
   `create_worktree`).
 - `WorkItemState` — an Effect `Schema.Literals` union over both.
+- `STEP_RUN_REASONS` / `STEP_RUN_REASON` — every `rfa:StepRunReason`
+  (`skos:notation` plus camelCase accessor), the complete harness vocabulary.
 - `LIFECYCLE_TRANSITIONS` — every declared `rfa:Transition` as queryable data
   (`from`, `to`, `guard`, `reasonCode`).
 - `isDeclaredLifecycleTransition(from, to)` — membership in the declared
@@ -160,7 +162,8 @@ Notes on the modelling:
 ## The lifecycle state space
 
 16 operational Lifecycle Steps, 4 terminal Work Item states, and 110 declared
-transitions, each carrying a named guard and one of 13 Step Run reason codes.
+transitions, each carrying a named guard and one Step Run reason code from the
+generated vocabulary.
 The happy path:
 
 ```mermaid
@@ -251,11 +254,12 @@ bunx nx run lifecycle-model:check-generated
 bunx nx run lifecycle-model:test
 ```
 
-When adding a lifecycle state or transition:
+When adding a lifecycle state, transition, or Step Run reason:
 
 1. Declare it in `rfa.ttl` (class + individual + SKOS concept with a
    `skos:notation`, or an `rfa:Transition` with `fromStep`, `toStep`,
-   `guard`, and `reasonCode`).
+   `guard`, and `reasonCode`, or an `rfa:StepRunReason` with `skos:notation`
+   and `skos:definition`).
 2. If it is a CONTEXT.md glossary term, add the glossary entry and mirror it
    in `context.ttl` — the parity test fails on any mismatch.
 3. Regenerate `lifecycle-model` and `graphql-schema`, and update fixtures if

--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -14,7 +14,7 @@
     "The Ready for Agent domain vocabulary and Work Item lifecycle model."@en ;
   dcterms:source
     <https://github.com/berenddeboer/ready-for-agent/blob/main/CONTEXT.md> ;
-  owl:versionInfo "0.4.2" .
+  owl:versionInfo "0.5.0" .
 
 rfa:ContextTerm
   a owl:Class ;
@@ -220,7 +220,7 @@ rfa:StepRunReason
   a owl:Class ;
   rdfs:label "Step Run reason"@en ;
   skos:definition
-    "A reason code from the harness Step Run reason vocabulary."@en .
+    "A named reason a Step Run finished, was cancelled, or is blocked. The class is the complete harness vocabulary: transition reasons and operational mid-run reasons."@en .
 
 rfa:fromStep
   a owl:ObjectProperty ;
@@ -266,21 +266,197 @@ rfa:retryable
   skos:definition
     "Whether a failed or interrupted run of the Lifecycle Step may be retried."@en .
 
-rfa:NativeReason a rfa:StepRunReason ; skos:notation "native" .
-rfa:AgentFallbackReason a rfa:StepRunReason ; skos:notation "agent_fallback" .
-rfa:ReviewDeferredReason a rfa:StepRunReason ; skos:notation "review_deferred" .
-rfa:ReviewClearedReason a rfa:StepRunReason ; skos:notation "review_cleared" .
-rfa:ReviewAcceptedReason a rfa:StepRunReason ; skos:notation "review_accepted" .
-rfa:HandlerFailedReason a rfa:StepRunReason ; skos:notation "handler_failed" .
-rfa:MergeRevalidationReason a rfa:StepRunReason ; skos:notation "merge_revalidation" .
-rfa:GreenNoReviewEvidenceReason a rfa:StepRunReason ; skos:notation "green-no-review-evidence" .
-rfa:PrMergedReason a rfa:StepRunReason ; skos:notation "pr_merged" .
-rfa:AbandonedReason a rfa:StepRunReason ; skos:notation "abandoned" .
-rfa:PrStatusChecksUnresolvedReason a rfa:StepRunReason ; skos:notation "pr_status_checks_unresolved" .
-rfa:GitHubThrottledReason a rfa:StepRunReason ; skos:notation "github_throttled" .
-rfa:ThinkingLevelNotInCatalogReason a rfa:StepRunReason ; skos:notation "thinking_level_not_in_catalog" .
-rfa:MissingSuccessfulChecksReason a rfa:StepRunReason ; skos:notation "missing_successful_checks" .
-rfa:PausedReason a rfa:StepRunReason ; skos:notation "paused" .
+rfa:AbandonedReason
+  a rfa:StepRunReason ;
+  skos:notation "abandoned" ;
+  skos:definition
+    "The Step Run was cancelled because the operator abandoned the Work Item."@en .
+
+rfa:AgentBackendAuthRejectedReason
+  a rfa:StepRunReason ;
+  skos:notation "agent_backend_auth_rejected" ;
+  skos:definition
+    "An Agent Turn failed because the backend provider rejected credentials as missing, expired, or invalid."@en .
+
+rfa:AgentBackendUnavailableReason
+  a rfa:StepRunReason ;
+  skos:notation "agent_backend_unavailable" ;
+  skos:definition
+    "An agent-dependent step is blocked because the Active Agent Backend is unavailable."@en .
+
+rfa:AgentFallbackReason
+  a rfa:StepRunReason ;
+  skos:notation "agent_fallback" ;
+  skos:definition
+    "A conditionally agent-using step completed via one repair Agent Turn after the native path did not establish the postcondition."@en .
+
+rfa:AgentModelNotInCatalogReason
+  a rfa:StepRunReason ;
+  skos:notation "agent_model_not_in_catalog" ;
+  skos:definition
+    "An agent-dependent step is blocked because the resolved Agent Model is absent from the Agent Backend's current Ready catalog. Rejected before the backend CLI is spawned."@en .
+
+rfa:BuildModelNotConfiguredReason
+  a rfa:StepRunReason ;
+  skos:notation "build_model_not_configured" ;
+  skos:definition
+    "An agent-dependent step is blocked because no build Agent Model is configured."@en .
+
+rfa:CopyGenerationReason
+  a rfa:StepRunReason ;
+  skos:notation "copy_generation" ;
+  skos:definition
+    "Mid-run: Commit is generating shared publication copy via an Agent Turn before the native git commit attempt."@en .
+
+rfa:GitHubThrottledReason
+  a rfa:StepRunReason ;
+  skos:notation "github_throttled" ;
+  skos:definition
+    "Watch PR Status Checks stopped cleanly at GitHub's explicit retry time."@en .
+
+rfa:GreenNoReviewEvidenceReason
+  a rfa:StepRunReason ;
+  skos:notation "green-no-review-evidence" ;
+  skos:definition
+    "A green-only Status Check Handoff completed without an Agent Turn because harness-owned GitHub observation found no positive automated-review evidence."@en .
+
+rfa:HandlerDefectReason
+  a rfa:StepRunReason ;
+  skos:notation "handler_defect" ;
+  skos:definition
+    "The Step Run ended because the Lifecycle Step handler threw a defect rather than a typed failure."@en .
+
+rfa:HandlerFailedReason
+  a rfa:StepRunReason ;
+  skos:notation "handler_failed" ;
+  skos:definition
+    "The Step Run ended because the Lifecycle Step handler failed with a typed or unexpected error."@en .
+
+rfa:InterruptedReason
+  a rfa:StepRunReason ;
+  skos:notation "interrupted" ;
+  skos:definition
+    "The Step Run was stopped before completion by an operator or harness interrupt."@en .
+
+rfa:IssueClosedPrClosedUnmergedReason
+  a rfa:StepRunReason ;
+  skos:notation "issue_closed_pr_closed_unmerged" ;
+  skos:definition
+    "A successful Step Run stopped because Issue revalidation found the Issue closed or missing and the Work Item PR was closed without merge. The Work Item is paused for an operator Start, Abandon, or Reset decision."@en .
+
+rfa:IssueClosedWhilePrOpenReason
+  a rfa:StepRunReason ;
+  skos:notation "issue_closed_while_pr_open" ;
+  skos:definition
+    "A successful Step Run stopped because Issue revalidation found the Issue closed or missing while a Work Item PR is still open or PR status was indeterminate. The Work Item is paused for operator Start after reopen."@en .
+
+rfa:MergeRevalidationReason
+  a rfa:StepRunReason ;
+  skos:notation "merge_revalidation" ;
+  skos:definition
+    "A successful Merge PR run that returned to Watch PR Status Checks for fresh validation."@en .
+
+rfa:MissingSuccessfulChecksReason
+  a rfa:StepRunReason ;
+  skos:notation "missing_successful_checks" ;
+  skos:definition
+    "Autonomous merge stopped because the Forge reported no successful status-check aggregate by the deadline."@en .
+
+rfa:NativeReason
+  a rfa:StepRunReason ;
+  skos:notation "native" ;
+  skos:definition
+    "A conditionally agent-using step completed via the harness-owned native path with no Agent Turn."@en .
+
+rfa:PausedReason
+  a rfa:StepRunReason ;
+  skos:notation "paused" ;
+  skos:definition
+    "The Step Run stopped because the Work Item was paused."@en .
+
+rfa:PrMergedReason
+  a rfa:StepRunReason ;
+  skos:notation "pr_merged" ;
+  skos:definition
+    "Confirmed Work Item PR merge outcome, used when a Step Run is cancelled because the PR merged before it finished, or a successful Step Run advances to local cleanup after Issue revalidation finds the Issue closed or missing and the owned PR already merged."@en .
+
+rfa:PrStatusChecksUnresolvedReason
+  a rfa:StepRunReason ;
+  skos:notation "pr_status_checks_unresolved" ;
+  skos:definition
+    "Watch PR Status Checks stopped because the status-check observation did not resolve."@en .
+
+rfa:ResetReason
+  a rfa:StepRunReason ;
+  skos:notation "reset" ;
+  skos:definition
+    "The Step Run was cancelled because the operator reset the Work Item."@en .
+
+rfa:ReviewAcceptedReason
+  a rfa:StepRunReason ;
+  skos:notation "review_accepted" ;
+  skos:definition
+    "A successful Review that accepted low-severity remediation without a full rerun."@en .
+
+rfa:ReviewApplyingFindingsReason
+  a rfa:StepRunReason ;
+  skos:notation "review_applying_findings" ;
+  skos:definition
+    "Mid-run: Review is applying findings with the build model."@en .
+
+rfa:ReviewAssessingRerunReason
+  a rfa:StepRunReason ;
+  skos:notation "review_assessing_rerun" ;
+  skos:definition
+    "Mid-run: Review is assessing whether low-severity remediation needs a rerun."@en .
+
+rfa:ReviewClearedReason
+  a rfa:StepRunReason ;
+  skos:notation "review_cleared" ;
+  skos:definition
+    "A successful Review that cleared low or medium findings without changes."@en .
+
+rfa:ReviewDeferredReason
+  a rfa:StepRunReason ;
+  skos:notation "review_deferred" ;
+  skos:definition
+    "A successful Review that deferred findings and advanced to Commit."@en .
+
+rfa:ReviewPreCommitReason
+  a rfa:StepRunReason ;
+  skos:notation "review_pre_commit" ;
+  skos:definition
+    "Mid-run: Review is re-running Pre-Commit after FIXED before re-review."@en .
+
+rfa:ReviewReviewingReason
+  a rfa:StepRunReason ;
+  skos:notation "review_reviewing" ;
+  skos:definition
+    "Mid-run: Review is running the reviewing Agent Turn."@en .
+
+rfa:ThinkingLevelNotInCatalogReason
+  a rfa:StepRunReason ;
+  skos:notation "thinking_level_not_in_catalog" ;
+  skos:definition
+    "An agent-dependent step is blocked because the resolved Thinking Level is not advertised by the governing Agent Model's current catalog entry. Rejected before the backend CLI is spawned."@en .
+
+rfa:TimeoutReason
+  a rfa:StepRunReason ;
+  skos:notation "timeout" ;
+  skos:definition
+    "The Step Run ended because the Lifecycle Step exceeded its configured maximum duration."@en .
+
+rfa:WaitingForAgentTurnReason
+  a rfa:StepRunReason ;
+  skos:notation "waiting_for_agent_turn" ;
+  skos:definition
+    "Mid-run: the Step Run is Running but blocked on maxConcurrentAgentTurns."@en .
+
+rfa:WorkerRestartedReason
+  a rfa:StepRunReason ;
+  skos:notation "worker_restarted" ;
+  skos:definition
+    "The prior harness or job-worker process ended while the Step Run was still Running."@en .
 
 rfa:CreateWorktree
   a owl:Class, owl:NamedIndividual, skos:Concept,

--- a/ontology/shapes.ttl
+++ b/ontology/shapes.ttl
@@ -121,6 +121,14 @@ rfa:StepRunReasonShape
     sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
     sh:minLength 1 ;
     sh:message "A Step Run reason must have one runtime notation."@en ;
+  ] ;
+  sh:property [
+    sh:path skos:definition ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:languageIn ("en") ;
+    sh:uniqueLang true ;
+    sh:message "A Step Run reason must have one English definition."@en ;
   ] .
 
 rfa:OperationalLifecycleStepShape

--- a/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
+++ b/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
@@ -25,8 +25,10 @@ const owlOnProperty = iri(`${namespace.owl}onProperty`)
 const owlSomeValuesFrom = iri(`${namespace.owl}someValuesFrom`)
 const owlUnionOf = iri(`${namespace.owl}unionOf`)
 const skosNotation = iri(`${namespace.skos}notation`)
+const skosDefinition = iri(`${namespace.skos}definition`)
 const operationalLifecycleStep = term("OperationalLifecycleStep")
 const terminalWorkItemState = term("TerminalWorkItemState")
+const stepRunReasonClass = term("StepRunReason")
 const transitionClass = term("Transition")
 const fromStep = term("fromStep")
 const toStep = term("toStep")
@@ -429,6 +431,87 @@ const notationsForClass = (
   return values
 }
 
+interface GeneratedStepRunReason {
+  readonly key: string
+  readonly notation: string
+  readonly definition: string
+}
+
+const notationToCamelCase = (notation: string): string => {
+  const key = notation
+    .split(/[-_]/)
+    .map((part, index) =>
+      index === 0 ? part : `${part.charAt(0).toUpperCase()}${part.slice(1)}`,
+    )
+    .join("")
+
+  if (key.length === 0 || !/^[A-Za-z][A-Za-z0-9]*$/.test(key)) {
+    throw new Error(`Cannot derive a TypeScript key from notation: ${notation}`)
+  }
+
+  return key
+}
+
+const stepRunReasons = (store: Store): readonly GeneratedStepRunReason[] => {
+  const values = store
+    .getSubjects(rdfType, stepRunReasonClass, null)
+    .map((subject): GeneratedStepRunReason => {
+      const notation = onlyNotation(store, subject)
+      return {
+        key: notationToCamelCase(notation),
+        notation,
+        definition: onlyLiteral(store, subject, skosDefinition),
+      }
+    })
+    .sort((left, right) => left.notation.localeCompare(right.notation))
+
+  if (values.length === 0) {
+    throw new Error("No Step Run reason codes found")
+  }
+
+  const duplicateNotation = values.find(
+    (value, index) => value.notation === values[index - 1]?.notation,
+  )
+  if (duplicateNotation !== undefined) {
+    throw new Error(
+      `Duplicate Step Run reason notation: ${duplicateNotation.notation}`,
+    )
+  }
+
+  const keys = values.map((value) => value.key).sort()
+  const duplicateKey = keys.find((key, index) => key === keys[index - 1])
+  if (duplicateKey !== undefined) {
+    throw new Error(`Duplicate Step Run reason key: ${duplicateKey}`)
+  }
+
+  return values
+}
+
+const renderJsDoc = (definition: string): string => {
+  const escaped = definition.replaceAll("*/", "*\\/")
+  return `  /** ${escaped} */`
+}
+
+const renderStepRunReasons = (values: readonly GeneratedStepRunReason[]) => `\
+${renderTuple(
+  "STEP_RUN_REASONS",
+  values.map((value) => value.notation),
+)}
+export const StepRunReason = Schema.Literals(STEP_RUN_REASONS)
+export type StepRunReason = typeof StepRunReason.Type
+
+export const STEP_RUN_REASON = {
+${values
+  .map(
+    (value) =>
+      `${renderJsDoc(value.definition)}\n  ${value.key}: ${JSON.stringify(value.notation)},`,
+  )
+  .join("\n")}
+} as const satisfies Record<string, StepRunReason>
+
+export type StepRunReasonCode = (typeof STEP_RUN_REASON)[keyof typeof STEP_RUN_REASON]
+`
+
 interface GeneratedTransition {
   readonly from: string
   readonly to: string
@@ -440,6 +523,7 @@ const transitions = (
   store: Store,
   operationalSteps: readonly string[],
   terminalStates: readonly string[],
+  reasonNotations: ReadonlySet<string>,
 ): readonly GeneratedTransition[] => {
   const stateSet = new Set([...operationalSteps, ...terminalStates])
   const values = store
@@ -460,6 +544,11 @@ const transitions = (
       if (!stateSet.has(to)) {
         throw new Error(
           `${subject.value} to-step ${to} is not a Work Item state`,
+        )
+      }
+      if (!reasonNotations.has(transitionReasonCode)) {
+        throw new Error(
+          `${subject.value} reason ${transitionReasonCode} is not a declared Step Run reason`,
         )
       }
 
@@ -506,7 +595,7 @@ export interface LifecycleTransition {
   readonly from: WorkItemState
   readonly to: WorkItemState
   readonly guard: string
-  readonly reasonCode: string
+  readonly reasonCode: StepRunReason
 }
 
 export const LIFECYCLE_TRANSITIONS = [
@@ -568,6 +657,7 @@ export const isAgentDependentLifecycleStep = (step: string): boolean =>
 const renderGeneratedSource = (
   operationalSteps: readonly string[],
   terminalStates: readonly string[],
+  lifecycleReasons: readonly GeneratedStepRunReason[],
   lifecycleTransitions: readonly GeneratedTransition[],
   lifecycleStepProperties: readonly GeneratedStepProperties[],
 ) => `\
@@ -597,6 +687,7 @@ export const WORK_ITEM_STATES = [
 export const WorkItemState = Schema.Literals(WORK_ITEM_STATES)
 export type WorkItemState = typeof WorkItemState.Type
 
+${renderStepRunReasons(lifecycleReasons)}
 ${renderStepPropertyMaps(lifecycleStepProperties)}
 ${renderTransitions(lifecycleTransitions)}
 `
@@ -610,6 +701,7 @@ const generate = async () => {
   const ontology = new Store(quads)
   const operationalSteps = notationsForClass(ontology, operationalLifecycleStep)
   const terminalStates = notationsForClass(ontology, terminalWorkItemState)
+  const lifecycleReasons = stepRunReasons(ontology)
   const lifecycleStepProperties = stepProperties(ontology)
 
   if (
@@ -627,7 +719,13 @@ const generate = async () => {
     stateSource: renderGeneratedSource(
       operationalSteps,
       terminalStates,
-      transitions(ontology, operationalSteps, terminalStates),
+      lifecycleReasons,
+      transitions(
+        ontology,
+        operationalSteps,
+        terminalStates,
+        new Set(lifecycleReasons.map((reason) => reason.notation)),
+      ),
       lifecycleStepProperties,
     ),
     predicateSource: renderPredicateExpressions(predicateExpressions(ontology)),

--- a/packages/lifecycle-model/src/generated/work-item-state.ts
+++ b/packages/lifecycle-model/src/generated/work-item-state.ts
@@ -48,6 +48,113 @@ export const WORK_ITEM_STATES = [
 export const WorkItemState = Schema.Literals(WORK_ITEM_STATES)
 export type WorkItemState = typeof WorkItemState.Type
 
+export const STEP_RUN_REASONS = [
+  "abandoned",
+  "agent_backend_auth_rejected",
+  "agent_backend_unavailable",
+  "agent_fallback",
+  "agent_model_not_in_catalog",
+  "build_model_not_configured",
+  "copy_generation",
+  "github_throttled",
+  "green-no-review-evidence",
+  "handler_defect",
+  "handler_failed",
+  "interrupted",
+  "issue_closed_pr_closed_unmerged",
+  "issue_closed_while_pr_open",
+  "merge_revalidation",
+  "missing_successful_checks",
+  "native",
+  "paused",
+  "pr_merged",
+  "pr_status_checks_unresolved",
+  "reset",
+  "review_accepted",
+  "review_applying_findings",
+  "review_assessing_rerun",
+  "review_cleared",
+  "review_deferred",
+  "review_pre_commit",
+  "review_reviewing",
+  "thinking_level_not_in_catalog",
+  "timeout",
+  "waiting_for_agent_turn",
+  "worker_restarted",
+] as const
+
+export const StepRunReason = Schema.Literals(STEP_RUN_REASONS)
+export type StepRunReason = typeof StepRunReason.Type
+
+export const STEP_RUN_REASON = {
+  /** The Step Run was cancelled because the operator abandoned the Work Item. */
+  abandoned: "abandoned",
+  /** An Agent Turn failed because the backend provider rejected credentials as missing, expired, or invalid. */
+  agentBackendAuthRejected: "agent_backend_auth_rejected",
+  /** An agent-dependent step is blocked because the Active Agent Backend is unavailable. */
+  agentBackendUnavailable: "agent_backend_unavailable",
+  /** A conditionally agent-using step completed via one repair Agent Turn after the native path did not establish the postcondition. */
+  agentFallback: "agent_fallback",
+  /** An agent-dependent step is blocked because the resolved Agent Model is absent from the Agent Backend's current Ready catalog. Rejected before the backend CLI is spawned. */
+  agentModelNotInCatalog: "agent_model_not_in_catalog",
+  /** An agent-dependent step is blocked because no build Agent Model is configured. */
+  buildModelNotConfigured: "build_model_not_configured",
+  /** Mid-run: Commit is generating shared publication copy via an Agent Turn before the native git commit attempt. */
+  copyGeneration: "copy_generation",
+  /** Watch PR Status Checks stopped cleanly at GitHub's explicit retry time. */
+  githubThrottled: "github_throttled",
+  /** A green-only Status Check Handoff completed without an Agent Turn because harness-owned GitHub observation found no positive automated-review evidence. */
+  greenNoReviewEvidence: "green-no-review-evidence",
+  /** The Step Run ended because the Lifecycle Step handler threw a defect rather than a typed failure. */
+  handlerDefect: "handler_defect",
+  /** The Step Run ended because the Lifecycle Step handler failed with a typed or unexpected error. */
+  handlerFailed: "handler_failed",
+  /** The Step Run was stopped before completion by an operator or harness interrupt. */
+  interrupted: "interrupted",
+  /** A successful Step Run stopped because Issue revalidation found the Issue closed or missing and the Work Item PR was closed without merge. The Work Item is paused for an operator Start, Abandon, or Reset decision. */
+  issueClosedPrClosedUnmerged: "issue_closed_pr_closed_unmerged",
+  /** A successful Step Run stopped because Issue revalidation found the Issue closed or missing while a Work Item PR is still open or PR status was indeterminate. The Work Item is paused for operator Start after reopen. */
+  issueClosedWhilePrOpen: "issue_closed_while_pr_open",
+  /** A successful Merge PR run that returned to Watch PR Status Checks for fresh validation. */
+  mergeRevalidation: "merge_revalidation",
+  /** Autonomous merge stopped because the Forge reported no successful status-check aggregate by the deadline. */
+  missingSuccessfulChecks: "missing_successful_checks",
+  /** A conditionally agent-using step completed via the harness-owned native path with no Agent Turn. */
+  native: "native",
+  /** The Step Run stopped because the Work Item was paused. */
+  paused: "paused",
+  /** Confirmed Work Item PR merge outcome, used when a Step Run is cancelled because the PR merged before it finished, or a successful Step Run advances to local cleanup after Issue revalidation finds the Issue closed or missing and the owned PR already merged. */
+  prMerged: "pr_merged",
+  /** Watch PR Status Checks stopped because the status-check observation did not resolve. */
+  prStatusChecksUnresolved: "pr_status_checks_unresolved",
+  /** The Step Run was cancelled because the operator reset the Work Item. */
+  reset: "reset",
+  /** A successful Review that accepted low-severity remediation without a full rerun. */
+  reviewAccepted: "review_accepted",
+  /** Mid-run: Review is applying findings with the build model. */
+  reviewApplyingFindings: "review_applying_findings",
+  /** Mid-run: Review is assessing whether low-severity remediation needs a rerun. */
+  reviewAssessingRerun: "review_assessing_rerun",
+  /** A successful Review that cleared low or medium findings without changes. */
+  reviewCleared: "review_cleared",
+  /** A successful Review that deferred findings and advanced to Commit. */
+  reviewDeferred: "review_deferred",
+  /** Mid-run: Review is re-running Pre-Commit after FIXED before re-review. */
+  reviewPreCommit: "review_pre_commit",
+  /** Mid-run: Review is running the reviewing Agent Turn. */
+  reviewReviewing: "review_reviewing",
+  /** An agent-dependent step is blocked because the resolved Thinking Level is not advertised by the governing Agent Model's current catalog entry. Rejected before the backend CLI is spawned. */
+  thinkingLevelNotInCatalog: "thinking_level_not_in_catalog",
+  /** The Step Run ended because the Lifecycle Step exceeded its configured maximum duration. */
+  timeout: "timeout",
+  /** Mid-run: the Step Run is Running but blocked on maxConcurrentAgentTurns. */
+  waitingForAgentTurn: "waiting_for_agent_turn",
+  /** The prior harness or job-worker process ended while the Step Run was still Running. */
+  workerRestarted: "worker_restarted",
+} as const satisfies Record<string, StepRunReason>
+
+export type StepRunReasonCode = (typeof STEP_RUN_REASON)[keyof typeof STEP_RUN_REASON]
+
 export type LifecycleStepPropertyMap<Value> = {
   readonly [Step in OperationalLifecycleStep]: Value
 }
@@ -123,7 +230,7 @@ export interface LifecycleTransition {
   readonly from: WorkItemState
   readonly to: WorkItemState
   readonly guard: string
-  readonly reasonCode: string
+  readonly reasonCode: StepRunReason
 }
 
 export const LIFECYCLE_TRANSITIONS = [

--- a/packages/lifecycle-model/test/step-run-reason.test.ts
+++ b/packages/lifecycle-model/test/step-run-reason.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { Parser, Store } from "n3"
+import {
+  LIFECYCLE_TRANSITIONS,
+  STEP_RUN_REASON,
+  STEP_RUN_REASONS,
+  StepRunReason,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const ontologyPath = resolve(import.meta.dir, "../../../ontology/rfa.ttl")
+
+const namespace = {
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  rfa: "https://ready-for-agent.dev/ontology/rfa#",
+  skos: "http://www.w3.org/2004/02/skos/core#",
+} as const
+
+const rdfType = `${namespace.rdf}type`
+const stepRunReasonClass = `${namespace.rfa}StepRunReason`
+const skosNotation = `${namespace.skos}notation`
+
+const ontologyReasonNotations = (): readonly string[] => {
+  const quads = new Parser({
+    baseIRI: `file://${ontologyPath}`,
+    format: "Turtle",
+  }).parse(readFileSync(ontologyPath, "utf8"))
+  const store = new Store(quads)
+
+  return store
+    .getSubjects(rdfType, stepRunReasonClass, null)
+    .map((subject) => {
+      const notations = store.getObjects(subject, skosNotation, null)
+      if (notations.length !== 1 || notations[0]?.termType !== "Literal") {
+        throw new Error(`${subject.value} must have exactly one skos:notation`)
+      }
+      return notations[0].value
+    })
+    .sort()
+}
+
+describe("generated STEP_RUN_REASON", () => {
+  it("exports exactly the ontology Step Run reason notations", () => {
+    expect([...STEP_RUN_REASONS]).toEqual(ontologyReasonNotations())
+    expect(Object.values(STEP_RUN_REASON).toSorted()).toEqual(
+      ontologyReasonNotations(),
+    )
+  })
+
+  it("keeps the camelCase accessors used by the harness", () => {
+    expect(STEP_RUN_REASON.handlerFailed).toBe("handler_failed")
+    expect(STEP_RUN_REASON.handlerDefect).toBe("handler_defect")
+    expect(STEP_RUN_REASON.greenNoReviewEvidence).toBe(
+      "green-no-review-evidence",
+    )
+    expect(STEP_RUN_REASON.agentBackendAuthRejected).toBe(
+      "agent_backend_auth_rejected",
+    )
+    expect(STEP_RUN_REASON.waitingForAgentTurn).toBe("waiting_for_agent_turn")
+    expect(STEP_RUN_REASON.issueClosedPrClosedUnmerged).toBe(
+      "issue_closed_pr_closed_unmerged",
+    )
+  })
+
+  it("backs the Effect schema with the generated notations", () => {
+    expect(StepRunReason.literals).toEqual(STEP_RUN_REASONS)
+  })
+
+  it("draws every declared transition reason from the generated table", () => {
+    const reasonCodes = new Set<string>(STEP_RUN_REASONS)
+    for (const transition of LIFECYCLE_TRANSITIONS) {
+      expect(reasonCodes.has(transition.reasonCode)).toBe(true)
+    }
+  })
+})

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleMaxDurations,
   OperationalLifecycleStep,
+  STEP_RUN_REASON,
   TERMINAL_WORK_ITEM_STATES,
   TerminalWorkItemState,
   WorkItemState,
@@ -16,6 +17,10 @@ import {
   JOBS_COMPLETED_WINDOW_MS,
 } from "./jobs-completed-window.js"
 
+export {
+  STEP_RUN_REASON,
+  type StepRunReasonCode,
+} from "@ready-for-agent/lifecycle-model"
 export type {
   ExecutionProfileReviewSelection,
   ExplicitWorkItemExecutionProfile,
@@ -368,108 +373,6 @@ export const filterWorkItemsByListKind = <
 
 /** How a conditionally agent-using step completed its postcondition. */
 export type LifecycleStepCompletion = "native" | "agent_fallback"
-
-export const STEP_RUN_REASON = {
-  handlerFailed: "handler_failed",
-  handlerDefect: "handler_defect",
-  prStatusChecksUnresolved: "pr_status_checks_unresolved",
-  /** Watch PR Status Checks stopped cleanly at GitHub's explicit retry time. */
-  githubThrottled: "github_throttled",
-  timeout: "timeout",
-  interrupted: "interrupted",
-  /** Prior harness/job-worker process ended while the Step Run was still Running. */
-  workerRestarted: "worker_restarted",
-  abandoned: "abandoned",
-  reset: "reset",
-  paused: "paused",
-  /** Mid-run: Step Run is Running but blocked on maxConcurrentAgentTurns. */
-  waitingForAgentTurn: "waiting_for_agent_turn",
-  /** Agent-dependent step blocked because Active Agent Backend is unavailable. */
-  agentBackendUnavailable: "agent_backend_unavailable",
-  /**
-   * Agent Turn failed because the backend provider rejected credentials
-   * (missing, expired, or invalid). Distinct from handler_failed so the
-   * outage is queryable (issue #1058).
-   */
-  agentBackendAuthRejected: "agent_backend_auth_rejected",
-  /** Agent-dependent step blocked because no build Agent Model is configured. */
-  buildModelNotConfigured: "build_model_not_configured",
-  /**
-   * Agent-dependent step blocked because the resolved Agent Model is absent
-   * from the Agent Backend's current Ready catalog (issue #838). Rejected
-   * before the backend CLI is spawned.
-   */
-  agentModelNotInCatalog: "agent_model_not_in_catalog",
-  /**
-   * Agent-dependent step blocked because the resolved Thinking Level is not
-   * advertised by the governing Agent Model's current catalog entry
-   * (issue #1073). Rejected before the backend CLI is spawned.
-   */
-  thinkingLevelNotInCatalog: "thinking_level_not_in_catalog",
-  /**
-   * Autonomous merge stopped because the Forge reported no successful
-   * status-check aggregate (`no_checks` or GitHub EXPECTED) by the deadline.
-   */
-  missingSuccessfulChecks: "missing_successful_checks",
-  /** Mid-run: Review is running the reviewing OpenCode pass. */
-  reviewReviewing: "review_reviewing",
-  /** Mid-run: Review is applying findings with the build model. */
-  reviewApplyingFindings: "review_applying_findings",
-  /** Mid-run: Review is re-running Pre-Commit after FIXED before re-review. */
-  reviewPreCommit: "review_pre_commit",
-  /** Mid-run: Review is assessing whether low-severity remediation needs rerun. */
-  reviewAssessingRerun: "review_assessing_rerun",
-  /** Successful Review that deferred findings and advanced to Commit. */
-  reviewDeferred: "review_deferred",
-  /** Successful Review that cleared low/medium findings without changes. */
-  reviewCleared: "review_cleared",
-  /** Successful Review that accepted low-severity remediation without full rerun. */
-  reviewAccepted: "review_accepted",
-  /** Successful Merge PR run that returned to Watch for fresh validation. */
-  mergeRevalidation: "merge_revalidation",
-  /**
-   * Green-only Status Check Handoff completed without an Agent Turn because
-   * harness-owned GitHub observation found no positive automated-review evidence.
-   */
-  greenNoReviewEvidence: "green-no-review-evidence",
-  /**
-   * Confirmed Work Item PR merge outcome. Used when:
-   * - a Step Run is interrupted/cancelled because the PR merged before it finished
-   * - a successful Step Run stops at Issue revalidation because the Issue is
-   *   closed/missing and the owned PR is already merged (advance to local cleanup)
-   */
-  prMerged: "pr_merged",
-  /**
-   * Successful Step Run that stopped because Issue revalidation found the
-   * Issue closed/missing while a Work Item PR is still open (or PR status
-   * was indeterminate). Work Item is paused for operator Start after reopen.
-   */
-  issueClosedWhilePrOpen: "issue_closed_while_pr_open",
-  /**
-   * Successful Step Run that stopped because Issue revalidation found the
-   * Issue closed/missing and the Work Item PR was closed without merge.
-   * Work Item is paused for operator decision (Start / Abandon / Reset).
-   */
-  issueClosedPrClosedUnmerged: "issue_closed_pr_closed_unmerged",
-  /**
-   * Conditionally agent-using step completed via harness-owned native path
-   * (no Agent Turn).
-   */
-  native: "native",
-  /**
-   * Conditionally agent-using step completed via one repair Agent Turn after
-   * the native path did not establish the postcondition.
-   */
-  agentFallback: "agent_fallback",
-  /**
-   * Mid-run: Commit is generating shared publication copy via an Agent Turn
-   * before the native git commit attempt.
-   */
-  copyGeneration: "copy_generation",
-} as const
-
-export type StepRunReasonCode =
-  (typeof STEP_RUN_REASON)[keyof typeof STEP_RUN_REASON]
 
 const AUTONOMOUS_MERGE_CHECK_REQUIREMENT =
   "Autonomous merge requires at least one successful external check. Configure or run a check, then Retry checks; otherwise review and merge the pull request manually."


### PR DESCRIPTION
The ontology and the harness `STEP_RUN_REASON` table had drifted, and
the docs already claimed the ontology owned those codes. Issue #1054
left an open ownership split; the recorded decision is that the ontology
owns every reason, including operational mid-run codes.

`ontology/rfa.ttl` now declares the full vocabulary (32
`rfa:StepRunReason` individuals, each with `skos:notation` and an
English definition). `lifecycle-model:generate` emits `STEP_RUN_REASON`
next to the state space; `work-item-lifecycle` re-exports the generated
table so existing camelCase accessors stay stable. ADR-0058, `AGENTS.md`,
and the `ontology-change` skill state that boundary with no leftover
exception.

`lifecycle-model:check-generated` (a dependency of
`lifecycle-model:test`, which PR CI runs via `nx affected`) fails if the
checked-in table and `rfa.ttl` diverge. Also verified:
`lifecycle-model` tests (183), typecheck/lint/knip on the touched
packages, and a stale generated file is rejected by `check-generated`.

Closes #1054