### PR TITLE
feat(claude): serve a bounded Agent Turn Tail from the parent transcript

### DIFF
--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -118,7 +118,7 @@ const CLAUDE_REGISTRATION: AgentBackendRegistration = {
   },
   capabilities: [
     { _tag: "SessionTelemetry", supported: true },
-    { _tag: "AgentTurnTail", supported: false },
+    { _tag: "AgentTurnTail", supported: true },
     { _tag: "KeymaxxerMcp", supported: false },
   ],
 }

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -115,7 +115,7 @@ describe("Agent Backend registry", () => {
     const claude = getBuiltInAgentBackend(AGENT_BACKEND_IDS.claude)
     expect(claude).toBeDefined()
     expect(capabilitySupported(claude!, "SessionTelemetry")).toBe(true)
-    expect(capabilitySupported(claude!, "AgentTurnTail")).toBe(false)
+    expect(capabilitySupported(claude!, "AgentTurnTail")).toBe(true)
     expect(capabilitySupported(claude!, "KeymaxxerMcp")).toBe(false)
   })
 })

--- a/packages/claude/src/lib/session-store.ts
+++ b/packages/claude/src/lib/session-store.ts
@@ -1,7 +1,26 @@
-import { type Dirent, readFileSync, readdirSync, statSync } from "node:fs"
+import {
+  type Dirent,
+  closeSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+} from "node:fs"
 import { homedir } from "node:os"
 import { basename, dirname, isAbsolute, join } from "node:path"
 import { Context, Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  AGENT_TURN_TAIL_ITEM_LIMIT,
+  type AgentTurnTail,
+  type AgentTurnTailSourceEvent,
+  makeAgentTurnTail,
+  missingAgentTurnTail,
+  selectAgentTurnTail,
+  unavailableAgentTurnTail,
+} from "@ready-for-agent/agent-backend"
 
 export const CLAUDE_SESSION_PROVIDER_ID = "anthropic"
 export const CLAUDE_BEDROCK_SESSION_PROVIDER_ID = "bedrock"
