### PR TITLE
feat(grok): serve a bounded Agent Turn Tail from Session files

### DIFF
--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -94,7 +94,7 @@ const GROK_REGISTRATION: AgentBackendRegistration = {
   },
   capabilities: [
     { _tag: "SessionTelemetry", supported: true },
-    { _tag: "AgentTurnTail", supported: false },
+    { _tag: "AgentTurnTail", supported: true },
     { _tag: "KeymaxxerMcp", supported: false },
   ],
 }

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -103,7 +103,7 @@ describe("Agent Backend registry", () => {
     const grok = getBuiltInAgentBackend(AGENT_BACKEND_IDS.grok)
     expect(grok).toBeDefined()
     expect(capabilitySupported(grok!, "SessionTelemetry")).toBe(true)
-    expect(capabilitySupported(grok!, "AgentTurnTail")).toBe(false)
+    expect(capabilitySupported(grok!, "AgentTurnTail")).toBe(true)
     expect(capabilitySupported(grok!, "KeymaxxerMcp")).toBe(false)
 
     const codex = getBuiltInAgentBackend(AGENT_BACKEND_IDS.codex)

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -10362,6 +10362,36 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("session reports Agent Turn Tail supported for Grok Build", async () => {
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        getWorkItem: () =>
+          Effect.succeed({
+            ...workItem,
+            agentBackend: "grok",
+            sessionId: "ses_owned",
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query Session($workItemId: ID!) {
+          session(workItemId: $workItemId) { agentTurnTailSupported }
+        }`,
+        variables: { workItemId: workItem.id },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { session: { agentTurnTailSupported: true } },
+    })
+  })
+
   test("agentTurnTail returns null for unknown Work Item", async () => {
     runtime = makeRuntime(
       {},

--- a/packages/grok/src/lib/session-store.ts
+++ b/packages/grok/src/lib/session-store.ts
@@ -1,7 +1,20 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import { basename, isAbsolute, join } from "node:path"
 import { Context, Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  type AgentTurnTail,
+  makeAgentTurnTail,
+  missingAgentTurnTail,
+  unavailableAgentTurnTail,
+} from "@ready-for-agent/agent-backend"
 import { type GrokHomeInput, resolveGrokHome } from "./grok-home.js"
+import { readGrokUpdatesJsonlTail } from "./session-tail.js"
+
+export const GROK_BACKEND = {
+  id: AGENT_BACKEND_IDS.grok,
+  label: "Grok Build",
+} as const
 
 /** 1 USD = 10^10 ticks (Grok headless `total_cost_usd_ticks` / `costUsdTicks`). */
 export const GROK_COST_USD_TICKS_PER_USD = 10_000_000_000
@@ -37,6 +50,7 @@ export type GrokSession = {
 
 export type GrokSessionStoreShape = {
   readonly getSession: (id: string) => Effect.Effect<GrokSession, never>
+  readonly getTail: (id: string) => Effect.Effect<AgentTurnTail, never>
 }
 
 export class GrokSessionStore extends Context.Service<
@@ -340,6 +354,51 @@ const readSessionFromDisk = (
   }
 }
 
+const readTailFromDisk = (
+  grokHome: string,
+  sessionId: string,
+): AgentTurnTail => {
+  const id = sessionId.trim()
+  if (id === "" || !isSafeGrokSessionIdSegment(id)) {
+    return missingAgentTurnTail(GROK_BACKEND)
+  }
+
+  const lookup = findGrokSessionDirectory(grokHome, id)
+  if (lookup.kind === "missing") {
+    return missingAgentTurnTail(GROK_BACKEND)
+  }
+  if (lookup.kind === "unavailable") {
+    return unavailableAgentTurnTail(GROK_BACKEND)
+  }
+
+  const summaryPath = join(lookup.path, "summary.json")
+  if (!existsSync(summaryPath)) {
+    return missingAgentTurnTail(GROK_BACKEND)
+  }
+  try {
+    const summaryRaw = readFileSync(summaryPath, "utf8")
+    if (parseSummary(summaryRaw) === null) {
+      return unavailableAgentTurnTail(GROK_BACKEND)
+    }
+  } catch {
+    return unavailableAgentTurnTail(GROK_BACKEND)
+  }
+
+  const updatesPath = join(lookup.path, "updates.jsonl")
+  if (!existsSync(updatesPath)) {
+    return makeAgentTurnTail({
+      availability: "available",
+      backend: GROK_BACKEND,
+      items: [],
+    })
+  }
+  return readGrokUpdatesJsonlTail({
+    updatesPath,
+    sessionId: id,
+    backend: GROK_BACKEND,
+  })
+}
+
 export const makeGrokSessionStore = (
   shape: GrokSessionStoreShape,
 ): GrokSessionStoreShape => shape
@@ -354,6 +413,11 @@ export const GrokSessionStoreLive = (
         Effect.sync(() => {
           const grokHome = resolveGrokHome(options)
           return readSessionFromDisk(grokHome, id)
+        }),
+      getTail: (id) =>
+        Effect.sync(() => {
+          const grokHome = resolveGrokHome(options)
+          return readTailFromDisk(grokHome, id)
         }),
     }),
   )

--- a/packages/grok/src/lib/session-tail.ts
+++ b/packages/grok/src/lib/session-tail.ts
@@ -1,0 +1,628 @@
+import { closeSync, fstatSync, openSync, readSync, statSync } from "node:fs"
+import {
+  AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX,
+  AGENT_TURN_TAIL_ITEM_LIMIT,
+  type AgentBackendDescriptor,
+  type AgentTurnTail,
+  type AgentTurnTailSourceEvent,
+  makeAgentTurnTail,
+  selectAgentTurnTail,
+  unavailableAgentTurnTail,
+} from "@ready-for-agent/agent-backend"
+
+const CHUNK_SIZE = 64 * 1024
+const LINE_PREFIX_BYTES = 8 * 1024
+const TEXT_EXTRACT_LIMIT = AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX + 1
+
+const TOOL_STATUS = new Set(["completed", "failed", "in_progress", "cancelled"])
+
+type ParsedEvent =
+  | { readonly kind: "ignore" }
+  | {
+      readonly kind: "user"
+      readonly at: string
+      readonly sessionId: string | null
+    }
+  | {
+      readonly kind: "assistant_text"
+      readonly text: string
+      readonly at: string
+      readonly sessionId: string | null
+    }
+  | {
+      readonly kind: "tool"
+      readonly toolCallId: string
+      readonly name: string
+      readonly status: string | null
+      readonly at: string
+      readonly sessionId: string | null
+    }
+
+type CollectedUser = {
+  kind: "user"
+  at: string
+}
+
+type CollectedAssistant = {
+  kind: "assistant_text"
+  text: string
+  at: string
+}
+
+type CollectedTool = {
+  kind: "tool"
+  toolCallId: string
+  name: string
+  status: string
+  at: string
+}
+
+type Collected = CollectedUser | CollectedAssistant | CollectedTool
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const unixOrMsToIso = (value: number): string | null => {
+  if (!Number.isFinite(value)) {
+    return null
+  }
+  const ms = value < 1_000_000_000_000 ? value * 1000 : value
+  const date = new Date(ms)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  return date.toISOString()
+}
+
+const timestampToIso = (value: unknown): string | null => {
+  if (typeof value === "number") {
+    return unixOrMsToIso(value)
+  }
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+  if (trimmed === "") {
+    return null
+  }
+  const asNumber = Number(trimmed)
+  if (Number.isFinite(asNumber) && trimmed !== "") {
+    const fromNumber = unixOrMsToIso(asNumber)
+    if (fromNumber !== null) {
+      return fromNumber
+    }
+  }
+  const parsed = Date.parse(trimmed)
+  if (!Number.isFinite(parsed)) {
+    return null
+  }
+  return new Date(parsed).toISOString()
+}
+
+const unescapeJson = (
+  source: string,
+  index: number,
+): { readonly char: string; readonly next: number } | null => {
+  const marker = source[index]
+  if (marker === undefined) {
+    return null
+  }
+  switch (marker) {
+    case '"':
+    case "\\":
+    case "/":
+      return { char: marker, next: index + 1 }
+    case "b":
+      return { char: "\b", next: index + 1 }
+    case "f":
+      return { char: "\f", next: index + 1 }
+    case "n":
+      return { char: "\n", next: index + 1 }
+    case "r":
+      return { char: "\r", next: index + 1 }
+    case "t":
+      return { char: "\t", next: index + 1 }
+    case "u": {
+      const hex = source.slice(index + 1, index + 5)
+      if (hex.length < 4) {
+        return null
+      }
+      const code = Number.parseInt(hex, 16)
+      if (!Number.isFinite(code)) {
+        return null
+      }
+      return { char: String.fromCharCode(code), next: index + 5 }
+    }
+    default:
+      return { char: marker, next: index + 1 }
+  }
+}
+
+const extractJsonString = (
+  source: string,
+  key: string,
+  fromIndex = 0,
+  maxLength = Number.POSITIVE_INFINITY,
+): string | null => {
+  const needle = `"${key}"`
+  let searchFrom = fromIndex
+  while (searchFrom < source.length) {
+    const keyAt = source.indexOf(needle, searchFrom)
+    if (keyAt === -1) {
+      return null
+    }
+    let cursor = keyAt + needle.length
+    while (cursor < source.length && /\s/.test(source[cursor] ?? "")) {
+      cursor += 1
+    }
+    if (source[cursor] !== ":") {
+      searchFrom = keyAt + 1
+      continue
+    }
+    cursor += 1
+    while (cursor < source.length && /\s/.test(source[cursor] ?? "")) {
+      cursor += 1
+    }
+    if (source[cursor] !== '"') {
+      searchFrom = keyAt + 1
+      continue
+    }
+    cursor += 1
+    let out = ""
+    while (cursor < source.length) {
+      const ch = source[cursor]
+      if (ch === '"') {
+        return out
+      }
+      if (ch === "\\") {
+        const escaped = unescapeJson(source, cursor + 1)
+        if (escaped === null) {
+          return out.length > 0 ? out : null
+        }
+        if (out.length < maxLength) {
+          out += escaped.char
+        }
+        cursor = escaped.next
+        if (out.length >= maxLength) {
+          return out
+        }
+        continue
+      }
+      if (out.length < maxLength) {
+        out += ch
+      }
+      cursor += 1
+      if (out.length >= maxLength) {
+        return out
+      }
+    }
+    return out.length > 0 ? out : null
+  }
+  return null
+}
+
+const extractTimestampFromPrefix = (source: string): string | null => {
+  const match = /"timestamp"\s*:\s*(-?\d+(?:\.\d+)?)/.exec(source)
+  if (match === null || match[1] === undefined) {
+    return null
+  }
+  return timestampToIso(Number(match[1]))
+}
+
+const extractSessionIdFromPrefix = (source: string): string | null => {
+  const value = extractJsonString(source, "sessionId")
+  if (value === null || value.trim() === "") {
+    return null
+  }
+  return value
+}
+
+const extractToolNameFromPrefix = (source: string): string => {
+  const metaAt = source.indexOf('"x.ai/tool"')
+  if (metaAt !== -1) {
+    const metaName = extractJsonString(source, "name", metaAt)
+    if (metaName !== null && metaName.trim() !== "") {
+      return metaName.trim()
+    }
+  }
+  const title = extractJsonString(source, "title")
+  return title?.trim() ?? ""
+}
+
+const extractToolStatusFromPrefix = (source: string): string | null => {
+  const status = extractJsonString(source, "status")
+  if (status === null) {
+    return null
+  }
+  const trimmed = status.trim()
+  if (!TOOL_STATUS.has(trimmed)) {
+    return null
+  }
+  return trimmed
+}
+
+const extractAssistantTextFromPrefix = (source: string): string => {
+  const contentAt = source.indexOf('"content"')
+  const searchFrom = contentAt === -1 ? 0 : contentAt
+  return extractJsonString(source, "text", searchFrom, TEXT_EXTRACT_LIMIT) ?? ""
+}
+
+const toolNameFromUpdate = (update: Record<string, unknown>): string => {
+  const meta = isRecord(update["_meta"]) ? update["_meta"] : null
+  const xai =
+    meta !== null && isRecord(meta["x.ai/tool"]) ? meta["x.ai/tool"] : null
+  if (xai !== null && typeof xai["name"] === "string") {
+    const name = xai["name"].trim()
+    if (name !== "") {
+      return name
+    }
+  }
+  if (typeof update["title"] === "string") {
+    return update["title"].trim()
+  }
+  return ""
+}
+
+const toolStatusFromUpdate = (
+  update: Record<string, unknown>,
+): string | null => {
+  if (typeof update["status"] !== "string") {
+    return null
+  }
+  const status = update["status"].trim()
+  if (!TOOL_STATUS.has(status)) {
+    return null
+  }
+  return status
+}
+
+const assistantTextFromUpdate = (update: Record<string, unknown>): string => {
+  const content = update["content"]
+  if (!isRecord(content)) {
+    return ""
+  }
+  if (content["type"] !== "text" || typeof content["text"] !== "string") {
+    return ""
+  }
+  return content["text"].slice(0, TEXT_EXTRACT_LIMIT)
+}
+
+const parseCompleteLine = (line: string): ParsedEvent | null => {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(line)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) {
+    return null
+  }
+  const at = timestampToIso(parsed["timestamp"])
+  if (at === null) {
+    return null
+  }
+  const params = parsed["params"]
+  if (!isRecord(params)) {
+    return null
+  }
+  const sessionId =
+    typeof params["sessionId"] === "string" ? params["sessionId"] : null
+  const update = params["update"]
+  if (!isRecord(update) || typeof update["sessionUpdate"] !== "string") {
+    return null
+  }
+  return eventFromUpdate({
+    sessionUpdate: update["sessionUpdate"],
+    at,
+    sessionId,
+    update,
+  })
+}
+
+const parsePrefix = (prefix: string): ParsedEvent | null => {
+  const sessionUpdate = extractJsonString(prefix, "sessionUpdate")
+  if (sessionUpdate === null) {
+    return null
+  }
+  const at = extractTimestampFromPrefix(prefix)
+  if (at === null) {
+    return null
+  }
+  return eventFromUpdate({
+    sessionUpdate,
+    at,
+    sessionId: extractSessionIdFromPrefix(prefix),
+    prefix,
+  })
+}
+
+const eventFromUpdate = (input: {
+  readonly sessionUpdate: string
+  readonly at: string
+  readonly sessionId: string | null
+  readonly update?: Record<string, unknown>
+  readonly prefix?: string
+}): ParsedEvent | null => {
+  switch (input.sessionUpdate) {
+    case "user_message_chunk":
+      return { kind: "user", at: input.at, sessionId: input.sessionId }
+    case "agent_message_chunk": {
+      const text =
+        input.update === undefined
+          ? input.prefix === undefined
+            ? ""
+            : extractAssistantTextFromPrefix(input.prefix)
+          : assistantTextFromUpdate(input.update)
+      if (text === "") {
+        return { kind: "ignore" }
+      }
+      return {
+        kind: "assistant_text",
+        text,
+        at: input.at,
+        sessionId: input.sessionId,
+      }
+    }
+    case "tool_call":
+    case "tool_call_update": {
+      const toolCallId =
+        input.update === undefined
+          ? extractJsonString(input.prefix ?? "", "toolCallId")
+          : typeof input.update["toolCallId"] === "string"
+            ? input.update["toolCallId"]
+            : null
+      if (toolCallId === null || toolCallId.trim() === "") {
+        return { kind: "ignore" }
+      }
+      const name =
+        input.update === undefined
+          ? extractToolNameFromPrefix(input.prefix ?? "")
+          : toolNameFromUpdate(input.update)
+      const status =
+        input.update === undefined
+          ? extractToolStatusFromPrefix(input.prefix ?? "")
+          : toolStatusFromUpdate(input.update)
+      return {
+        kind: "tool",
+        toolCallId: toolCallId.trim(),
+        name,
+        status,
+        at: input.at,
+        sessionId: input.sessionId,
+      }
+    }
+    default:
+      return { kind: "ignore" }
+  }
+}
+
+const parseLinePrefix = (
+  prefix: string,
+  complete: boolean,
+): ParsedEvent | null => {
+  const trimmed = prefix.endsWith("\r") ? prefix.slice(0, -1) : prefix
+  if (trimmed.trim() === "") {
+    return { kind: "ignore" }
+  }
+  if (complete && trimmed.length <= LINE_PREFIX_BYTES) {
+    return parseCompleteLine(trimmed) ?? parsePrefix(trimmed)
+  }
+  return parsePrefix(trimmed)
+}
+
+const belongsToSession = (event: ParsedEvent, sessionId: string): boolean => {
+  if (event.kind === "ignore") {
+    return false
+  }
+  if (event.sessionId === null || event.sessionId === "") {
+    return true
+  }
+  return event.sessionId === sessionId
+}
+
+const capAssistantText = (text: string): string =>
+  text.length > TEXT_EXTRACT_LIMIT ? text.slice(0, TEXT_EXTRACT_LIMIT) : text
+
+const collectEventsFromFd = (
+  fd: number,
+  fileSize: number,
+  sessionId: string,
+): ReadonlyArray<AgentTurnTailSourceEvent> => {
+  const collected: Collected[] = []
+  const tools = new Map<string, CollectedTool>()
+  let activityCount = 0
+  let pendingUnnamed = 0
+  let stop = false
+
+  const considerStop = (): void => {
+    if (activityCount >= AGENT_TURN_TAIL_ITEM_LIMIT && pendingUnnamed === 0) {
+      stop = true
+    }
+  }
+
+  const onEvent = (event: ParsedEvent): boolean => {
+    if (!belongsToSession(event, sessionId) || event.kind === "ignore") {
+      return true
+    }
+    if (event.kind === "user") {
+      collected.push({ kind: "user", at: event.at })
+      stop = true
+      return false
+    }
+    if (event.kind === "assistant_text") {
+      const last = collected[collected.length - 1]
+      if (last !== undefined && last.kind === "assistant_text") {
+        last.text = capAssistantText(event.text + last.text)
+      } else {
+        collected.push({
+          kind: "assistant_text",
+          text: capAssistantText(event.text),
+          at: event.at,
+        })
+        activityCount += 1
+      }
+      return true
+    }
+    const existing = tools.get(event.toolCallId)
+    if (existing !== undefined) {
+      if (existing.name === "" && event.name !== "") {
+        existing.name = event.name
+        pendingUnnamed = Math.max(0, pendingUnnamed - 1)
+      }
+      considerStop()
+      return !stop
+    }
+    if (activityCount >= AGENT_TURN_TAIL_ITEM_LIMIT) {
+      considerStop()
+      return !stop
+    }
+    const item: CollectedTool = {
+      kind: "tool",
+      toolCallId: event.toolCallId,
+      name: event.name,
+      status: event.status ?? "in_progress",
+      at: event.at,
+    }
+    collected.push(item)
+    tools.set(event.toolCallId, item)
+    activityCount += 1
+    if (item.name === "") {
+      pendingUnnamed += 1
+    }
+    considerStop()
+    return !stop
+  }
+
+  scanLinePrefixesReverse(fd, fileSize, (prefix, complete) => {
+    if (stop) {
+      return false
+    }
+    const event = parseLinePrefix(prefix, complete)
+    if (event === null) {
+      return true
+    }
+    return onEvent(event)
+  })
+
+  const events: AgentTurnTailSourceEvent[] = []
+  for (let index = collected.length - 1; index >= 0; index -= 1) {
+    const item = collected[index]
+    if (item === undefined) {
+      continue
+    }
+    if (item.kind === "user") {
+      events.push({ kind: "user", at: item.at })
+      continue
+    }
+    if (item.kind === "assistant_text") {
+      events.push({
+        kind: "assistant_text",
+        text: item.text,
+        at: item.at,
+      })
+      continue
+    }
+    if (item.name === "") {
+      continue
+    }
+    events.push({
+      kind: "tool",
+      name: item.name,
+      status: item.status,
+      at: item.at,
+    })
+  }
+  return events
+}
+
+const scanLinePrefixesReverse = (
+  fd: number,
+  fileSize: number,
+  onPrefix: (prefix: string, complete: boolean) => boolean,
+): void => {
+  const chunk = Buffer.alloc(CHUNK_SIZE)
+  let searchEnd = fileSize
+  let nextLineEnd = fileSize
+
+  const emit = (lineStart: number, lineEnd: number): boolean => {
+    if (lineStart >= lineEnd) {
+      return true
+    }
+    const lineLength = lineEnd - lineStart
+    const readLen = Math.min(LINE_PREFIX_BYTES, lineLength)
+    const buf = Buffer.allocUnsafe(readLen)
+    const bytes = readSync(fd, buf, 0, readLen, lineStart)
+    if (bytes <= 0) {
+      return true
+    }
+    return onPrefix(
+      buf.subarray(0, bytes).toString("utf8"),
+      readLen === lineLength,
+    )
+  }
+
+  while (searchEnd > 0) {
+    const readSize = Math.min(CHUNK_SIZE, searchEnd)
+    const readAt = searchEnd - readSize
+    const bytesRead = readSync(fd, chunk, 0, readSize, readAt)
+    if (bytesRead <= 0) {
+      break
+    }
+    for (let index = bytesRead - 1; index >= 0; index -= 1) {
+      if (chunk[index] !== 0x0a) {
+        continue
+      }
+      const newlineAt = readAt + index
+      const lineStart = newlineAt + 1
+      const lineEnd = nextLineEnd
+      nextLineEnd = newlineAt
+      if (!emit(lineStart, lineEnd)) {
+        return
+      }
+    }
+    searchEnd = readAt
+  }
+
+  if (nextLineEnd > 0) {
+    emit(0, nextLineEnd)
+  }
+}
+
+export const readGrokUpdatesJsonlTail = (input: {
+  readonly updatesPath: string
+  readonly sessionId: string
+  readonly backend: AgentBackendDescriptor
+}): AgentTurnTail => {
+  let fd: number | undefined
+  try {
+    const info = statSync(input.updatesPath)
+    if (!info.isFile()) {
+      return unavailableAgentTurnTail(input.backend)
+    }
+    fd = openSync(input.updatesPath, "r")
+    const fileSize = fstatSync(fd).size
+    if (fileSize <= 0) {
+      return makeAgentTurnTail({
+        availability: "available",
+        backend: input.backend,
+        items: [],
+      })
+    }
+    const events = collectEventsFromFd(fd, fileSize, input.sessionId)
+    return makeAgentTurnTail({
+      availability: "available",
+      backend: input.backend,
+      items: selectAgentTurnTail(events),
+    })
+  } catch {
+    return unavailableAgentTurnTail(input.backend)
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd)
+      } catch {
+        // The tail read already finished or failed.
+      }
+    }
+  }
+}

--- a/packages/grok/src/lib/session-telemetry-layer.ts
+++ b/packages/grok/src/lib/session-telemetry-layer.ts
@@ -1,21 +1,15 @@
 import { Effect, Layer } from "effect"
 import {
-  AGENT_BACKEND_IDS,
   type SessionTelemetry,
   SessionTelemetryProvider,
-  unsupportedAgentTurnTail,
 } from "@ready-for-agent/agent-backend"
 import {
+  GROK_BACKEND,
   type GrokSession,
   GrokSessionStore,
   GrokSessionStoreLive,
   type GrokSessionStoreOptions,
 } from "./session-store.js"
-
-const GROK_BACKEND = {
-  id: AGENT_BACKEND_IDS.grok,
-  label: "Grok Build",
-} as const
 
 const toSessionTelemetry = (session: GrokSession): SessionTelemetry => ({
   id: session.id,
@@ -36,8 +30,9 @@ const toSessionTelemetry = (session: GrokSession): SessionTelemetry => ({
 })
 
 /**
- * Expose Grok Build on-disk Session Telemetry through the generic provider.
- * Reads `$GROK_HOME/sessions/<cwd-encoded>/<session-id>/` (summary.json + updates.jsonl).
+ * Expose Grok Build on-disk Session Telemetry and Agent Turn Tail.
+ * Reads `$GROK_HOME/sessions/<cwd-encoded>/<session-id>/` (summary.json +
+ * a bounded reverse read of updates.jsonl for the tail).
  */
 export const GrokSessionTelemetryLive = (
   options: GrokSessionStoreOptions = {},
@@ -50,7 +45,7 @@ export const GrokSessionTelemetryLive = (
       return SessionTelemetryProvider.of({
         getSession: (sessionId) =>
           store.getSession(sessionId).pipe(Effect.map(toSessionTelemetry)),
-        getTail: () => Effect.succeed(unsupportedAgentTurnTail(GROK_BACKEND)),
+        getTail: (sessionId) => store.getTail(sessionId),
       })
     }),
   ).pipe(Layer.provide(storeLayer))

--- a/packages/grok/test/session-store.spec.ts
+++ b/packages/grok/test/session-store.spec.ts
@@ -3,6 +3,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect, ManagedRuntime } from "effect"
 import {
+  AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX,
+  AGENT_TURN_TAIL_ITEM_LIMIT,
+} from "@ready-for-agent/agent-backend"
+import {
+  GROK_BACKEND,
   GROK_COST_USD_TICKS_PER_USD,
   GROK_SESSION_PROVIDER_ID,
   GrokSessionStore,
@@ -432,6 +437,380 @@ describe("GrokSessionStore", () => {
       await runtime.dispose()
       expect(session.availability).toBe("available")
       expect(session.id).toBe("ses_trim")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+const TS_USER_OLD = 1787000001
+const TS_OLD_TEXT = 1787000002
+const TS_OLD_TOOL = 1787000003
+const TS_USER = 1787000004
+const TS_TOOL = 1787000005
+const TS_TEXT = 1787000006
+const AT_TOOL = "2026-08-17T20:53:25.000Z"
+const AT_TEXT = "2026-08-17T20:53:26.000Z"
+const AT_TOOL_7 = "2026-08-17T20:53:31.000Z"
+const SECRET_PAYLOAD = `SECRET_PAYLOAD_${"x".repeat(50_000)}`
+const CHILD_SECRET = "CHILD_SESSION_SECRET_SHOULD_NOT_APPEAR"
+
+const sessionUpdateLine = (
+  timestamp: number,
+  sessionId: string,
+  update: Record<string, unknown>,
+): string =>
+  JSON.stringify({
+    timestamp,
+    method: "session/update",
+    params: { sessionId, update },
+  })
+
+const userLine = (timestamp: number, sessionId: string, text: string): string =>
+  sessionUpdateLine(timestamp, sessionId, {
+    sessionUpdate: "user_message_chunk",
+    content: { type: "text", text },
+  })
+
+const thoughtLine = (
+  timestamp: number,
+  sessionId: string,
+  text: string,
+): string =>
+  sessionUpdateLine(timestamp, sessionId, {
+    sessionUpdate: "agent_thought_chunk",
+    content: { type: "text", text },
+  })
+
+const assistantLine = (
+  timestamp: number,
+  sessionId: string,
+  text: string,
+): string =>
+  sessionUpdateLine(timestamp, sessionId, {
+    sessionUpdate: "agent_message_chunk",
+    content: { type: "text", text },
+  })
+
+const toolCallLine = (
+  timestamp: number,
+  sessionId: string,
+  toolCallId: string,
+  name: string,
+): string =>
+  sessionUpdateLine(timestamp, sessionId, {
+    sessionUpdate: "tool_call",
+    toolCallId,
+    title: name,
+    rawInput: { command: "should-not-appear" },
+    _meta: {
+      "x.ai/tool": {
+        version: 1,
+        name,
+        kind: "execute",
+        namespace: "grok_build",
+        label: "Run Command",
+        read_only: false,
+      },
+    },
+  })
+
+const toolUpdateLine = (
+  timestamp: number,
+  sessionId: string,
+  toolCallId: string,
+  status: string,
+  output: string,
+): string =>
+  sessionUpdateLine(timestamp, sessionId, {
+    sessionUpdate: "tool_call_update",
+    toolCallId,
+    status,
+    rawOutput: { type: "Bash", output },
+    content: [{ type: "content", content: { type: "text", text: output } }],
+  })
+
+const subagentFinishedLineForTail = (
+  timestamp: number,
+  sessionId: string,
+): string =>
+  sessionUpdateLine(timestamp, sessionId, {
+    sessionUpdate: "subagent_finished",
+    child_session_id: "ses_child",
+    status: "completed",
+    output: CHILD_SECRET,
+  })
+
+const getTail = async (grokHome: string, sessionId: string) => {
+  const runtime = ManagedRuntime.make(GrokSessionStoreLive({ grokHome }))
+  const tail = await runtime.runPromise(
+    Effect.gen(function* () {
+      const store = yield* GrokSessionStore
+      return yield* store.getTail(sessionId)
+    }),
+  )
+  await runtime.dispose()
+  return tail
+}
+
+describe("GrokSessionStore.getTail", () => {
+  test("reads the latest Agent Turn Tail without tool payloads", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      writeSessionFixture(dir, "%2Fwork", "ses_fixture", {
+        summary: { current_model_id: "grok-4.6" },
+        updatesJsonl: [
+          userLine(TS_USER_OLD, "ses_fixture", "old implement prompt"),
+          thoughtLine(TS_OLD_TEXT, "ses_fixture", "thinking about old turn"),
+          assistantLine(TS_OLD_TEXT, "ses_fixture", "old turn"),
+          toolCallLine(TS_OLD_TOOL, "ses_fixture", "call_old", "read_file"),
+          toolUpdateLine(
+            TS_OLD_TOOL,
+            "ses_fixture",
+            "call_old",
+            "completed",
+            SECRET_PAYLOAD,
+          ),
+          userLine(TS_USER, "ses_fixture", "harness review prompt"),
+          thoughtLine(TS_TOOL, "ses_fixture", "I will run tests"),
+          toolCallLine(
+            TS_TOOL,
+            "ses_fixture",
+            "call_new",
+            "run_terminal_command",
+          ),
+          toolUpdateLine(
+            TS_TOOL,
+            "ses_fixture",
+            "call_new",
+            "failed",
+            SECRET_PAYLOAD,
+          ),
+          assistantLine(TS_TEXT, "ses_fixture", "tests failed"),
+          turnCompletedLine({ inputTokens: 10 }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail(dir, "ses_fixture")
+      expect(tail).toEqual({
+        availability: "available",
+        backend: GROK_BACKEND,
+        jumpHint: false,
+        items: [
+          {
+            kind: "tool",
+            name: "run_terminal_command",
+            status: "failed",
+            at: AT_TOOL,
+          },
+          {
+            kind: "assistant_text",
+            text: "tests failed",
+            truncated: false,
+            at: AT_TEXT,
+          },
+        ],
+      })
+      expect(JSON.stringify(tail)).not.toContain("SECRET_PAYLOAD")
+      expect(JSON.stringify(tail)).not.toContain("should-not-appear")
+      expect(JSON.stringify(tail)).not.toContain("old turn")
+      expect(JSON.stringify(tail)).not.toContain("thinking")
+      expect(JSON.stringify(tail)).not.toContain("harness review prompt")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns empty tail with jumpHint when the latest turn has no activity", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      writeSessionFixture(dir, "%2Fwork", "ses_fixture", {
+        summary: { current_model_id: "grok-4.6" },
+        updatesJsonl: [
+          userLine(TS_USER_OLD, "ses_fixture", "implement"),
+          assistantLine(TS_OLD_TEXT, "ses_fixture", "done"),
+          userLine(TS_USER, "ses_fixture", "review in children"),
+          subagentFinishedLineForTail(TS_TEXT, "ses_fixture"),
+        ].join("\n"),
+      })
+
+      const tail = await getTail(dir, "ses_fixture")
+      expect(tail.availability).toBe("available")
+      expect(tail.items).toEqual([])
+      expect(tail.jumpHint).toBe(true)
+      expect(JSON.stringify(tail)).not.toContain(CHILD_SECRET)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("does not include child Session activity recorded under another Session ID", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      writeSessionFixture(dir, "%2Fwork", "ses_fixture", {
+        summary: { current_model_id: "grok-4.6" },
+        updatesJsonl: [
+          userLine(TS_USER, "ses_fixture", "review"),
+          toolCallLine(TS_TOOL, "ses_child", "call_child", "grep"),
+          toolUpdateLine(
+            TS_TOOL,
+            "ses_child",
+            "call_child",
+            "completed",
+            "hit",
+          ),
+          assistantLine(TS_TEXT, "ses_child", CHILD_SECRET),
+        ].join("\n"),
+      })
+      writeSessionFixture(dir, "%2Fwork", "ses_child", {
+        summary: { current_model_id: "grok-4.6" },
+        updatesJsonl: [
+          userLine(TS_USER, "ses_child", "child prompt"),
+          assistantLine(TS_TEXT, "ses_child", CHILD_SECRET),
+        ].join("\n"),
+      })
+
+      const tail = await getTail(dir, "ses_fixture")
+      expect(tail.availability).toBe("available")
+      expect(tail.items).toEqual([])
+      expect(tail.jumpHint).toBe(true)
+      expect(JSON.stringify(tail)).not.toContain(CHILD_SECRET)
+      expect(JSON.stringify(tail)).not.toContain("grep")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns the last 20 activity items and truncates assistant text at 2k", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      const longText = "a".repeat(AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX + 50)
+      const toolLines = Array.from({ length: 25 }, (_, index) => {
+        const timestamp = TS_USER + 1 + index
+        const id = `call_${index + 1}`
+        return [
+          toolCallLine(timestamp, "ses_fixture", id, `tool-${index + 1}`),
+          toolUpdateLine(
+            timestamp,
+            "ses_fixture",
+            id,
+            "completed",
+            SECRET_PAYLOAD,
+          ),
+        ].join("\n")
+      })
+      writeSessionFixture(dir, "%2Fwork", "ses_fixture", {
+        summary: { current_model_id: "grok-4.6" },
+        updatesJsonl: [
+          userLine(TS_USER, "ses_fixture", "implement"),
+          ...toolLines,
+          assistantLine(TS_USER + 26, "ses_fixture", "part-one-"),
+          assistantLine(TS_USER + 27, "ses_fixture", longText),
+        ].join("\n"),
+      })
+
+      const tail = await getTail(dir, "ses_fixture")
+      expect(tail.availability).toBe("available")
+      expect(tail.items).toHaveLength(AGENT_TURN_TAIL_ITEM_LIMIT)
+      expect(tail.items[0]).toEqual({
+        kind: "tool",
+        name: "tool-7",
+        status: "completed",
+        at: AT_TOOL_7,
+      })
+      const last = tail.items[19]
+      expect(last?.kind).toBe("assistant_text")
+      if (last?.kind === "assistant_text") {
+        expect(last.text).toBe(
+          `part-one-${"a".repeat(AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX - "part-one-".length)}`,
+        )
+        expect(last.truncated).toBe(true)
+      }
+      expect(JSON.stringify(tail)).not.toContain("SECRET_PAYLOAD")
+      expect(
+        tail.items.some(
+          (item) => item.kind === "tool" && item.name === "tool-6",
+        ),
+      ).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns MISSING when the Session directory is absent", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      mkdirSync(join(dir, "sessions"), { recursive: true })
+      const tail = await getTail(dir, "ses_gone")
+      expect(tail).toEqual({
+        availability: "missing",
+        backend: GROK_BACKEND,
+        items: [],
+        jumpHint: false,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns UNAVAILABLE when the Session store is unreadable", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      writeFileSync(join(dir, "sessions"), "not-a-directory")
+      const tail = await getTail(dir, "ses_any")
+      expect(tail).toEqual({
+        availability: "unavailable",
+        backend: GROK_BACKEND,
+        items: [],
+        jumpHint: false,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("Session token usage still loads without fetching the tail", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-tail-"))
+    try {
+      writeSessionFixture(dir, "%2Fwork", "ses_fixture", {
+        summary: {
+          current_model_id: "grok-4.6",
+          created_at: "2026-08-17T20:00:00.000Z",
+          updated_at: "2026-08-17T20:53:26.000Z",
+        },
+        updatesJsonl: [
+          userLine(TS_USER, "ses_fixture", "implement"),
+          assistantLine(TS_TEXT, "ses_fixture", "done"),
+          turnCompletedLine({
+            inputTokens: 11,
+            outputTokens: 3,
+            reasoningTokens: 1,
+            cachedReadTokens: 2,
+            costUsdTicks: 100_000_000,
+          }),
+        ].join("\n"),
+      })
+
+      const runtime = ManagedRuntime.make(
+        GrokSessionStoreLive({ grokHome: dir }),
+      )
+      const session = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* GrokSessionStore
+          return yield* store.getSession("ses_fixture")
+        }),
+      )
+      await runtime.dispose()
+
+      expect(session.availability).toBe("available")
+      expect(session.tokens).toEqual({
+        input: 11,
+        output: 3,
+        reasoning: 1,
+        cacheRead: 2,
+        cacheWrite: 0,
+      })
+      expect(session.cost).toBe(costUsdFromTicks(100_000_000))
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/packages/grok/test/session-telemetry-layer.spec.ts
+++ b/packages/grok/test/session-telemetry-layer.spec.ts
@@ -96,4 +96,134 @@ describe("GrokSessionTelemetryLive", () => {
       rmSync(dir, { recursive: true, force: true })
     }
   })
+
+  test("maps store tail without fetching usage through session()", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "grok-telemetry-"))
+    try {
+      const sessionDir = join(dir, "sessions", "%2Fproj", "ses_map")
+      mkdirSync(sessionDir, { recursive: true })
+      writeFileSync(
+        join(sessionDir, "summary.json"),
+        JSON.stringify({
+          current_model_id: "grok-4.6",
+          created_at: "2026-08-17T20:00:00.000Z",
+          updated_at: "2026-08-17T20:53:26.000Z",
+        }),
+      )
+      writeFileSync(
+        join(sessionDir, "updates.jsonl"),
+        [
+          JSON.stringify({
+            timestamp: 1787000004,
+            method: "session/update",
+            params: {
+              sessionId: "ses_map",
+              update: {
+                sessionUpdate: "user_message_chunk",
+                content: { type: "text", text: "implement" },
+              },
+            },
+          }),
+          JSON.stringify({
+            timestamp: 1787000005,
+            method: "session/update",
+            params: {
+              sessionId: "ses_map",
+              update: {
+                sessionUpdate: "tool_call",
+                toolCallId: "call_1",
+                title: "run_terminal_command",
+                rawInput: { command: "bun test" },
+                _meta: {
+                  "x.ai/tool": { name: "run_terminal_command" },
+                },
+              },
+            },
+          }),
+          JSON.stringify({
+            timestamp: 1787000005,
+            method: "session/update",
+            params: {
+              sessionId: "ses_map",
+              update: {
+                sessionUpdate: "tool_call_update",
+                toolCallId: "call_1",
+                status: "failed",
+                rawOutput: { output: "SECRET_PAYLOAD" },
+              },
+            },
+          }),
+          JSON.stringify({
+            timestamp: 1787000006,
+            method: "session/update",
+            params: {
+              sessionId: "ses_map",
+              update: {
+                sessionUpdate: "agent_message_chunk",
+                content: { type: "text", text: "tests failed" },
+              },
+            },
+          }),
+          JSON.stringify({
+            params: {
+              update: {
+                sessionUpdate: "turn_completed",
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 4,
+                  reasoningTokens: 1,
+                  cachedReadTokens: 2,
+                  costUsdTicks: 100_000_000,
+                },
+              },
+            },
+          }),
+        ].join("\n"),
+      )
+
+      const runtime = ManagedRuntime.make(
+        GrokSessionTelemetryLive({ grokHome: dir }),
+      )
+      const { session, tail } = await runtime.runPromise(
+        Effect.gen(function* () {
+          const provider = yield* SessionTelemetryProvider
+          const usage = yield* provider.getSession("ses_map")
+          const peek = yield* provider.getTail("ses_map")
+          return { session: usage, tail: peek }
+        }),
+      )
+      await runtime.dispose()
+
+      expect(session.availability).toBe("available")
+      expect(session.tokens).toEqual({
+        input: 10,
+        output: 4,
+        reasoning: 1,
+        cacheRead: 2,
+        cacheWrite: 0,
+      })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "grok", label: "Grok Build" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "tool",
+            name: "run_terminal_command",
+            status: "failed",
+            at: "2026-08-17T20:53:25.000Z",
+          },
+          {
+            kind: "assistant_text",
+            text: "tests failed",
+            truncated: false,
+            at: "2026-08-17T20:53:26.000Z",
+          },
+        ],
+      })
+      expect(JSON.stringify(tail)).not.toContain("SECRET_PAYLOAD")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
Why

GitHub #1139 added Agent Turn Tail to the Session usage dialog, but Grok
Build still reported `UNSUPPORTED`. Operators on Grok Work Items could
see token usage and Jump, not a cheap peek of the latest Agent Turn.
Full Session files are often huge because of tool output, and ACP
`session/load` replays the entire Session including payloads, so it is
not a path.

This is the Grok reader for GitHub #1142. Codex and Claude stay
`UNSUPPORTED` until their own tickets.

What changed

- Grok's `AgentTurnTail` capability is now supported, so Show tail
  appears when a Grok Work Item has a Session ID.
- `GrokSessionStore.getTail` live-reads
  `$GROK_HOME/sessions/<cwd>/<id>/updates.jsonl` from the end: last
  user/prompt boundary, last 20 items, assistant text capped at 2k and
  marked truncated, tool name/status only.
- Thinking, harness prompts, tool args, and `rawOutput` are dropped.
  Child Session / subagent rows are not followed.
- Missing Session directories stay `MISSING`; unreadable stores stay
  `UNAVAILABLE`. `getSession` still loads token usage without fetching
  the tail.

Verification

- `bunx nx test grok` (71 passed)
- `bunx nx test agent-backend` (142 passed)
- GraphQL session/tail tests, including Grok
  `agentTurnTailSupported: true`

Local review found no runtime or contract issues. No UI screenshots:
this ticket is the backend reader; the dialog path shipped in #1139.

Closes #1142