### PR TITLE
test(harness): cover Session usage Show tail, Refresh, and idle Jump hint

### DIFF
--- a/apps/harness/e2e/features/session-usage-agent-turn-tail.feature
+++ b/apps/harness/e2e/features/session-usage-agent-turn-tail.feature
@@ -1,0 +1,45 @@
+@ui-history
+Feature: Session usage Agent Turn Tail
+  Opening Session usage from a Session ID stays cheap: token usage loads
+  without the tail. Show tail then Refresh peek the latest OpenCode Agent
+  Turn. An idle canonical Session shows the Jump hint. Close forgets the peek
+  (issue #1144).
+
+  Background:
+    Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
+
+  Scenario: Clicking a Session ID opens token usage without fetching the tail
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Session usage for the idle OpenCode Session from Pipeline
+    Then the Session usage dialog is visible
+    And the Session usage dialog shows successful Session Telemetry fields
+    And the Session usage dialog shows Show tail
+    And the Session usage dialog does not show Agent Turn Tail
+
+  Scenario: Show tail then Refresh shows the empty OpenCode Jump hint
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Session usage for the idle OpenCode Session from Pipeline
+    And I show the Agent Turn Tail
+    Then the Session usage dialog shows the empty Jump hint
+    When I refresh the Agent Turn Tail
+    Then the Session usage dialog shows the empty Jump hint
+
+  Scenario: Closing Session usage forgets the tail peek
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Session usage for the idle OpenCode Session from Pipeline
+    And I show the Agent Turn Tail
+    Then the Session usage dialog shows the empty Jump hint
+    When I close the Session usage dialog
+    And I open Session usage for the idle OpenCode Session from Pipeline
+    Then the Session usage dialog shows successful Session Telemetry fields
+    And the Session usage dialog shows Show tail
+    And the Session usage dialog does not show Agent Turn Tail
+
+  Scenario: Show tail is hidden when the Agent Backend cannot serve a tail
+    When I open the Codex missing Session Telemetry path directly
+    Then the Session usage dialog is visible
+    And the Session usage dialog does not show Show tail

--- a/apps/harness/e2e/steps/session-telemetry-browser-history.ts
+++ b/apps/harness/e2e/steps/session-telemetry-browser-history.ts
@@ -118,6 +118,7 @@ const installSessionQueryRoute = async (page: Page) => {
               cost: 1.25,
               createdAt: "2026-07-14T08:00:00.000Z",
               updatedAt: "2026-07-14T09:00:00.000Z",
+              agentTurnTailSupported: true,
             },
           },
         }),

