### PR TITLE
style(harness): match completed cards to kanban lane borders

### DIFF
--- a/apps/harness/src/completed-work-item-row.tsx
+++ b/apps/harness/src/completed-work-item-row.tsx
@@ -36,7 +36,7 @@ export type CompletedWorkItemIssueLookup = {
  * Completed Work Item archive row for the historical Completed page
  * (`docs/harness-design-system.md` §4.5, wayfinder #698 prototype).
  *
- * Complete rows: 6px Merged line bar, no stamp. Abandoned rows: dashed border,
+ * Complete rows: 2px ink border on all sides, no stamp. Abandoned rows: dashed border,
  * ghosted title, dashed ABANDONED stamp. Footer carries lane-coloured archive
  * legs (BUILD / REVIEW / PR|MR) that expand to fine-grained lifecycle chips
  * (same pattern as Kanban earlier-lane summaries). The forge change-request
@@ -123,12 +123,7 @@ export function CompletedWorkItemRow({
   )
 
   return (
-    <li
-      className={cx(
-        ui.archiveRow,
-        abandoned ? ui.archiveRowAbandoned : ui.archiveRowComplete,
-      )}
-    >
+    <li className={cx(ui.archiveRow, abandoned && ui.archiveRowAbandoned)}>
       <div className={ui.archiveRowTop}>
         <p className={ui.archiveRepo} title={repositoryLabel}>
           {repositoryLabel}

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -33,9 +33,8 @@ const pipelineTabActiveRivets =
 const laneSwitchRivets = plateMiniRivets
 
 /**
- * Light-theme brushed metal for ticket-style cards (repo cards, completed
- * archive rows). Dark keeps solid `bg-panel`. Full static strings so Tailwind
- * can scan them.
+ * Light-theme brushed metal for ticket-style cards (repo cards). Dark keeps
+ * solid `bg-panel`. Full static strings so Tailwind can scan them.
  */
 const cardMetalLight =
   "in-[html[data-theme=light]]:bg-[linear-gradient(165deg,rgb(255_255_255/0.72)_0%,rgb(255_255_255/0.18)_42%,transparent_68%),linear-gradient(180deg,#f0f2f0_0%,#e3e7e4_55%,#dfe4e1_100%)]"
@@ -270,17 +269,13 @@ export const ui = {
   archiveRows: "m-0 grid list-none gap-[0.6rem] p-0",
 
   /**
-   * Completed archive card. Same shell, metal fill, and type scale as repo
-   * cards (§4.6) so Completed and Repos read as one family.
+   * Completed archive card. Kanban lane outer stroke (2px ink) on all four
+   * sides, parchment fill, repos type scale. No lane-color left bar.
    */
   archiveRow: cx(
-    "grid min-w-0 gap-[0.55rem] border-[1.5px] border-ink bg-panel",
+    "grid min-w-0 gap-[0.55rem] border-2 border-ink bg-[var(--ticket-fill)]",
     "px-[1.1rem] pt-4 pb-[1.15rem]",
-    cardMetalLight,
   ),
-
-  archiveRowComplete:
-    "shadow-[inset_6px_0_0_var(--lane-merged),inset_8px_0_0_var(--merged-halo)]",
 
   archiveRowAbandoned: "border-dashed border-ink-faint",
 

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -126,7 +126,7 @@ describe("Completed surface routes", () => {
     const row = rowSource()
     expect(row).toContain("export function CompletedWorkItemRow(")
     expect(row).toContain("planArchiveLegs")
-    expect(row).toContain("ui.archiveRowComplete")
+    expect(row).not.toContain("ui.archiveRowComplete")
     expect(row).toContain("ui.archiveRowAbandoned")
     expect(row).toContain("ui.legLane")
     expect(row).toContain("ui.archiveLeg")
@@ -166,11 +166,11 @@ describe("Completed surface routes", () => {
     expect(topIdx).toBeGreaterThan(-1)
     expect(prTopIdx).toBeGreaterThan(topIdx)
     expect(titleIdx).toBeGreaterThan(prTopIdx)
-    expect(ui).toContain("archiveRowComplete:")
-    // Same light-mode brushed metal as repo cards (shared cardMetalLight).
-    expect(ui).toMatch(
-      /archiveRow:[\s\S]*?cardMetalLight|archiveRow:[\s\S]*?#f0f2f0_0%/,
-    )
+    expect(ui).not.toContain("archiveRowComplete:")
+    expect(ui).not.toContain("inset_6px_0_0_var(--lane-merged)")
+    expect(ui).toMatch(/archiveRow:[\s\S]*?border-2[\s\S]*?border-ink/)
+    // Same parchment fill as Kanban tickets; 2px ink stroke like lane chrome.
+    expect(ui).toMatch(/archiveRow:[\s\S]*?bg-\[var\(--ticket-fill\)\]/)
     expect(ui).toContain("cardMetalLight")
     // Repos-aligned type: card padding, title metrics, issue-num mono, kicker repo.
     expect(ui).toMatch(/archiveRow:[\s\S]*?px-\[1\.1rem\]/)

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -407,9 +407,11 @@ not pure white, not brushed metal. No radius, no offset shadow.
   extends to this single-column surface; no lane columns here.
 - **Archive body**: `--panel`, 1.5px ink border (no top), 0.8rem padding,
   0.6rem row gap.
-- **Rows**: hard-bordered cards sharing the **repos** type + shell language
-  (1.1rem padding, brushed-metal light fill / `--panel` dark).
-  - *Complete* — 6px Merged line bar (`inset`, halo in dark). **No COMPLETE
+- **Rows**: hard-bordered cards sharing Kanban lane chrome (2px ink stroke
+  on all four sides, `--ticket-fill` parchment) and the **repos** type
+  scale (1.1rem padding).
+  - *Complete* — 2px ink border on all four sides (same weight as the
+    Kanban board’s outer left/right; no Merged left bar). **No COMPLETE
     stamp** — Complete is the page's default; only exceptions are stamped.
   - *Abandoned* — dashed `--ink-faint` border, ghosted title (`--ink-dim`),
     dashed ABANDONED stamp.


### PR DESCRIPTION
## Why

Completed archive cards used a 6px Merged left bar and brushed-metal fill, so they read as a different family from the homepage Kanban. Operators asked for the same 2px ink stroke as the Kanban lane outer left/right — on all four sides — and the ticket parchment fill.

## What Changed

Dropped the Merged inset bar. Completed cards now use `--ticket-fill` and a 2px ink border on all four sides. Abandoned cards still use a dashed faint border.
