### PR TITLE
feat(codex): serve a bounded Agent Turn Tail from the Session rollout

### DIFF
--- a/apps/harness/e2e/features/session-usage-agent-turn-tail.feature
+++ b/apps/harness/e2e/features/session-usage-agent-turn-tail.feature
@@ -40,6 +40,6 @@ Feature: Session usage Agent Turn Tail
     And the Session usage dialog does not show Agent Turn Tail
 
   Scenario: Show tail is hidden when the Agent Backend cannot serve a tail
-    When I open the Codex missing Session Telemetry path directly
+    When I open Session usage for a Session whose Agent Backend cannot serve a tail
     Then the Session usage dialog is visible
     And the Session usage dialog does not show Show tail

--- a/apps/harness/e2e/steps/session-usage-agent-turn-tail.ts
+++ b/apps/harness/e2e/steps/session-usage-agent-turn-tail.ts
@@ -54,6 +54,18 @@ const idleAgentTurnTail = {
   items: [],
 } as const
 
+const unsupportedTailSession = {
+  id: TELEMETRY_FIXTURE.codexMissingSessionId,
+  availability: "MISSING",
+  backend: { id: "codex", label: "Codex Build" },
+  model: null,
+  tokens: null,
+  cost: null,
+  createdAt: null,
+  updatedAt: null,
+  agentTurnTailSupported: false,
+} as const
+
 const installIdleTailRoute = async (page: Page) => {
   await page.unroute("**/graphql").catch(() => {})
   await page.route("**/graphql", async (route) => {
@@ -94,6 +106,47 @@ const installIdleTailRoute = async (page: Page) => {
     await route.continue()
   })
 }
+
+When(
+  "I open Session usage for a Session whose Agent Backend cannot serve a tail",
+  async ({ page }) => {
+    await page.unroute("**/graphql").catch(() => {})
+    await page.route("**/graphql", async (route) => {
+      const request = route.request()
+      if (request.method() !== "POST") {
+        await route.continue()
+        return
+      }
+      let query = ""
+      try {
+        const body = request.postDataJSON() as {
+          query?: string
+        }
+        query = body.query ?? ""
+      } catch {
+        await route.continue()
+        return
+      }
+      if (isSessionUsageQuery(query)) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: { session: unsupportedTailSession } }),
+        })
+        return
+      }
+      await route.continue()
+    })
+    await page.goto(
+      `/session/${TELEMETRY_FIXTURE.codexMissingWorkItemId}/telemetry`,
+    )
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog).toBeVisible({ timeout: 15_000 })
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+  },
+)
 
 When(
   "I open Session usage for the idle OpenCode Session from Pipeline",

--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -106,7 +106,7 @@ const CODEX_REGISTRATION: AgentBackendRegistration = {
   },
   capabilities: [
     { _tag: "SessionTelemetry", supported: true },
-    { _tag: "AgentTurnTail", supported: false },
+    { _tag: "AgentTurnTail", supported: true },
     { _tag: "KeymaxxerMcp", supported: false },
   ],
 }

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -109,7 +109,7 @@ describe("Agent Backend registry", () => {
     const codex = getBuiltInAgentBackend(AGENT_BACKEND_IDS.codex)
     expect(codex).toBeDefined()
     expect(capabilitySupported(codex!, "SessionTelemetry")).toBe(true)
-    expect(capabilitySupported(codex!, "AgentTurnTail")).toBe(false)
+    expect(capabilitySupported(codex!, "AgentTurnTail")).toBe(true)
     expect(capabilitySupported(codex!, "KeymaxxerMcp")).toBe(false)
 
     const claude = getBuiltInAgentBackend(AGENT_BACKEND_IDS.claude)

--- a/packages/codex/src/lib/session-store.ts
+++ b/packages/codex/src/lib/session-store.ts
@@ -1,6 +1,10 @@
 import {
   type Dirent,
+  closeSync,
+  fstatSync,
+  openSync,
   readFileSync,
+  readSync,
   readdirSync,
   realpathSync,
   statSync,
@@ -8,9 +12,25 @@ import {
 import { homedir } from "node:os"
 import { basename, isAbsolute, join, relative, resolve } from "node:path"
 import { Context, Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX,
+  AGENT_TURN_TAIL_ITEM_LIMIT,
+  type AgentTurnTail,
+  type AgentTurnTailSourceEvent,
+  makeAgentTurnTail,
+  missingAgentTurnTail,
+  selectAgentTurnTail,
+  unavailableAgentTurnTail,
+} from "@ready-for-agent/agent-backend"
 import { Database } from "bun:sqlite"
 
 export const CODEX_SESSION_PROVIDER_ID = "openai"
+
+const CODEX_BACKEND = {
+  id: AGENT_BACKEND_IDS.codex,
+  label: "Codex Build",
+} as const
 
 export type CodexSessionModel = {
   readonly providerId: string
@@ -50,6 +70,7 @@ export type CodexSession = CodexSessionAvailable | CodexSessionUnavailable
 
 export type CodexSessionStoreShape = {
   readonly getSession: (id: string) => Effect.Effect<CodexSession, never>
+  readonly getTail: (id: string) => Effect.Effect<AgentTurnTail, never>
 }
 
 export class CodexSessionStore extends Context.Service<
@@ -699,6 +720,455 @@ const readCodexSessionFromDisk = (input: {
   })
 }
 
+const IDENTITY_PEEK_BYTES = 16_384
+const TAIL_CHUNK_BYTES = 64 * 1024
+const TAIL_PARSE_MAX_BYTES = 16 * 1024
+/** Enough of a line to classify it and recover a 2k assistant-text cap. */
+const TAIL_LINE_PREFIX_BYTES = AGENT_TURN_TAIL_ASSISTANT_TEXT_MAX + 512
+
+const availableTail = (
+  events: ReadonlyArray<AgentTurnTailSourceEvent>,
+): AgentTurnTail =>
+  makeAgentTurnTail({
+    availability: "available",
+    backend: CODEX_BACKEND,
+    items: selectAgentTurnTail(events),
+  })
+
+const extractQuotedFieldFrom = (
+  raw: string,
+  key: string,
+  fromIndex: number,
+): string | null => {
+  const needle = `"${key}":"`
+  const start = raw.indexOf(needle, fromIndex)
+  if (start === -1) {
+    return null
+  }
+  let index = start + needle.length
+  let value = ""
+  while (index < raw.length) {
+    const char = raw[index]
+    if (char === "\\") {
+      const next = raw[index + 1]
+      if (next === undefined) {
+        break
+      }
+      if (next === "n") value += "\n"
+      else if (next === "t") value += "\t"
+      else if (next === '"') value += '"'
+      else if (next === "\\") value += "\\"
+      else value += next
+      index += 2
+      continue
+    }
+    if (char === '"') {
+      return value
+    }
+    value += char
+    index += 1
+  }
+  return value
+}
+
+const extractQuotedField = (raw: string, key: string): string | null =>
+  extractQuotedFieldFrom(raw, key, 0)
+
+/** Payload `type` sits after `"payload":{`, not in message/tool bodies. */
+const extractPayloadType = (line: string): string | null => {
+  const payloadIndex = line.indexOf('"payload"')
+  if (payloadIndex === -1) {
+    return null
+  }
+  return extractQuotedFieldFrom(line, "type", payloadIndex)
+}
+
+const isPayloadHeavyLine = (line: string): boolean => {
+  const payloadType = extractPayloadType(line)
+  return (
+    payloadType === "function_call_output" ||
+    payloadType === "custom_tool_call_output" ||
+    payloadType === "tool_search_output"
+  )
+}
+
+const toolEvent = (input: {
+  readonly name: string | null
+  readonly status: string | null
+  readonly at: string
+}): AgentTurnTailSourceEvent | null => {
+  if (input.name === null || input.name === "") {
+    return null
+  }
+  return {
+    kind: "tool",
+    name: input.name,
+    status:
+      input.status === null || input.status === "" ? "unknown" : input.status,
+    at: input.at,
+  }
+}
+
+const largeLineToTailEvent = (
+  line: string,
+): AgentTurnTailSourceEvent | null => {
+  const at = timestamp(extractQuotedField(line, "timestamp"))
+  if (at === null) {
+    return null
+  }
+  const outerType = extractQuotedField(line, "type")
+  const payloadType = extractPayloadType(line)
+  if (outerType === "event_msg") {
+    if (payloadType === "user_message") {
+      return { kind: "user", at }
+    }
+    if (payloadType === "agent_message") {
+      const text = extractQuotedField(line, "message")
+      if (text === null || text === "") {
+        return null
+      }
+      return { kind: "assistant_text", text, at }
+    }
+    return null
+  }
+  if (outerType !== "response_item") {
+    return null
+  }
+  if (payloadType === "message") {
+    return extractQuotedField(line, "role") === "user"
+      ? { kind: "user", at }
+      : null
+  }
+  if (payloadType === "function_call" || payloadType === "custom_tool_call") {
+    return toolEvent({
+      name: extractQuotedField(line, "name"),
+      status: extractQuotedField(line, "status"),
+      at,
+    })
+  }
+  if (payloadType === "web_search_call") {
+    return toolEvent({
+      name: "web_search",
+      status: extractQuotedField(line, "status"),
+      at,
+    })
+  }
+  if (payloadType === "tool_search_call") {
+    return toolEvent({
+      name: "tool_search",
+      status: extractQuotedField(line, "status"),
+      at,
+    })
+  }
+  return null
+}
+
+const parsedLineToTailEvent = (
+  parsed: Readonly<Record<string, unknown>>,
+): AgentTurnTailSourceEvent | null => {
+  const at = timestamp(parsed["timestamp"])
+  if (at === null) {
+    return null
+  }
+  const payload = parsed["payload"]
+  if (!isRecord(payload)) {
+    return null
+  }
+  const outerType = parsed["type"]
+  const payloadType = payload["type"]
+  if (outerType === "event_msg") {
+    if (payloadType === "user_message") {
+      return { kind: "user", at }
+    }
+    if (payloadType === "agent_message") {
+      const text =
+        typeof payload["message"] === "string" ? payload["message"] : ""
+      if (text === "") {
+        return null
+      }
+      return { kind: "assistant_text", text, at }
+    }
+    return null
+  }
+  if (outerType !== "response_item") {
+    return null
+  }
+  if (payloadType === "message") {
+    return payload["role"] === "user" ? { kind: "user", at } : null
+  }
+  if (payloadType === "function_call" || payloadType === "custom_tool_call") {
+    return toolEvent({
+      name: nonEmptyString(payload["name"]),
+      status: nonEmptyString(payload["status"]),
+      at,
+    })
+  }
+  if (payloadType === "web_search_call") {
+    return toolEvent({
+      name: "web_search",
+      status: nonEmptyString(payload["status"]),
+      at,
+    })
+  }
+  if (payloadType === "tool_search_call") {
+    return toolEvent({
+      name: "tool_search",
+      status: nonEmptyString(payload["status"]),
+      at,
+    })
+  }
+  return null
+}
+
+const lineToTailEvent = (line: string): AgentTurnTailSourceEvent | null => {
+  const trimmed = line.trim()
+  if (trimmed === "" || isPayloadHeavyLine(trimmed)) {
+    return null
+  }
+  if (trimmed.length <= TAIL_PARSE_MAX_BYTES) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (isRecord(parsed)) {
+        return parsedLineToTailEvent(parsed)
+      }
+    } catch {
+      // Prefix of a longer line — classify from the type fields at the start.
+    }
+  }
+  return largeLineToTailEvent(trimmed)
+}
+
+type PeekedRollout =
+  | { readonly kind: "unreadable" }
+  | { readonly kind: "corrupt" }
+  | { readonly kind: "identity"; readonly sessionId: string }
+
+const peekCodexRolloutIdentity = (path: string): PeekedRollout => {
+  let fd: number | undefined
+  try {
+    fd = openSync(path, "r")
+    const buf = Buffer.alloc(IDENTITY_PEEK_BYTES)
+    const bytesRead = readSync(fd, buf, 0, IDENTITY_PEEK_BYTES, 0)
+    const raw = buf.subarray(0, bytesRead).toString("utf8")
+    for (const line of raw.split("\n")) {
+      if (line.trim() === "") {
+        continue
+      }
+      try {
+        const parsed: unknown = JSON.parse(line)
+        if (!isRecord(parsed) || parsed["type"] !== "session_meta") {
+          continue
+        }
+        const payload = parsed["payload"]
+        if (!isRecord(payload)) {
+          continue
+        }
+        const sessionId = nonEmptyString(payload["id"])
+        if (sessionId !== null) {
+          return { kind: "identity", sessionId }
+        }
+      } catch {}
+    }
+    return { kind: "corrupt" }
+  } catch {
+    return { kind: "unreadable" }
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd)
+    }
+  }
+}
+
+/**
+ * Read the latest Agent Turn from the end of a live-written rollout.
+ * Stops at the last user event or 20 newer activity items. Only the first
+ * 2k of each line is decoded so tool payloads are not loaded.
+ */
+const readTailEventsFromRollout = (
+  path: string,
+):
+  | { readonly kind: "unreadable" }
+  | {
+      readonly kind: "events"
+      readonly events: ReadonlyArray<AgentTurnTailSourceEvent>
+    } => {
+  let fd: number | undefined
+  try {
+    fd = openSync(path, "r")
+    const size = fstatSync(fd).size
+    if (size === 0) {
+      return { kind: "events", events: [] }
+    }
+
+    const activityNewestFirst: AgentTurnTailSourceEvent[] = []
+    let foundUser = false
+    let offset = size
+    let leftoverHead: Buffer = Buffer.alloc(0)
+    const chunk = Buffer.alloc(TAIL_CHUNK_BYTES)
+
+    const consumeLine = (lineBuf: Buffer): void => {
+      if (
+        lineBuf.length === 0 ||
+        foundUser ||
+        activityNewestFirst.length >= AGENT_TURN_TAIL_ITEM_LIMIT
+      ) {
+        return
+      }
+      const prefix =
+        lineBuf.length > TAIL_LINE_PREFIX_BYTES
+          ? lineBuf.subarray(0, TAIL_LINE_PREFIX_BYTES)
+          : lineBuf
+      const event = lineToTailEvent(prefix.toString("utf8"))
+      if (event === null) {
+        return
+      }
+      if (event.kind === "user") {
+        foundUser = true
+        return
+      }
+      activityNewestFirst.push(event)
+    }
+
+    const capLeftover = (value: Buffer): Buffer =>
+      value.length > TAIL_LINE_PREFIX_BYTES
+        ? value.subarray(0, TAIL_LINE_PREFIX_BYTES)
+        : value
+
+    while (
+      offset > 0 &&
+      !foundUser &&
+      activityNewestFirst.length < AGENT_TURN_TAIL_ITEM_LIMIT
+    ) {
+      const readSize = Math.min(TAIL_CHUNK_BYTES, offset)
+      offset -= readSize
+      const bytesRead = readSync(fd, chunk, 0, readSize, offset)
+      const data = Buffer.concat([chunk.subarray(0, bytesRead), leftoverHead])
+      const parts: Buffer[] = []
+      let start = 0
+      for (let index = 0; index < data.length; index += 1) {
+        if (data[index] === 0x0a) {
+          parts.push(data.subarray(start, index))
+          start = index + 1
+        }
+      }
+      parts.push(data.subarray(start))
+      leftoverHead = capLeftover(parts[0] ?? Buffer.alloc(0))
+      for (let index = parts.length - 1; index >= 1; index -= 1) {
+        const part = parts[index]
+        if (part !== undefined) {
+          consumeLine(part)
+        }
+      }
+    }
+
+    if (
+      !foundUser &&
+      leftoverHead.length > 0 &&
+      activityNewestFirst.length < AGENT_TURN_TAIL_ITEM_LIMIT
+    ) {
+      consumeLine(leftoverHead)
+    }
+
+    return { kind: "events", events: activityNewestFirst.slice().reverse() }
+  } catch {
+    return { kind: "unreadable" }
+  } finally {
+    if (fd !== undefined) {
+      closeSync(fd)
+    }
+  }
+}
+
+const tailFromFoundPath = (input: {
+  readonly sessionId: string
+  readonly path: string
+}): AgentTurnTail => {
+  const identity = peekCodexRolloutIdentity(input.path)
+  if (identity.kind !== "identity" || identity.sessionId !== input.sessionId) {
+    return unavailableAgentTurnTail(CODEX_BACKEND)
+  }
+  const events = readTailEventsFromRollout(input.path)
+  if (events.kind === "unreadable") {
+    return unavailableAgentTurnTail(CODEX_BACKEND)
+  }
+  return availableTail(events.events)
+}
+
+const tailFromLookup = (input: {
+  readonly sessionId: string
+  readonly lookup: CodexRolloutLookup
+}): AgentTurnTail => {
+  if (input.lookup.kind === "missing") {
+    return missingAgentTurnTail(CODEX_BACKEND)
+  }
+  if (input.lookup.kind === "unavailable") {
+    return unavailableAgentTurnTail(CODEX_BACKEND)
+  }
+  return tailFromFoundPath({
+    sessionId: input.sessionId,
+    path: input.lookup.path,
+  })
+}
+
+const readCodexTailFromDisk = (input: {
+  readonly codexHome: string
+  readonly sessionId: string
+}): AgentTurnTail => {
+  const id = input.sessionId.trim()
+  if (id === "" || !isSafeCodexSessionIdSegment(id)) {
+    return missingAgentTurnTail(CODEX_BACKEND)
+  }
+
+  const sessionsRoot = sessionsRootLookup(input.codexHome)
+  if (sessionsRoot.kind === "missing") {
+    return missingAgentTurnTail(CODEX_BACKEND)
+  }
+  if (sessionsRoot.kind === "unavailable") {
+    return unavailableAgentTurnTail(CODEX_BACKEND)
+  }
+
+  const indexed = findIndexedRollout({
+    codexHome: input.codexHome,
+    sessionsRoot: sessionsRoot.path,
+    sessionId: id,
+  })
+  if (indexed !== null) {
+    const identity = peekCodexRolloutIdentity(indexed.path)
+    if (identity.kind === "identity" && identity.sessionId === id) {
+      const events = readTailEventsFromRollout(indexed.path)
+      if (events.kind === "unreadable") {
+        return unavailableAgentTurnTail(CODEX_BACKEND)
+      }
+      return availableTail(events.events)
+    }
+    const scanned = findScannedRollout({
+      sessionsRoot: sessionsRoot.path,
+      sessionId: id,
+      excludePath: indexed.path,
+    })
+    if (scanned.kind === "found") {
+      return tailFromLookup({ sessionId: id, lookup: scanned })
+    }
+    if (scanned.kind === "unavailable") {
+      return unavailableAgentTurnTail(CODEX_BACKEND)
+    }
+    if (identity.kind === "identity") {
+      return isScannedRolloutFileName(basename(indexed.path), id)
+        ? unavailableAgentTurnTail(CODEX_BACKEND)
+        : missingAgentTurnTail(CODEX_BACKEND)
+    }
+    return unavailableAgentTurnTail(CODEX_BACKEND)
+  }
+
+  return tailFromLookup({
+    sessionId: id,
+    lookup: findScannedRollout({
+      sessionsRoot: sessionsRoot.path,
+      sessionId: id,
+    }),
+  })
+}
+
 export const makeCodexSessionStore = (
   shape: CodexSessionStoreShape,
 ): CodexSessionStoreShape => shape