@@ -44,8 +63,14 @@ export type ClaudeSessionUnavailable = {
 
 export type ClaudeSession = ClaudeSessionAvailable | ClaudeSessionUnavailable
 
+const CLAUDE_BACKEND = {
+  id: AGENT_BACKEND_IDS.claude,
+  label: "Claude Code",
+} as const
+
 export type ClaudeSessionStoreShape = {
   readonly getSession: (id: string) => Effect.Effect<ClaudeSession, never>
+  readonly getTail: (id: string) => Effect.Effect<AgentTurnTail, never>
 }
 
 export class ClaudeSessionStore extends Context.Service<
@@ -497,6 +522,286 @@ const readClaudeSessionFromDisk = (input: {
   }
 }
 
+const TAIL_READ_CHUNK_BYTES = 64 * 1024
+const NEWLINE = 0x0a
+
+type ClaudeTailLineEvent =
+  | { readonly kind: "user"; readonly at: string }
+  | {
+      readonly kind: "assistant_text"
+      readonly text: string
+      readonly at: string
+    }
+  | {
+      readonly kind: "tool_use"
+      readonly id: string
+      readonly name: string
+      readonly at: string
+    }
+  | {
+      readonly kind: "tool_result"
+      readonly id: string
+      readonly status: string
+      readonly at: string
+    }
+
+const isChildSessionLine = (
+  record: Readonly<Record<string, unknown>>,
+): boolean =>
+  record["isSidechain"] === true ||
+  (record["parent_tool_use_id"] !== undefined &&
+    record["parent_tool_use_id"] !== null)
+
+const toolStatusFromResult = (isError: unknown): string =>
+  isError === true ? "failed" : "completed"
+
+const eventsFromUserContent = (
+  content: unknown,
+  at: string,
+): ClaudeTailLineEvent[] => {
+  if (typeof content === "string") {
+    return [{ kind: "user", at }]
+  }
+  if (!Array.isArray(content)) {
+    return [{ kind: "user", at }]
+  }
+
+  const events: ClaudeTailLineEvent[] = []
+  let hasPrompt = false
+  for (const block of content) {
+    if (!isRecord(block)) {
+      continue
+    }
+    if (block["type"] === "tool_result") {
+      const id = nonEmptyString(block["tool_use_id"])
+      if (id !== null) {
+        events.push({
+          kind: "tool_result",
+          id,
+          status: toolStatusFromResult(block["is_error"]),
+          at,
+        })
+      }
+      continue
+    }
+    if (block["type"] === "text") {
+      hasPrompt = true
+    }
+  }
+  if (hasPrompt || events.length === 0) {
+    events.push({ kind: "user", at })
+  }
+  return events
+}
+
+const eventsFromAssistantContent = (
+  content: unknown,
+  at: string,
+): ClaudeTailLineEvent[] => {
+  if (typeof content === "string") {
+    return content === "" ? [] : [{ kind: "assistant_text", text: content, at }]
+  }
+  if (!Array.isArray(content)) {
+    return []
+  }
+
+  const events: ClaudeTailLineEvent[] = []
+  for (const block of content) {
+    if (!isRecord(block)) {
+      continue
+    }
+    if (block["type"] === "text") {
+      const text = typeof block["text"] === "string" ? block["text"] : ""
+      if (text !== "") {
+        events.push({ kind: "assistant_text", text, at })
+      }
+      continue
+    }
+    if (block["type"] === "tool_use") {
+      const id = nonEmptyString(block["id"])
+      const name = nonEmptyString(block["name"])
+      if (id !== null && name !== null) {
+        events.push({ kind: "tool_use", id, name, at })
+      }
+    }
+  }
+  return events
+}
+
+/** Map one JSONL line to tail events. Unknown shapes and child lines are skipped. */
+const eventsFromClaudeTranscriptLine = (
+  line: string,
+): ReadonlyArray<ClaudeTailLineEvent> => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(line)
+  } catch {
+    return []
+  }
+  if (!isRecord(parsed) || isChildSessionLine(parsed)) {
+    return []
+  }
+
+  const timestamp = timestampFromLine(parsed["timestamp"])
+  if (timestamp === null) {
+    return []
+  }
+  const at = timestamp.raw
+  const type = parsed["type"]
+
+  if (type === "user") {
+    const message = parsed["message"]
+    return eventsFromUserContent(
+      isRecord(message) ? message["content"] : undefined,
+      at,
+    )
+  }
+
+  if (type === "assistant") {
+    const message = parsed["message"]
+    return eventsFromAssistantContent(
+      isRecord(message) ? message["content"] : undefined,
+      at,
+    )
+  }
+
+  if (type === "tool_use") {
+    const id = nonEmptyString(parsed["id"])
+    const name = nonEmptyString(parsed["name"])
+    return id === null || name === null
+      ? []
+      : [{ kind: "tool_use", id, name, at }]
+  }
+
+  if (type === "tool_result") {
+    const id = nonEmptyString(parsed["tool_use_id"])
+    return id === null
+      ? []
+      : [
+          {
+            kind: "tool_result",
+            id,
+            status: toolStatusFromResult(parsed["is_error"]),
+            at,
+          },
+        ]
+  }
+
+  return []
+}
+
+/**
+ * Visit complete JSONL lines newest-first without decoding the rest of the
+ * file once the visitor stops.
+ */
+const forEachJsonlLineFromEnd = (
+  path: string,
+  visit: (line: string) => boolean,
+): void => {
+  const fd = openSync(path, "r")
+  try {
+    let position = fstatSync(fd).size
+    let leftover = Buffer.alloc(0)
+    while (position > 0) {
+      const toRead = Math.min(TAIL_READ_CHUNK_BYTES, position)
+      position -= toRead
+      const chunk = Buffer.allocUnsafe(toRead)
+      readSync(fd, chunk, 0, toRead, position)
+      const combined = Buffer.concat([chunk, leftover])
+      let end = combined.length
+      for (let index = combined.length - 1; index >= 0; index -= 1) {
+        if (combined[index] !== NEWLINE) {
+          continue
+        }
+        const line = combined.subarray(index + 1, end)
+        end = index
+        if (line.length === 0) {
+          continue
+        }
+        if (!visit(line.toString("utf8"))) {
+          return
+        }
+      }
+      leftover = combined.subarray(0, end)
+    }
+    if (leftover.length > 0) {
+      visit(leftover.toString("utf8"))
+    }
+  } finally {
+    closeSync(fd)
+  }
+}
+
+const readClaudeTailFromDisk = (input: {
+  readonly claudeConfigDir: string
+  readonly sessionId: string
+}): AgentTurnTail => {
+  const id = input.sessionId.trim()
+  if (id === "" || !isSafeClaudeSessionIdSegment(id)) {
+    return missingAgentTurnTail(CLAUDE_BACKEND)
+  }
+
+  const lookup = findClaudeSessionTranscript({
+    claudeConfigDir: input.claudeConfigDir,
+    sessionId: id,
+  })
+  if (lookup.kind === "missing") {
+    return missingAgentTurnTail(CLAUDE_BACKEND)
+  }
+  if (lookup.kind === "unavailable") {
+    return unavailableAgentTurnTail(CLAUDE_BACKEND)
+  }
+
+  try {
+    const newestFirst: AgentTurnTailSourceEvent[] = []
+    const pendingResults = new Map<string, string>()
+
+    forEachJsonlLineFromEnd(lookup.path, (line) => {
+      const lineEvents = eventsFromClaudeTranscriptLine(line)
+      for (let index = lineEvents.length - 1; index >= 0; index -= 1) {
+        const event = lineEvents[index]
+        if (event === undefined) {
+          continue
+        }
+        if (event.kind === "user") {
+          return false
+        }
+        if (event.kind === "tool_result") {
+          pendingResults.set(event.id, event.status)
+          continue
+        }
+        if (event.kind === "tool_use") {
+          newestFirst.push({
+            kind: "tool",
+            name: event.name,
+            status: pendingResults.get(event.id) ?? "running",
+            at: event.at,
+          })
+          pendingResults.delete(event.id)
+        } else {
+          newestFirst.push({
+            kind: "assistant_text",
+            text: event.text,
+            at: event.at,
+          })
+        }
+        if (newestFirst.length >= AGENT_TURN_TAIL_ITEM_LIMIT) {
+          return false
+        }
+      }
+      return true
+    })
+
+    return makeAgentTurnTail({
+      availability: "available",
+      backend: CLAUDE_BACKEND,
+      items: selectAgentTurnTail(newestFirst.reverse()),
+    })
+  } catch {
+    return unavailableAgentTurnTail(CLAUDE_BACKEND)
+  }
+}
+
 export const makeClaudeSessionStore = (
   shape: ClaudeSessionStoreShape,
 ): ClaudeSessionStoreShape => shape