--- a/apps/harness/e2e/steps/session-usage-agent-turn-tail.ts
+++ b/apps/harness/e2e/steps/session-usage-agent-turn-tail.ts
@@ -1,0 +1,158 @@
+/**
+ * Playwright-BDD steps for Session usage Agent Turn Tail (issue #1144).
+ *
+ * Session() stays cheap on open. agentTurnTail() is shaped to the idle
+ * OpenCode Jump hint so the running UI can be checked without a local
+ * OpenCode session store.
+ */
+import { type Page, expect } from "@playwright/test"
+import { TELEMETRY_FIXTURE } from "../support/session-telemetry-fixture.ts"
+import { Then, When } from "./fixtures.ts"
+
+const sessionUsageDialog = (page: Page) =>
+  page.getByRole("dialog", { name: /Session$/ })
+
+const jumpHint =
+  /No recent activity on this Session\. Child Sessions are not shown\. Use Jump\./
+
+const isAgentTurnTailQuery = (query: string): boolean =>
+  /\bagentTurnTail\s*\(/.test(query)
+
+const isSessionUsageQuery = (query: string): boolean =>
+  !isAgentTurnTailQuery(query) &&
+  /\bsession\s*\(/.test(query) &&
+  (query.includes("availability") ||
+    query.includes("tokens") ||
+    query.includes("agentTurnTailSupported"))
+
+const availableIdleSession = {
+  id: TELEMETRY_FIXTURE.idleSessionId,
+  availability: "AVAILABLE",
+  backend: { id: "opencode", label: "OpenCode" },
+  model: {
+    providerId: "openai",
+    id: "gpt-e2e",
+    thinkingLevel: "high",
+  },
+  tokens: {
+    input: 100,
+    output: 20,
+    reasoning: 5,
+    cacheRead: 50,
+    cacheWrite: 10,
+  },
+  cost: 1.25,
+  createdAt: "2026-07-14T08:00:00.000Z",
+  updatedAt: "2026-07-14T09:00:00.000Z",
+  agentTurnTailSupported: true,
+} as const
+
+const idleAgentTurnTail = {
+  availability: "AVAILABLE",
+  backend: { id: "opencode", label: "OpenCode" },
+  jumpHint: true,
+  items: [],
+} as const
+
+const installIdleTailRoute = async (page: Page) => {
+  await page.unroute("**/graphql").catch(() => {})
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    if (request.method() !== "POST") {
+      await route.continue()
+      return
+    }
+    let query = ""
+    try {
+      const body = request.postDataJSON() as {
+        query?: string
+      }
+      query = body.query ?? ""
+    } catch {
+      await route.continue()
+      return
+    }
+
+    if (isAgentTurnTailQuery(query)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { agentTurnTail: idleAgentTurnTail } }),
+      })
+      return
+    }
+
+    if (isSessionUsageQuery(query)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { session: availableIdleSession } }),
+      })
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+When(
+  "I open Session usage for the idle OpenCode Session from Pipeline",
+  async ({ page }) => {
+    await installIdleTailRoute(page)
+    const sessionButton = page.getByRole("button", {
+      name: TELEMETRY_FIXTURE.idleSessionId,
+      exact: true,
+    })
+    await expect(sessionButton).toBeVisible({ timeout: 30_000 })
+    await sessionButton.click()
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog).toBeVisible({ timeout: 15_000 })
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+  },
+)
+
+When("I show the Agent Turn Tail", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await dialog.getByRole("button", { name: "Show tail" }).click()
+  await expect(dialog.getByText(jumpHint)).toBeVisible({ timeout: 15_000 })
+})
+
+When("I refresh the Agent Turn Tail", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await dialog.getByRole("button", { name: "Refresh" }).click()
+  await expect(dialog.getByText(jumpHint)).toBeVisible({ timeout: 15_000 })
+})
+
+Then("the Session usage dialog shows Show tail", async ({ page }) => {
+  await expect(
+    sessionUsageDialog(page).getByRole("button", { name: "Show tail" }),
+  ).toBeVisible()
+})
+
+Then("the Session usage dialog does not show Show tail", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+  await expect(dialog.getByRole("button", { name: "Show tail" })).toHaveCount(0)
+  await expect(dialog.getByRole("button", { name: "Refresh" })).toHaveCount(0)
+})
+
+Then(
+  "the Session usage dialog does not show Agent Turn Tail",
+  async ({ page }) => {
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog.getByText("Loading tail…")).toHaveCount(0)
+    await expect(dialog.getByText(jumpHint)).toHaveCount(0)
+    await expect(dialog.getByRole("button", { name: "Refresh" })).toHaveCount(0)
+  },
+)
+
+Then("the Session usage dialog shows the empty Jump hint", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await expect(dialog.getByText(jumpHint)).toBeVisible()
+  await expect(dialog.getByRole("button", { name: "Refresh" })).toBeVisible()
+  await expect(dialog.getByRole("button", { name: "Show tail" })).toHaveCount(0)
+})

--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -1,5 +1,6 @@
 /**
- * Deterministic Work Item / Session Telemetry fixtures for live e2e (issue #841).
+ * Deterministic Work Item / Session Telemetry fixtures for live e2e
+ * (issues #841 / #1144).
  *
  * Seeds once per live Harness process via {@link ensureLiveHarnessPersistence}:
  * the first call writes rows against the stopped database and restarts; later
@@ -43,6 +44,15 @@ export const TELEMETRY_FIXTURE = {
   completedPageTwoSessionId: "ses_e2e_fixture_completed_page_two",
   completedPageTwoIssueNumber: 104,
   completedPageTwoIssueId: "issue-01KZD5SESS10NTE0FXX0000004",
+  /**
+   * OpenCode Work Item whose latest Agent Turn has no canonical activity
+   * (issue #1144). Session usage is AVAILABLE via GraphQL shaping; the tail
+   * peek is the empty Jump hint.
+   */
+  idleWorkItemId: "wi-01KZD5SESS10NTE0FXX0000005",
+  idleSessionId: "ses_e2e_fixture_idle",
+  idleIssueNumber: 105,
+  idleIssueId: "issue-01KZD5SESS10NTE0FXX0000005",
 } as const
 
 /** Named Session Telemetry Work Items the operator-visible scenarios open. */