@@ -712,6 +1182,13 @@ export const CodexSessionStoreLive = (
       getSession: (id) =>
         Effect.sync(() =>
           readCodexSessionFromDisk({
+            codexHome: resolveCodexHome(options),
+            sessionId: id,
+          }),
+        ),
+      getTail: (id) =>
+        Effect.sync(() =>
+          readCodexTailFromDisk({
             codexHome: resolveCodexHome(options),
             sessionId: id,
           }),

--- a/packages/codex/src/lib/session-telemetry-layer.ts
+++ b/packages/codex/src/lib/session-telemetry-layer.ts
@@ -3,7 +3,6 @@ import {
   AGENT_BACKEND_IDS,
   type SessionTelemetry,
   SessionTelemetryProvider,
-  unsupportedAgentTurnTail,
 } from "@ready-for-agent/agent-backend"
 import {
   type CodexSession,
@@ -40,7 +39,7 @@ export const CodexSessionTelemetryLive = (
       return SessionTelemetryProvider.of({
         getSession: (sessionId) =>
           store.getSession(sessionId).pipe(Effect.map(toSessionTelemetry)),
-        getTail: () => Effect.succeed(unsupportedAgentTurnTail(CODEX_BACKEND)),
+        getTail: (sessionId) => store.getTail(sessionId),
       })
     }),
   ).pipe(Layer.provide(storeLayer))

--- a/packages/codex/test/session-store.spec.ts
+++ b/packages/codex/test/session-store.spec.ts
@@ -33,6 +33,19 @@ const getSession = (input: {
     ),
   )
 
+const getTail = (input: {
+  readonly codexHome: string
+  readonly sessionId: string
+}) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* CodexSessionStore
+      return yield* store.getTail(input.sessionId)
+    }).pipe(
+      Effect.provide(CodexSessionStoreLive({ codexHome: input.codexHome })),
+    ),
+  )
+
 const writeScannedRollout = (input: {
   readonly codexHome: string
   readonly partition: string
@@ -776,5 +789,535 @@ describe("CodexSessionStore", () => {
     expect(resolveCodexHome({ env: { HOME: "/home/test" } })).toBe(
       "/home/test/.codex",
     )
+  })
+})
+
+describe("CodexSessionStore Agent Turn Tail", () => {
+  it("reads the latest Agent Turn without tool payloads", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "tail-latest-turn"
+      const payloadMarker = "HUGE_TOOL_OUTPUT_SHOULD_NOT_APPEAR"
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:00.000Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "old prompt" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "old turn" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            type: "response_item",
+            payload: {
+              type: "function_call",
+              name: "read",
+              arguments: payloadMarker,
+              call_id: "call_old",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:03.100Z",
+            type: "response_item",
+            payload: {
+              type: "function_call_output",
+              call_id: "call_old",
+              output: payloadMarker.repeat(200),
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:04.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "review the tests" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:05.000Z",
+            type: "response_item",
+            payload: {
+              type: "custom_tool_call",
+              name: "bun test",
+              status: "failed",
+              call_id: "call_new",
+              input: payloadMarker,
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:05.100Z",
+            type: "response_item",
+            payload: {
+              type: "custom_tool_call_output",
+              call_id: "call_new",
+              output: payloadMarker.repeat(200),
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:06.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "tests failed" },
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "codex", label: "Codex Build" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "tool",
+            name: "bun test",
+            status: "failed",
+            at: "2026-08-18T12:00:05.000Z",
+          },
+          {
+            kind: "assistant_text",
+            text: "tests failed",
+            truncated: false,
+            at: "2026-08-18T12:00:06.000Z",
+          },
+        ],
+      })
+      expect(JSON.stringify(tail)).not.toContain(payloadMarker)
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns an empty tail with jumpHint when the latest turn has no activity", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "tail-empty-turn"
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:00.000Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "old prompt" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "old turn" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "new prompt" },
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail.availability).toBe("available")
+      expect(tail.items).toEqual([])
+      expect(tail.jumpHint).toBe(true)
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("does not include child Session or inter-agent activity", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "tail-no-children"
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:00.000Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "implement it" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            type: "event_msg",
+            payload: {
+              type: "sub_agent_activity",
+              kind: "started",
+              agent_thread_id: "child-session",
+              agent_path: "/root/spec_review",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            type: "response_item",
+            payload: {
+              type: "agent_message",
+              content: [
+                {
+                  type: "input_text",
+                  text: "Message Type: NEW_TASK\nTask name: /root/spec_review",
+                },
+              ],
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:04.000Z",
+            type: "response_item",
+            payload: {
+              type: "reasoning",
+              summary: [{ text: "thinking about child work" }],
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:05.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "parent progress" },
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "codex", label: "Codex Build" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "assistant_text",
+            text: "parent progress",
+            truncated: false,
+            at: "2026-08-18T12:00:05.000Z",
+          },
+        ],
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("keeps only the last 20 activity items and truncates assistant text at 2k", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "tail-bounds"
+      const longText = `${"a".repeat(2000)}EXTRA`
+      const lines = [
+        JSON.stringify({
+          timestamp: "2026-08-18T12:00:00.000Z",
+          type: "session_meta",
+          payload: { id: sessionId },
+        }),
+        JSON.stringify({
+          timestamp: "2026-08-18T12:00:01.000Z",
+          type: "event_msg",
+          payload: { type: "user_message", message: "go" },
+        }),
+      ]
+      for (let index = 1; index <= 25; index += 1) {
+        lines.push(
+          JSON.stringify({
+            timestamp: `2026-08-18T12:00:${String(index + 1).padStart(2, "0")}.000Z`,
+            type: "response_item",
+            payload: {
+              type: "function_call",
+              name: `tool-${index}`,
+              call_id: `call_${index}`,
+            },
+          }),
+        )
+      }
+      lines.push(
+        JSON.stringify({
+          timestamp: "2026-08-18T12:00:28.000Z",
+          type: "event_msg",
+          payload: { type: "agent_message", message: longText },
+        }),
+      )
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: lines.join("\n"),
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail.items).toHaveLength(20)
+      expect(tail.items[0]).toEqual({
+        kind: "tool",
+        name: "tool-7",
+        status: "unknown",
+        at: "2026-08-18T12:00:08.000Z",
+      })
+      expect(tail.items[19]).toEqual({
+        kind: "assistant_text",
+        text: "a".repeat(2000),
+        truncated: true,
+        at: "2026-08-18T12:00:28.000Z",
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("does not treat a large tool call whose payload mentions user_message as a turn boundary", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "tail-large-tool"
+      const input = `user_message ${"x".repeat(20_000)}`
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:00.000Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "apply the patch" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            type: "response_item",
+            payload: {
+              type: "custom_tool_call",
+              name: "apply_patch",
+              status: "completed",
+              call_id: "call_patch",
+              input,
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            type: "response_item",
+            payload: {
+              type: "custom_tool_call_output",
+              call_id: "call_patch",
+              output: `user_message ${"y".repeat(40_000)}`,
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:04.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "patched" },
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "codex", label: "Codex Build" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "tool",
+            name: "apply_patch",
+            status: "completed",
+            at: "2026-08-18T12:00:02.000Z",
+          },
+          {
+            kind: "assistant_text",
+            text: "patched",
+            truncated: false,
+            at: "2026-08-18T12:00:04.000Z",
+          },
+        ],
+      })
+      expect(JSON.stringify(tail)).not.toContain("x".repeat(100))
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("classifies turn boundaries and tools from payload type, not payload text", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "tail-payload-type"
+      const longAssistant = `mentions user_message ${"a".repeat(2500)}`
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:00.000Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "old prompt" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "old turn" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:03.000Z",
+            type: "event_msg",
+            payload: {
+              type: "user_message",
+              message: "what is function_call_output",
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:04.000Z",
+            type: "response_item",
+            payload: {
+              type: "custom_tool_call",
+              name: "apply_patch",
+              status: "completed",
+              call_id: "call_patch",
+              input: `agent_message ${"z".repeat(20_000)}`,
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:05.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: longAssistant },
+          }),
+        ].join("\n"),
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail.availability).toBe("available")
+      expect(tail.jumpHint).toBe(false)
+      expect(tail.items).toEqual([
+        {
+          kind: "tool",
+          name: "apply_patch",
+          status: "completed",
+          at: "2026-08-18T12:00:04.000Z",
+        },
+        {
+          kind: "assistant_text",
+          text: longAssistant.slice(0, 2000),
+          truncated: true,
+          at: "2026-08-18T12:00:05.000Z",
+        },
+      ])
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("reads an indexed rollout tail and rejects unsafe Session IDs as MISSING", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "indexed-tail-session"
+      const rolloutPath = writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:00.000Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:01.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "go" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-18T12:00:02.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "working" },
+          }),
+        ].join("\n"),
+      })
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath,
+      })
+
+      await expect(getTail({ codexHome, sessionId })).resolves.toEqual({
+        availability: "available",
+        backend: { id: "codex", label: "Codex Build" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "assistant_text",
+            text: "working",
+            truncated: false,
+            at: "2026-08-18T12:00:02.000Z",
+          },
+        ],
+      })
+      await expect(
+        getTail({ codexHome, sessionId: "../escape" }),
+      ).resolves.toMatchObject({
+        availability: "missing",
+        backend: { id: "codex", label: "Codex Build" },
+        items: [],
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns MISSING when the Codex Session record is absent", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      mkdirSync(join(codexHome, "sessions"), { recursive: true })
+      await expect(
+        getTail({ codexHome, sessionId: "no-such-session" }),
+      ).resolves.toMatchObject({
+        availability: "missing",
+        backend: { id: "codex", label: "Codex Build" },
+        items: [],
+        jumpHint: false,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns UNAVAILABLE when the Codex Session record is unreadable", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "18"),
+        sessionId: "corrupt-tail-session",
+        raw: "not-json\n",
+      })
+      await expect(
+        getTail({ codexHome, sessionId: "corrupt-tail-session" }),
+      ).resolves.toMatchObject({
+        availability: "unavailable",
+        backend: { id: "codex", label: "Codex Build" },
+        items: [],
+        jumpHint: false,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/codex/test/session-telemetry-layer.spec.ts
+++ b/packages/codex/test/session-telemetry-layer.spec.ts
@@ -35,6 +35,19 @@ const getTelemetry = (input: {
     ),
   )
 
+const getTail = (input: {
+  readonly codexHome: string
+  readonly sessionId: string
+}) =>
+  Effect.runPromise(
+    Effect.gen(function* () {
+      const provider = yield* SessionTelemetryProvider
+      return yield* provider.getTail(input.sessionId)
+    }).pipe(
+      Effect.provide(CodexSessionTelemetryLive({ codexHome: input.codexHome })),
+    ),
+  )
+
 describe("CodexSessionTelemetryLive", () => {
   it("live-reads the last cumulative rollout totals with Codex Build provenance", async () => {
     const codexHome = mkdtempSync(join(tmpdir(), "codex-telemetry-"))
@@ -169,6 +182,113 @@ describe("CodexSessionTelemetryLive", () => {
         cost: null,
         createdAt: null,
         updatedAt: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("serves the latest Agent Turn Tail without fetching it from session()", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-telemetry-"))
+    try {
+      const sessionId = "019fab2c-9466-7432-ad16-9de23f94f2db"
+      writeRollout({
+        codexHome,
+        sessionId,
+        lines: [
+          {
+            timestamp: "2026-08-08T01:02:03.123Z",
+            type: "session_meta",
+            payload: { id: sessionId },
+          },
+          {
+            timestamp: "2026-08-08T01:02:04.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "review the tests" },
+          },
+          {
+            timestamp: "2026-08-08T01:02:05.000Z",
+            type: "response_item",
+            payload: {
+              type: "custom_tool_call",
+              name: "bun test",
+              status: "failed",
+              call_id: "call_tail",
+              input: "PAYLOAD_MUST_STAY_OUT",
+            },
+          },
+          {
+            timestamp: "2026-08-08T01:02:06.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "tests failed" },
+          },
+          {
+            timestamp: "2026-08-08T01:03:00.456Z",
+            type: "event_msg",
+            payload: {
+              type: "token_count",
+              info: {
+                total_token_usage: {
+                  input_tokens: 250,
+                  output_tokens: 45,
+                  reasoning_output_tokens: 11,
+                  cached_input_tokens: 140,
+                  cache_write_input_tokens: 13,
+                },
+              },
+            },
+          },
+        ],
+      })
+
+      const session = await getTelemetry({ codexHome, sessionId })
+      expect(session.availability).toBe("available")
+      expect(session.tokens).toEqual({
+        input: 250,
+        output: 45,
+        reasoning: 11,
+        cacheRead: 140,
+        cacheWrite: 13,
+      })
+
+      const tail = await getTail({ codexHome, sessionId })
+      expect(tail).toEqual({
+        availability: "available",
+        backend: { id: "codex", label: "Codex Build" },
+        jumpHint: false,
+        items: [
+          {
+            kind: "tool",
+            name: "bun test",
+            status: "failed",
+            at: "2026-08-08T01:02:05.000Z",
+          },
+          {
+            kind: "assistant_text",
+            text: "tests failed",
+            truncated: false,
+            at: "2026-08-08T01:02:06.000Z",
+          },
+        ],
+      })
+      expect(JSON.stringify(session)).not.toContain("PAYLOAD_MUST_STAY_OUT")
+      expect(JSON.stringify(tail)).not.toContain("PAYLOAD_MUST_STAY_OUT")
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("maps a missing Session to MISSING tail without failing", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-telemetry-"))
+    try {
+      mkdirSync(join(codexHome, "sessions"), { recursive: true })
+      await expect(
+        getTail({ codexHome, sessionId: "no-such-session" }),
+      ).resolves.toMatchObject({
+        availability: "missing",
+        backend: { id: "codex", label: "Codex Build" },
+        items: [],
+        jumpHint: false,
       })
     } finally {
       rmSync(codexHome, { recursive: true, force: true })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -10392,6 +10392,36 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("session reports Agent Turn Tail supported for Codex Build", async () => {
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        getWorkItem: () =>
+          Effect.succeed({
+            ...workItem,
+            agentBackend: "codex",
+            sessionId: "019fab2c-9466-7432-ad16-9de23f94f2db",
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query Session($workItemId: ID!) {
+          session(workItemId: $workItemId) { agentTurnTailSupported }
+        }`,
+        variables: { workItemId: workItem.id },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { session: { agentTurnTailSupported: true } },
+    })
+  })
+
   test("agentTurnTail returns null for unknown Work Item", async () => {
     runtime = makeRuntime(
       {},


### PR DESCRIPTION
Show tail on a Codex Build Work Item was a dead end: the usage dialog and `agentTurnTail` query
already existed from #1139, but Codex reported `UNSUPPORTED` and never read the rollout.

This change turns Agent Turn Tail on for Codex and live-reads the canonical Session from the end of
the Codex-owned JSONL. The peek is the latest Agent Turn only: last 20 items, assistant text
truncated at 2k and marked truncated, tool names/status/timestamps, no tool payloads, thinking,
harness prompts, or child/inter-agent activity. An empty latest turn still returns the existing Jump
hint. Missing or unreadable rollouts stay `MISSING` / `UNAVAILABLE`. `session()` still loads token
usage without fetching the tail.

The reader stops at the last user event or 20 newer activity items, decodes only a short line
prefix, and classifies from the payload `type` field so payload *text* cannot become a turn boundary
or drop a tool.

Verified with Codex store and telemetry tests (latest-turn slice, 20/2k bounds, Jump hint, child
skip, payload-type classification, MISSING/UNAVAILABLE) plus GraphQL `agentTurnTailSupported` for
Codex. No browser check in this ticket (#1144 covers the OpenCode UI path).

Closes #1143