@@ -510,6 +815,13 @@ export const ClaudeSessionStoreLive = (
       getSession: (id) =>
         Effect.sync(() =>
           readClaudeSessionFromDisk({
+            claudeConfigDir: resolveClaudeConfigDir(options),
+            sessionId: id,
+          }),
+        ),
+      getTail: (id) =>
+        Effect.sync(() =>
+          readClaudeTailFromDisk({
             claudeConfigDir: resolveClaudeConfigDir(options),
             sessionId: id,
           }),

--- a/packages/claude/src/lib/session-telemetry-layer.ts
+++ b/packages/claude/src/lib/session-telemetry-layer.ts
@@ -3,7 +3,6 @@ import {
   AGENT_BACKEND_IDS,
   type SessionTelemetry,
   SessionTelemetryProvider,
-  unsupportedAgentTurnTail,
 } from "@ready-for-agent/agent-backend"
 import {
   type ClaudeSession,
@@ -51,7 +50,7 @@ export const ClaudeSessionTelemetryLive = (
       return SessionTelemetryProvider.of({
         getSession: (sessionId) =>
           store.getSession(sessionId).pipe(Effect.map(toSessionTelemetry)),
-        getTail: () => Effect.succeed(unsupportedAgentTurnTail(CLAUDE_BACKEND)),
+        getTail: (sessionId) => store.getTail(sessionId),
       })
     }),
   ).pipe(Layer.provide(storeLayer))

--- a/packages/claude/test/session-store.spec.ts
+++ b/packages/claude/test/session-store.spec.ts
@@ -66,6 +66,101 @@ const getSession = async (input: {
   }
 }
 
+const getTail = async (input: {
+  readonly claudeConfigDir: string
+  readonly id: string
+}) => {
+  const runtime = ManagedRuntime.make(
+    ClaudeSessionStoreLive({ claudeConfigDir: input.claudeConfigDir }),
+  )
+  try {
+    return await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* ClaudeSessionStore
+        return yield* store.getTail(input.id)
+      }),
+    )
+  } finally {
+    await runtime.dispose()
+  }
+}
+
+const userPromptLine = (input: {
+  readonly timestamp: string
+  readonly text: string
+}): string =>
+  JSON.stringify({
+    type: "user",
+    timestamp: input.timestamp,
+    isSidechain: false,
+    message: { role: "user", content: input.text },
+  })
+
+const assistantTextLine = (input: {
+  readonly timestamp: string
+  readonly text: string
+  readonly isSidechain?: boolean
+  readonly parentToolUseId?: string
+}): string =>
+  JSON.stringify({
+    type: "assistant",
+    timestamp: input.timestamp,
+    isSidechain: input.isSidechain ?? false,
+    ...(input.parentToolUseId === undefined
+      ? {}
+      : { parent_tool_use_id: input.parentToolUseId }),
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: input.text }],
+    },
+  })
+
+const assistantToolUseLine = (input: {
+  readonly timestamp: string
+  readonly id: string
+  readonly name: string
+  readonly command: string
+}): string =>
+  JSON.stringify({
+    type: "assistant",
+    timestamp: input.timestamp,
+    isSidechain: false,
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: input.id,
+          name: input.name,
+          input: { command: input.command },
+        },
+      ],
+    },
+  })
+
+const userToolResultLine = (input: {
+  readonly timestamp: string
+  readonly toolUseId: string
+  readonly content: string
+  readonly isError?: boolean
+}): string =>
+  JSON.stringify({
+    type: "user",
+    timestamp: input.timestamp,
+    isSidechain: false,
+    message: {
+      role: "user",
+      content: [
+        {
+          tool_use_id: input.toolUseId,
+          type: "tool_result",
+          content: input.content,
+          is_error: input.isError ?? false,
+        },
+      ],
+    },
+  })
+
 describe("ClaudeSessionStore", () => {
   test("reads real-shaped main and recursive subagent transcripts", async () => {
     const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
@@ -441,6 +536,412 @@ describe("ClaudeSessionStore", () => {
       ).resolves.toMatchObject({
         availability: "unavailable",
         tokens: null,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("reads the latest Agent Turn Tail without tool payloads", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    const payload = "PAYLOAD_MUST_NOT_APPEAR".repeat(200)
+    try {
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-work-repo",
+        sessionId: "tail-session",
+        jsonl: [
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            text: "old harness prompt",
+          }),
+          assistantTextLine({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            text: "old turn",
+          }),
+          assistantToolUseLine({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            id: "toolu_old",
+            name: "Read",
+            command: payload,
+          }),
+          userToolResultLine({
+            timestamp: "2026-08-18T12:00:03.500Z",
+            toolUseId: "toolu_old",
+            content: payload,
+          }),
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:04.000Z",
+            text: "Implement GitHub issue #1145.",
+          }),
+          assistantToolUseLine({
+            timestamp: "2026-08-18T12:00:05.000Z",
+            id: "toolu_test",
+            name: "Bash",
+            command: "bun test",
+          }),
+          userToolResultLine({
+            timestamp: "2026-08-18T12:00:05.500Z",
+            toolUseId: "toolu_test",
+            content: payload,
+            isError: true,
+          }),
+          JSON.stringify({
+            type: "assistant",
+            timestamp: "2026-08-18T12:00:06.000Z",
+            isSidechain: false,
+            message: {
+              role: "assistant",
+              content: [
+                { type: "thinking", thinking: payload },
+                { type: "text", text: "tests failed" },
+              ],
+            },
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({
+        claudeConfigDir: dir,
+        id: "  tail-session  ",
+      })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "claude", label: "Claude Code" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "tool",
+            name: "Bash",
+            status: "failed",
+            at: "2026-08-18T12:00:05.000Z",
+          },
+          {
+            kind: "assistant_text",
+            text: "tests failed",
+            truncated: false,
+            at: "2026-08-18T12:00:06.000Z",
+          },
+        ],
+      })
+      expect(JSON.stringify(tail)).not.toContain("PAYLOAD_MUST_NOT_APPEAR")
+      expect(JSON.stringify(tail)).not.toContain("bun test")
+      expect(JSON.stringify(tail)).not.toContain("old harness prompt")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns empty tail with jumpHint when the latest turn has no activity", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    try {
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-work-repo",
+        sessionId: "empty-turn",
+        jsonl: [
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            text: "implement",
+          }),
+          assistantTextLine({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            text: "done",
+          }),
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            text: "review in children",
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({
+        claudeConfigDir: dir,
+        id: "empty-turn",
+      })
+      expect(tail.availability).toBe("available")
+      expect(tail.items).toEqual([])
+      expect(tail.jumpHint).toBe(true)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns the last 20 activity items of the latest turn", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    try {
+      const lines = [
+        userPromptLine({
+          timestamp: "2026-08-18T12:00:00.000Z",
+          text: "implement",
+        }),
+      ]
+      for (let index = 1; index <= 25; index += 1) {
+        const second = String(index).padStart(2, "0")
+        lines.push(
+          assistantToolUseLine({
+            timestamp: `2026-08-18T12:00:${second}.000Z`,
+            id: `toolu_${index}`,
+            name: `tool-${index}`,
+            command: "secret-arg",
+          }),
+          userToolResultLine({
+            timestamp: `2026-08-18T12:00:${second}.500Z`,
+            toolUseId: `toolu_${index}`,
+            content: "secret-output",
+          }),
+        )
+      }
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-work-repo",
+        sessionId: "long-turn",
+        jsonl: lines.join("\n"),
+      })
+
+      const tail = await getTail({
+        claudeConfigDir: dir,
+        id: "long-turn",
+      })
+      expect(tail.items).toHaveLength(20)
+      expect(tail.items[0]).toEqual({
+        kind: "tool",
+        name: "tool-6",
+        status: "completed",
+        at: "2026-08-18T12:00:06.000Z",
+      })
+      expect(tail.items[19]).toEqual({
+        kind: "tool",
+        name: "tool-25",
+        status: "completed",
+        at: "2026-08-18T12:00:25.000Z",
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("truncates assistant text at 2k characters", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    try {
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-work-repo",
+        sessionId: "long-text",
+        jsonl: [
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            text: "summarize",
+          }),
+          assistantTextLine({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            text: "a".repeat(2050),
+          }),
+        ].join("\n"),
+      })
+
+      await expect(
+        getTail({ claudeConfigDir: dir, id: "long-text" }),
+      ).resolves.toMatchObject({
+        availability: "available",
+        items: [
+          {
+            kind: "assistant_text",
+            text: "a".repeat(2000),
+            truncated: true,
+            at: "2026-08-18T12:00:02.000Z",
+          },
+        ],
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("does not include child Session or subagent activity", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    try {
+      const mainPath = writeTranscript({
+        claudeConfigDir: dir,
+        project: "-work-repo",
+        sessionId: "parent-session",
+        jsonl: [
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            text: "implement",
+          }),
+          assistantTextLine({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            text: "parent done",
+          }),
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            text: "review in children",
+          }),
+          assistantTextLine({
+            timestamp: "2026-08-18T12:00:04.000Z",
+            text: "sidechain leak",
+            isSidechain: true,
+          }),
+          assistantTextLine({
+            timestamp: "2026-08-18T12:00:05.000Z",
+            text: "nested subagent leak",
+            parentToolUseId: "toolu_parent",
+          }),
+        ].join("\n"),
+      })
+      const subagentPath = join(
+        mainPath,
+        "..",
+        "parent-session",
+        "subagents",
+        "worker.jsonl",
+      )
+      mkdirSync(join(subagentPath, ".."), { recursive: true })
+      writeFileSync(
+        subagentPath,
+        assistantTextLine({
+          timestamp: "2026-08-18T12:00:06.000Z",
+          text: "child is reviewing",
+          isSidechain: true,
+        }),
+      )
+
+      const tail = await getTail({
+        claudeConfigDir: dir,
+        id: "parent-session",
+      })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "claude", label: "Claude Code" },
+        jumpHint: true,
+        items: [],
+      })
+      expect(JSON.stringify(tail)).not.toContain("child is reviewing")
+      expect(JSON.stringify(tail)).not.toContain("sidechain leak")
+      expect(JSON.stringify(tail)).not.toContain("nested subagent leak")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("keeps MISSING and UNAVAILABLE instead of failing the tail read", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    try {
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-other-project",
+        sessionId: "foreign-session",
+        jsonl: "",
+      })
+      await expect(
+        getTail({ claudeConfigDir: dir, id: "wanted-session" }),
+      ).resolves.toEqual({
+        availability: "missing",
+        backend: { id: "claude", label: "Claude Code" },
+        items: [],
+        jumpHint: false,
+      })
+
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-project-a",
+        sessionId: "duplicated-session",
+        jsonl: "",
+      })
+      writeTranscript({
+        claudeConfigDir: dir,
+        project: "-project-b",
+        sessionId: "duplicated-session",
+        jsonl: "",
+      })
+      await expect(
+        getTail({ claudeConfigDir: dir, id: "duplicated-session" }),
+      ).resolves.toEqual({
+        availability: "unavailable",
+        backend: { id: "claude", label: "Claude Code" },
+        items: [],
+        jumpHint: false,
+      })
+
+      mkdirSync(join(dir, "projects", "-work-repo", "corrupt-session.jsonl"), {
+        recursive: true,
+      })
+      await expect(
+        getTail({ claudeConfigDir: dir, id: "corrupt-session" }),
+      ).resolves.toEqual({
+        availability: "unavailable",
+        backend: { id: "claude", label: "Claude Code" },
+        items: [],
+        jumpHint: false,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("reads Session token usage without fetching the tail", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-"))
+    try {
+      const sessionId = "usage-without-tail"
+      const mainPath = writeTranscript({
+        claudeConfigDir: dir,
+        project: "-work-repo",
+        sessionId,
+        jsonl: [
+          assistantLine({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            model: "claude-sonnet-5",
+            usage: {
+              input_tokens: 10,
+              output_tokens: 4,
+              cache_read_input_tokens: 30,
+              cache_creation_input_tokens: 5,
+            },
+          }),
+          userPromptLine({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            text: "review in children",
+          }),
+        ].join("\n"),
+      })
+      const subagentPath = join(
+        mainPath,
+        "..",
+        sessionId,
+        "subagents",
+        "worker.jsonl",
+      )
+      mkdirSync(join(subagentPath, ".."), { recursive: true })
+      writeFileSync(
+        subagentPath,
+        assistantLine({
+          timestamp: "2026-08-18T12:00:03.000Z",
+          model: "claude-haiku-4-5-20251001",
+          usage: {
+            input_tokens: 2,
+            output_tokens: 11,
+          },
+        }),
+      )
+
+      const session = await getSession({ claudeConfigDir: dir, id: sessionId })
+      expect(session).toMatchObject({
+        availability: "available",
+        tokens: {
+          input: 12,
+          output: 15,
+          reasoning: 0,
+          cacheRead: 30,
+          cacheWrite: 5,
+        },
+      })
+      await expect(
+        getTail({ claudeConfigDir: dir, id: sessionId }),
+      ).resolves.toMatchObject({
+        availability: "available",
+        items: [],
+        jumpHint: true,
       })
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/packages/claude/test/session-telemetry-layer.spec.ts
+++ b/packages/claude/test/session-telemetry-layer.spec.ts
@@ -24,6 +24,23 @@ describe("ClaudeSessionTelemetryLive", () => {
       ),
     )
 
+  const getTail = (input: {
+    readonly claudeConfigDir: string
+    readonly sessionId: string
+  }) =>
+    Effect.runPromise(
+      Effect.gen(function* () {
+        const provider = yield* SessionTelemetryProvider
+        return yield* provider.getTail(input.sessionId)
+      }).pipe(
+        Effect.provide(
+          ClaudeSessionTelemetryLive({
+            claudeConfigDir: input.claudeConfigDir,
+          }),
+        ),
+      ),
+    )
+
   const writeTranscript = (input: {
     readonly claudeConfigDir: string
     readonly sessionId: string
@@ -102,6 +119,53 @@ describe("ClaudeSessionTelemetryLive", () => {
           providerId: "bedrock",
           thinkingLevel: "medium",
         },
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("serves Agent Turn Tail from the parent transcript only", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-telemetry-"))
+    try {
+      const sessionId = "tail-session"
+      const path = join(dir, "projects", "-work-repo", `${sessionId}.jsonl`)
+      mkdirSync(join(path, ".."), { recursive: true })
+      writeFileSync(
+        path,
+        [
+          JSON.stringify({
+            type: "user",
+            timestamp: "2026-08-18T12:00:01.000Z",
+            isSidechain: false,
+            message: { role: "user", content: "implement" },
+          }),
+          JSON.stringify({
+            type: "assistant",
+            timestamp: "2026-08-18T12:00:02.000Z",
+            isSidechain: false,
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "working" }],
+            },
+          }),
+        ].join("\n"),
+      )
+
+      await expect(
+        getTail({ claudeConfigDir: dir, sessionId }),
+      ).resolves.toEqual({
+        availability: "available",
+        backend: { id: "claude", label: "Claude Code" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "assistant_text",
+            text: "working",
+            truncated: false,
+            at: "2026-08-18T12:00:02.000Z",
+          },
+        ],
       })
     } finally {
       rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Why

#1139 added Agent Turn Tail to the Session usage dialog and GraphQL
`agentTurnTail` query, but Claude Code still reported `UNSUPPORTED`.
Operators on Claude Work Items could see token usage and not a cheap
peek of the latest Agent Turn.

## What changed

Claude now implements the same bounded live-read as OpenCode:

- Registry `AgentTurnTail` is supported, so Show tail appears when a
  Claude Work Item has a Session ID.
- `ClaudeSessionStore.getTail` reverse-reads the canonical parent JSONL
  and stops at the last user/prompt marker or 20 activity items. It does
  not `readFileSync` the whole transcript or walk `subagents/`.
- Items are assistant text (truncated at 2k and marked `truncated`) and
  tool name/status with timestamps. Tool args, tool payloads, thinking,
  harness prompts, `isSidechain` lines, and `parent_tool_use_id` nested
  activity are omitted.
- An empty latest turn returns the existing Jump hint. Missing or
  unreadable transcripts stay `MISSING` / `UNAVAILABLE` instead of
  failing the dialog.
- Session token usage remains a separate `getSession` path and does not
  fetch the tail.

## Verification

- `bunx nx test claude` and `bunx nx test agent-backend`.
- Reader tests cover latest-turn slice, 20-item cap, 2k truncation, no
  payloads in the result, excluded child/subagent activity,
  `MISSING`/`UNAVAILABLE`, and independent token usage.
- Uncommitted review reported `REVIEW_CLEAN`.

## Limitations

Grok Build and Codex Build still report `UNSUPPORTED` until their own
bounded readers land. This change does not alter the usage dialog or
click-Session-ID telemetry fetch.

Closes #1145