@@ -51,6 +61,7 @@ export const SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS = [
   TELEMETRY_FIXTURE.codexMissingWorkItemId,
   TELEMETRY_FIXTURE.completedWorkItemId,
   TELEMETRY_FIXTURE.completedPageTwoWorkItemId,
+  TELEMETRY_FIXTURE.idleWorkItemId,
 ] as const
 
 /** Completed archive fillers that pin the page-2 fixture. */
@@ -237,6 +248,22 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        ${now},
        ${now}
      );`,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.idleIssueId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.idleIssueNumber},
+       'E2E Session usage idle OpenCode tail',
+       '',
+       ${sqlLiteral(`https://github.com/${TELEMETRY_FIXTURE.projectPath}/issues/${TELEMETRY_FIXTURE.idleIssueNumber}`)},
+       'OPEN',
+       ${now},
+       0,
+       ${now},
+       ${now}
+     );`,
     `INSERT INTO work_item (
        id, repository_id, issue_number, issue_title, agent_backend,
        state, state_ready_at, paused, holds_worker_slot, session_id,
@@ -252,6 +279,24 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        1,
        0,
        ${sqlLiteral(TELEMETRY_FIXTURE.missingSessionId)},
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO work_item (
+       id, repository_id, issue_number, issue_title, agent_backend,
+       state, state_ready_at, paused, holds_worker_slot, session_id,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.idleWorkItemId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.idleIssueNumber},
+       'E2E Session usage idle OpenCode tail',
+       'opencode',
+       'implement',
+       ${now},
+       1,
+       0,
+       ${sqlLiteral(TELEMETRY_FIXTURE.idleSessionId)},
        ${now},
        ${now}
      );`,

--- a/apps/harness/test/session-telemetry-route.test.ts
+++ b/apps/harness/test/session-telemetry-route.test.ts
@@ -35,7 +35,7 @@ const jobsSwitcherSource = () =>
 const routedDialogSource = () =>
   readFileSync(join(import.meta.dir, "../src/routed-dialog.ts"), "utf8")
 
-describe("Session Telemetry route (issues #841 / #843 / #906)", () => {
+describe("Session Telemetry route (issues #841 / #843 / #906 / #1144)", () => {
   test("is a dedicated TanStack file route with a canonical Pipeline background", () => {
     const source = telemetryRouteSource()
     expect(source).toContain(
@@ -120,5 +120,7 @@ describe("Session Telemetry route (issues #841 / #843 / #906)", () => {
     expect(dialog).toContain("No recent activity on this Session")
     expect(dialog).toContain("Child Sessions are not shown")
     expect(dialog).toContain("Jump")
+    expect(dialog).toContain("enabled: enabled && tailOpen")
+    expect(dialog).toContain("setTailOpen(false)")
   })
 })


### PR DESCRIPTION
## Why

#1139 already shipped Agent Turn Tail in the Session usage dialog. Opening a
Session ID stays telemetry-only; **Show tail** / **Refresh** peek the latest
canonical turn; an idle OpenCode Session shows the empty Jump hint. #1144 asked
for an operator-visible browser check of that path, not another unit test of
the reader or GraphQL layer.

## What changed

Adds a `@ui-history` Playwright-BDD feature plus an idle OpenCode Work Item on
the existing Session Telemetry fixture set.

- Clicking the idle Session ID opens token usage with **Show tail** and no
  tail panel.
- **Show tail** then **Refresh** keep the known Jump hint: *No recent
  activity on this Session. Child Sessions are not shown. Use Jump.*
- Closing and reopening forgets the peek (**Show tail** again, no tail
  panel).
- A Codex Session still hides **Show tail** through the live
  `agentTurnTailSupported` flag.
- Source checks lock `enabled && tailOpen` and `setTailOpen(false)`.

AVAILABLE `session()` / `agentTurnTail()` responses are GraphQL-shaped the
same way existing Session Telemetry history scenarios shape AVAILABLE usage.
Review dropped intercept fetch-count assertions so the check stays on dialog
copy and controls. A live OpenCode SQLite store is out of scope here:
`@ui-history` does not isolate `opencode db path`, and empty-turn → Jump hint
is already covered in the OpenCode session-store unit suite.

## Verification

- `bunx nx test harness` (includes the new source assertions and e2e
  suite-tag scan)
- Playwright `Session usage Agent Turn Tail` — 4 scenarios passed
- Related Session Telemetry history scenarios (Pipeline open, Codex missing,
  AVAILABLE usage) still passed

Closes #1144