### PR TITLE
feat(lifecycle): treat post-deadline no_checks as green for Always

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -359,9 +359,9 @@ export const ambientGitHubLayer = (options: {
           ),
         ),
         mergePullRequest: Effect.fn("AmbientGitHub.mergePullRequest")(
-          (repository, headRefName) =>
+          (repository, headRefName, options) =>
             authenticated("lifecycle", repository, (service) =>
-              service.mergePullRequest(repository, headRefName),
+              service.mergePullRequest(repository, headRefName, options),
             ),
         ),
         rerunWorkflowRun: Effect.fn("AmbientGitHub.rerunWorkflowRun")(

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -261,9 +261,9 @@ export const ambientGitLabLayer = (options: {
           ),
         ),
         mergePullRequest: Effect.fn("AmbientGitLab.mergePullRequest")(
-          (repository, headRefName) =>
+          (repository, headRefName, options) =>
             authenticated(repository.forgeHost, (service) =>
-              service.mergePullRequest(repository, headRefName),
+              service.mergePullRequest(repository, headRefName, options),
             ),
         ),
         ensureIssueCompletedWithSummary: Effect.fn(

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -779,12 +779,17 @@ export const keymaxxerGitHubLayer = (options: {
           }),
         ),
         mergePullRequest: Effect.fn("KeymaxxerGitHub.mergePullRequest")(
-          (repository, headRefName) =>
+          (repository, headRefName, options) =>
             callHelper({
               operation: "merge-pull-request",
               repository,
               describe: "merge pull request",
-              args: [encodeArgument(headRefName)],
+              args: [
+                encodeArgument(headRefName),
+                ...(options?.acceptNoChecks === true
+                  ? [encodeArgument(JSON.stringify({ acceptNoChecks: true }))]
+                  : []),
+              ],
               decode: decodeJson(
                 SerializedMergePullRequestResult,
                 repository,

--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -651,7 +651,7 @@ export const keymaxxerGitLabLayer = (options: {
           ),
         ),
         mergePullRequest: Effect.fn("KeymaxxerGitLab.mergePullRequest")(
-          (repository, headRefName) =>
+          (repository, headRefName, options) =>
             withVaultOrAmbient(
               repository,
               (tokenName) =>
@@ -660,7 +660,16 @@ export const keymaxxerGitLabLayer = (options: {
                   repository,
                   tokenName,
                   describe: "merge pull request",
-                  args: [encodeArgument(headRefName)],
+                  args: [
+                    encodeArgument(headRefName),
+                    ...(options?.acceptNoChecks === true
+                      ? [
+                          encodeArgument(
+                            JSON.stringify({ acceptNoChecks: true }),
+                          ),
+                        ]
+                      : []),
+                  ],
                   decode: decodeJson(
                     SerializedMergePullRequestResult,
                     repository,
@@ -668,7 +677,11 @@ export const keymaxxerGitLabLayer = (options: {
                   ),
                 }),
               (ambientService) =>
-                ambientService.mergePullRequest(repository, headRefName),
+                ambientService.mergePullRequest(
+                  repository,
+                  headRefName,
+                  options,
+                ),
             ),
         ),
         ensureIssueCompletedWithSummary: Effect.fn(

--- a/packages/github-service/src/bin/merge-pull-request.ts
+++ b/packages/github-service/src/bin/merge-pull-request.ts
@@ -1,11 +1,16 @@
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { GitHubService } from "../lib/github-service.js"
 import {
+  CliArgumentError,
   decodeArgument,
   githubRepository,
   runGitHubCli,
   writeStandardOutput,
 } from "./cli.js"
+
+const MergePullRequestOptionsPayload = Schema.Struct({
+  acceptNoChecks: Schema.optional(Schema.Boolean),
+})
 
 export const mergePullRequestProgram = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
@@ -13,10 +18,24 @@ export const mergePullRequestProgram = (args: ReadonlyArray<string>) =>
     const forgeHost = yield* decodeArgument(args[1], "forge host")
     const projectPath = yield* decodeArgument(args[2], "project path")
     const headRefName = yield* decodeArgument(args[3], "head ref")
+    const options =
+      args[4] === undefined
+        ? undefined
+        : yield* Schema.decodeUnknownEffect(
+            Schema.fromJsonString(MergePullRequestOptionsPayload),
+          )(yield* decodeArgument(args[4], "merge options")).pipe(
+            Effect.mapError(
+              () =>
+                new CliArgumentError({
+                  message: "Invalid merge pull request options",
+                }),
+            ),
+          )
     const github = yield* GitHubService
     const result = yield* github.mergePullRequest(
       githubRepository(forge, forgeHost, projectPath),
       headRefName,
+      options,
     )
     yield* writeStandardOutput(JSON.stringify(result))
   })

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -307,12 +307,14 @@ type MergeCheckRollupVerdict =
   | { readonly _tag: "checks_not_green" }
 
 /**
- * Harness-initiated merge requires a non-empty successful aggregate.
- * A null rollup or EXPECTED context is not green.
+ * Harness-initiated merge requires a non-empty successful aggregate, except
+ * Always after the Check-Start Deadline may accept a null/`no_checks` rollup.
+ * EXPECTED is never green.
  */
 const classifyMergeCheckRollup = (
   rollup: { readonly state: unknown } | null | undefined,
   context: string,
+  options?: { readonly acceptNoChecks?: boolean },
 ): MergeCheckRollupVerdict => {
   if (rollup === undefined) {
     return {
@@ -320,7 +322,12 @@ const classifyMergeCheckRollup = (
       message: `GitHub omitted the check rollup for ${context}`,
     }
   }
-  if (rollup === null || rollup.state === "EXPECTED") {
+  if (rollup === null) {
+    return options?.acceptNoChecks === true
+      ? { _tag: "ok" }
+      : { _tag: "missing_successful_checks" }
+  }
+  if (rollup.state === "EXPECTED") {
     return { _tag: "missing_successful_checks" }
   }
   if (!isGitHubStatusCheckState(rollup.state)) {
@@ -1955,7 +1962,7 @@ const makeGitHubApiService = (
     }
   }),
   mergePullRequest: Effect.fn("GitHubService.mergePullRequest")(
-    function* (repository, headRefName) {
+    function* (repository, headRefName, options) {
       const loadPullRequest = () =>
         githubQuery(
           `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
@@ -2032,6 +2039,7 @@ const makeGitHubApiService = (
       const preMergeChecks = classifyMergeCheckRollup(
         pullRequest.statusCheckRollup,
         `${repository.owner}/${repository.name}:${headRefName}`,
+        options,
       )
       if (preMergeChecks._tag === "invalid") {
         return yield* new GitHubRequestError({
@@ -2169,6 +2177,7 @@ const makeGitHubApiService = (
       const postMergeChecks = classifyMergeCheckRollup(
         mergedPullRequest.statusCheckRollup,
         `${repository.owner}/${repository.name}:${headRefName}`,
+        options,
       )
       if (postMergeChecks._tag === "invalid") {
         return yield* new GitHubRequestError({

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -6,6 +6,7 @@ import type {
 import type { GitHubServiceError } from "./errors.js"
 import type {
   GitHubRepository,
+  MergePullRequestOptions,
   MergePullRequestResult,
   PrStatusCheckDiagnostic,
   PrStatusCheckDiagnosticsOptions,
@@ -128,6 +129,7 @@ export interface GitHubServiceShape {
   readonly mergePullRequest: (
     repository: GitHubRepository,
     headRefName: string,
+    options?: MergePullRequestOptions,
   ) => Effect.Effect<MergePullRequestResult, GitHubServiceError>
   /**
    * Rerun an entire GitHub Actions workflow run (not failed-jobs-only).

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -162,6 +162,15 @@ export type MergeRevalidationReason =
   | "checks_not_green"
   | "mergeability_changed"
 
+/**
+ * Options for a Forge merge mutation. Always after the Check-Start Deadline
+ * accepts an absent/`no_checks` aggregate; EXPECTED, pending, and failed still
+ * block. Classify and omitted options stay fail-closed on `no_checks`.
+ */
+export type MergePullRequestOptions = {
+  readonly acceptNoChecks?: boolean
+}
+
 /** Domain result of a merge attempt; request/response failures remain errors. */
 export type MergePullRequestResult =
   | { readonly _tag: "merged" }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -2743,6 +2743,87 @@ describe("GitHubService live implementation", () => {
     },
   )
 
+  it("merges Always when the check rollup is absent", async () => {
+    const mutations: unknown[] = []
+    const service = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  id: "PR_kwDOOpen",
+                  state: "OPEN",
+                  merged: false,
+                  headRefOid: "abc123",
+                  mergeable: "MERGEABLE",
+                  statusCheckRollup: null,
+                },
+              ],
+            },
+          },
+        }) as never,
+      mutation: (request) => {
+        mutations.push(request)
+        return Promise.resolve({
+          mergePullRequest: {
+            pullRequest: { merged: true, state: "MERGED" },
+          },
+        }) as never
+      },
+    })
+
+    const result = await Effect.runPromise(
+      service.mergePullRequest(repository, "branch", {
+        acceptNoChecks: true,
+      }),
+    )
+    expect(result).toEqual({ _tag: "merged" })
+    expect(mutations).toHaveLength(1)
+  })
+
+  it("still returns missing-check Needs Human for Always when a required context is EXPECTED", async () => {
+    const mutations: unknown[] = []
+    const service = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  id: "PR_kwDOOpen",
+                  state: "OPEN",
+                  merged: false,
+                  headRefOid: "abc123",
+                  mergeable: "MERGEABLE",
+                  statusCheckRollup: { state: "EXPECTED" },
+                },
+              ],
+            },
+          },
+        }) as never,
+      mutation: (request) => {
+        mutations.push(request)
+        return Promise.resolve({
+          mergePullRequest: {
+            pullRequest: { merged: true, state: "MERGED" },
+          },
+        }) as never
+      },
+    })
+
+    const result = await Effect.runPromise(
+      service.mergePullRequest(repository, "branch", {
+        acceptNoChecks: true,
+      }),
+    )
+    expect(result).toMatchObject({
+      _tag: "needs_human",
+      reason: "missing_successful_checks",
+    })
+    expect(mutations).toHaveLength(0)
+  })
+
   it.each([
     ["non-green checks", "MERGEABLE", "FAILURE", "checks_not_green"],
     ["a conflict", "CONFLICTING", "SUCCESS", "mergeability_changed"],

--- a/packages/gitlab-service/src/bin/merge-pull-request.ts
+++ b/packages/gitlab-service/src/bin/merge-pull-request.ts
@@ -1,11 +1,16 @@
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { GitLabService } from "../lib/gitlab-service.js"
 import {
+  CliArgumentError,
   decodeArgument,
   gitlabRepository,
   runGitLabCli,
   writeStandardOutput,
 } from "./cli.js"
+
+const MergePullRequestOptionsPayload = Schema.Struct({
+  acceptNoChecks: Schema.optional(Schema.Boolean),
+})
 
 export const mergePullRequestProgram = (args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
@@ -15,8 +20,25 @@ export const mergePullRequestProgram = (args: ReadonlyArray<string>) =>
       yield* decodeArgument(args[2], "project path"),
     )
     const headRefName = yield* decodeArgument(args[3], "head ref")
+    const options =
+      args[4] === undefined
+        ? undefined
+        : yield* Schema.decodeUnknownEffect(
+            Schema.fromJsonString(MergePullRequestOptionsPayload),
+          )(yield* decodeArgument(args[4], "merge options")).pipe(
+            Effect.mapError(
+              () =>
+                new CliArgumentError({
+                  message: "Invalid merge pull request options",
+                }),
+            ),
+          )
     const gitlab = yield* GitLabService
-    const result = yield* gitlab.mergePullRequest(repository, headRefName)
+    const result = yield* gitlab.mergePullRequest(
+      repository,
+      headRefName,
+      options,
+    )
     yield* writeStandardOutput(JSON.stringify(result))
   })
 

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -1531,7 +1531,7 @@ export const makeGitLabService = (options: {
       })
     }),
     mergePullRequest: Effect.fn("GitLabService.mergePullRequest")(
-      function* (repository, headRefName) {
+      function* (repository, headRefName, options) {
         const loadMergeRequest = (): Effect.Effect<
           MergeRequestCheck | null,
           GitLabServiceError
@@ -1573,7 +1573,7 @@ export const makeGitLabService = (options: {
          * allow_failure failures are not hard-fail, while still-running and
          * hard-fail pipelines revalidate. An absent head pipeline or a
          * no_checks aggregate (including skipped-only / ignore-only jobs) is
-         * not green and yields missing_successful_checks. A tip-aligned
+         * not green unless Always accepts `no_checks`. A tip-aligned
          * head_pipeline whose SHA is not the MR tip is treated as not green so
          * a concurrent push cannot merge an untested head under a stale
          * success (same tip-freshness rule as Watch pending). Merged-results
@@ -1588,7 +1588,9 @@ export const makeGitLabService = (options: {
           Effect.gen(function* () {
             const headPipeline = mergeRequest.head_pipeline
             if (headPipeline === null || headPipeline === undefined) {
-              return "missing_successful_checks" as const
+              return options?.acceptNoChecks === true
+                ? null
+                : ("missing_successful_checks" as const)
             }
             if (isStaleHeadPipelineForTip(mergeRequest)) {
               return "checks_not_green" as const
@@ -1636,7 +1638,9 @@ export const makeGitLabService = (options: {
               return "checks_not_green" as const
             }
             if (aggregate === "no_checks") {
-              return "missing_successful_checks" as const
+              return options?.acceptNoChecks === true
+                ? null
+                : ("missing_successful_checks" as const)
             }
             return null
           })

--- a/packages/gitlab-service/src/lib/gitlab-service.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service.ts
@@ -1,5 +1,6 @@
 import { Context, type Effect } from "effect"
 import type {
+  MergePullRequestOptions,
   MergePullRequestResult,
   PrStatusCheckDiagnostic,
   PrStatusCheckDiagnosticsOptions,
@@ -144,6 +145,7 @@ export interface GitLabServiceShape {
   readonly mergePullRequest: (
     repository: GitLabRepository,
     headRefName: string,
+    options?: MergePullRequestOptions,
   ) => Effect.Effect<MergePullRequestResult, GitLabServiceError>
   /**
    * Ensure a No-Change Outcome summary is posted once (hidden Work Item marker)

--- a/packages/gitlab-service/test/gitlab-service.spec.ts
+++ b/packages/gitlab-service/test/gitlab-service.spec.ts
@@ -2278,6 +2278,106 @@ describe("GitLab PR status checks and ready-for-review", () => {
     expect(putCount).toBe(0)
   })
 
+  test("mergePullRequest merges Always when no head pipeline is visible", async () => {
+    let putCount = 0
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname.endsWith("/merge_requests") &&
+        url.search.includes("state=opened")
+      ) {
+        return json([{ iid: 12, draft: false }])
+      }
+      if (method === "GET" && url.pathname.endsWith("/merge_requests/12")) {
+        return json({
+          iid: 12,
+          state: "opened",
+          draft: false,
+          title: "Ready",
+          sha: "abc123",
+          target_branch: "main",
+          detailed_merge_status: "mergeable",
+          merge_status: "can_be_merged",
+          has_conflicts: false,
+          head_pipeline: null,
+        })
+      }
+      if (method === "PUT") {
+        putCount += 1
+        return json({ iid: 12, state: "merged" })
+      }
+      throw new Error(`Unexpected: ${method} ${url.pathname}${url.search}`)
+    }) as typeof fetch)
+
+    expect(
+      await Effect.runPromise(
+        service.mergePullRequest(repository, "rfa/branch", {
+          acceptNoChecks: true,
+        }),
+      ),
+    ).toEqual({ _tag: "merged" })
+    expect(putCount).toBe(1)
+  })
+
+  test("mergePullRequest merges Always for skipped-only jobs", async () => {
+    let putCount = 0
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname.endsWith("/merge_requests") &&
+        url.search.includes("state=opened")
+      ) {
+        return json([{ iid: 12, draft: false }])
+      }
+      if (method === "GET" && url.pathname.endsWith("/merge_requests/12")) {
+        return json({
+          iid: 12,
+          state: "opened",
+          draft: false,
+          title: "Ready",
+          sha: "abc123",
+          target_branch: "main",
+          detailed_merge_status: "mergeable",
+          merge_status: "can_be_merged",
+          has_conflicts: false,
+          head_pipeline: { id: 1, status: "manual", sha: "abc123" },
+        })
+      }
+      if (method === "GET" && url.pathname.includes("/pipelines/1/jobs")) {
+        return json([
+          { id: 1, name: "test", status: "skipped", allow_failure: false },
+        ])
+      }
+      if (method === "GET" && url.pathname.includes("/bridges")) {
+        return json([])
+      }
+      if (method === "PUT") {
+        putCount += 1
+        return json({ iid: 12, state: "merged" })
+      }
+      throw new Error(`Unexpected: ${method} ${url.pathname}${url.search}`)
+    }) as typeof fetch)
+
+    expect(
+      await Effect.runPromise(
+        service.mergePullRequest(repository, "rfa/branch", {
+          acceptNoChecks: true,
+        }),
+      ),
+    ).toEqual({ _tag: "merged" })
+    expect(putCount).toBe(1)
+  })
+
   test.each([
     [
       "non-green pipeline",

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -55,7 +55,7 @@ import type {
 } from "./resolve-pr-merge-conflict.js"
 import type { ReviewResult } from "./review.js"
 import type { ReviewError } from "./review-errors.js"
-import type { WorkItemId } from "./types.js"
+import type { MergeMode, WorkItemId } from "./types.js"
 
 /**
  * Context supplied to every Lifecycle Step handler.
@@ -93,6 +93,11 @@ export interface LifecycleStepContext {
    * Work Item Auto-merge override. Null/omitted follows Repository Auto-merge.
    */
   readonly autoMergeOverride?: boolean | null
+  /**
+   * Durable Merge Mode. `always` is the Always pin and accepts post-deadline
+   * `no_checks` at Merge PR revalidation.
+   */
+  readonly mergeMode?: MergeMode
   readonly maxDuration?: Duration.Duration
 }
 

--- a/packages/work-item-lifecycle/src/lib/merge-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/merge-pr.ts
@@ -40,10 +40,12 @@ export const mergePr = (context: LifecycleStepContext) =>
       issueNumber: context.issueNumber,
       workItemId: context.workItemId,
     })
+    const options =
+      context.mergeMode === "always" ? { acceptNoChecks: true } : undefined
     if (repository.forge === "gitlab") {
       const gitlab = yield* GitLabService
-      return yield* gitlab.mergePullRequest(repository, branch)
+      return yield* gitlab.mergePullRequest(repository, branch, options)
     }
     const github = yield* GitHubService
-    return yield* github.mergePullRequest(repository, branch)
+    return yield* github.mergePullRequest(repository, branch, options)
   })

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -473,6 +473,25 @@ const nextStateAfterReadyForMerge = (
 const isMissingSuccessfulCheckStatus = (tag: string): boolean =>
   tag === "no_checks" || tag === "expected"
 
+/**
+ * After the Check-Start Deadline, Always + `no_checks` is green (ADR 0059).
+ * EXPECTED, pending, and failed still block. Classify stays fail-closed.
+ */
+const isAlwaysNoChecksCarveOut = (
+  mergeMode: string | null | undefined,
+  statusTag: string,
+): boolean =>
+  decodeMergeMode(mergeMode) === "always" && statusTag === "no_checks"
+
+const shouldHandOffMissingSuccessfulChecks = (input: {
+  readonly autonomousMerge: boolean
+  readonly mergeMode: string | null | undefined
+  readonly statusTag: string
+}): boolean =>
+  input.autonomousMerge &&
+  isMissingSuccessfulCheckStatus(input.statusTag) &&
+  !isAlwaysNoChecksCarveOut(input.mergeMode, input.statusTag)
+
 const decodeWorkItemAutoMergeOverride = (
   value: boolean | number | null | undefined,
 ): boolean | null =>
@@ -2736,10 +2755,27 @@ export const makeWorkItemLifecycleLive = (
                     // Known draft→ready with opt-out: reuse settled draft evidence.
                     if (skipReadyPhaseStartupWait) {
                       if (
-                        autonomousMerge &&
-                        isMissingSuccessfulCheckStatus(status._tag)
+                        shouldHandOffMissingSuccessfulChecks({
+                          autonomousMerge,
+                          mergeMode: workItem.merge_mode,
+                          statusTag: status._tag,
+                        })
                       ) {
                         return missingSuccessfulChecksHandoff(status._tag)
+                      }
+                      if (
+                        isAlwaysNoChecksCarveOut(
+                          workItem.merge_mode,
+                          status._tag,
+                        ) &&
+                        !pastDeadline
+                      ) {
+                        return {
+                          transition: {
+                            nextState: "watch_pr_status_checks" as const,
+                            delay: requeueDelay,
+                          },
+                        }
                       }
                       return {
                         transition: {
@@ -2760,8 +2796,11 @@ export const makeWorkItemLifecycleLive = (
                       }
                     }
                     if (
-                      autonomousMerge &&
-                      isMissingSuccessfulCheckStatus(status._tag)
+                      shouldHandOffMissingSuccessfulChecks({
+                        autonomousMerge,
+                        mergeMode: workItem.merge_mode,
+                        statusTag: status._tag,
+                      })
                     ) {
                       return missingSuccessfulChecksHandoff(status._tag)
                     }
@@ -2895,12 +2934,27 @@ export const makeWorkItemLifecycleLive = (
                   }
                   if (isSettledNonFailingPrStatus(status._tag)) {
                     if (
-                      autonomousMerge &&
-                      isMissingSuccessfulCheckStatus(status._tag)
+                      shouldHandOffMissingSuccessfulChecks({
+                        autonomousMerge,
+                        mergeMode: workItem.merge_mode,
+                        statusTag: status._tag,
+                      })
                     ) {
                       return {
                         checkStartLastObservedIsDraft: 0 as const,
                         ...missingSuccessfulChecksHandoff(status._tag),
+                      }
+                    }
+                    if (
+                      isAlwaysNoChecksCarveOut(workItem.merge_mode, status._tag)
+                    ) {
+                      // Preserve the original Check-Start Deadline; Watch
+                      // applies the Always + no_checks carve-out when due.
+                      return {
+                        checkStartLastObservedIsDraft: 0 as const,
+                        transition: {
+                          nextState: "watch_pr_status_checks" as const,
+                        },
                       }
                     }
                     return {
@@ -4536,6 +4590,7 @@ export const makeWorkItemLifecycleLive = (
                   workItem.auto_merge_override === undefined
                     ? null
                     : Boolean(workItem.auto_merge_override),
+                mergeMode: decodeMergeMode(workItem.merge_mode),
                 maxDuration,
               }
 

--- a/packages/work-item-lifecycle/test/merge-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/merge-pr.spec.ts
@@ -74,8 +74,9 @@ describe("mergePr", () => {
       getPullRequestLifecycleStatus: () =>
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
-      mergePullRequest: (_repository, branch) => {
+      mergePullRequest: (_repository, branch, options) => {
         requestedBranch = branch
+        expect(options).toBeUndefined()
         return Effect.succeed({ _tag: "merged" as const })
       },
       uploadUserAttachment: () =>
@@ -90,6 +91,24 @@ describe("mergePr", () => {
     )
 
     expect(requestedBranch).toBe(`rfa/acme-widgets/42/${context.workItemId}`)
+  })
+
+  it("asks GitHub to accept no_checks only for Always", async () => {
+    let seenOptions: { readonly acceptNoChecks?: boolean } | undefined
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: (_repository, _branch, options) => {
+        seenOptions = options
+        return Effect.succeed({ _tag: "merged" as const })
+      },
+    } as GitHubServiceShape)
+
+    await Effect.runPromise(
+      mergePr({ ...context, mergeMode: "always" }).pipe(
+        Effect.provide(Layer.merge(db, github)),
+      ),
+    )
+
+    expect(seenOptions).toEqual({ acceptNoChecks: true })
   })
 
   it("requires a worktree path", async () => {
@@ -160,8 +179,9 @@ describe("mergePr", () => {
       },
     } as GitHubServiceShape)
     const gitlab = Layer.succeed(GitLabService, {
-      mergePullRequest: (_repository, branch) => {
+      mergePullRequest: (_repository, branch, options) => {
         requestedBranch = branch
+        expect(options).toBeUndefined()
         return Effect.succeed({ _tag: "merged" as const })
       },
     } as GitLabServiceShape)
@@ -174,5 +194,36 @@ describe("mergePr", () => {
 
     expect(requestedBranch).toBe(`rfa/project-widgets/42/${context.workItemId}`)
     expect(githubCalls).toBe(0)
+  })
+
+  it("asks GitLab to accept no_checks only for Always", async () => {
+    let seenOptions: { readonly acceptNoChecks?: boolean } | undefined
+    const gitlabRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/widgets",
+      localPath: "/repos/widgets",
+    })
+    const gitlabDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([gitlabRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () => Effect.die("GitHub must not merge a GitLab repo"),
+    } as GitHubServiceShape)
+    const gitlab = Layer.succeed(GitLabService, {
+      mergePullRequest: (_repository, _branch, options) => {
+        seenOptions = options
+        return Effect.succeed({ _tag: "merged" as const })
+      },
+    } as GitLabServiceShape)
+
+    await Effect.runPromise(
+      mergePr({ ...context, mergeMode: "always" }).pipe(
+        Effect.provide(Layer.mergeAll(gitlabDb, github, gitlab)),
+      ),
+    )
+
+    expect(seenOptions).toEqual({ acceptNoChecks: true })
   })
 })

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -2897,14 +2897,14 @@ describe("WorkItemLifecycle", () => {
         }
       })
 
-      it("blocks Merge Mode always with no_checks and never calls Merge PR", async () => {
+      it("advances Merge Mode always to Merge PR after the deadline with no_checks", async () => {
         let mergeCalls = 0
         const steps: LifecycleStepsShape = {
           ...successfulSteps,
           watchPrStatusChecks: () => Effect.succeed(watchResult("no_checks")),
           mergePr: () => {
             mergeCalls += 1
-            return Effect.die("Merge PR must not run without successful checks")
+            return Effect.succeed({ _tag: "merged" as const })
           },
         }
         const { afterWatch } = await runWatchToDeadline(
@@ -2913,12 +2913,216 @@ describe("WorkItemLifecycle", () => {
         )
         expect(afterWatch._tag).toBe("processed")
         if (afterWatch._tag === "processed") {
-          expect(afterWatch.workItem.state).toBe("needs_human")
-          expect(afterWatch.workItem.failureMessage).toBe(
-            MISSING_SUCCESSFUL_CHECKS_REASON_NO_CHECKS,
-          )
+          expect(afterWatch.workItem.state).toBe("merge_pr")
+          expect(afterWatch.workItem.failureCode).toBeNull()
         }
         expect(mergeCalls).toBe(0)
+      })
+
+      it("waits before the deadline then merges Always with no_checks", () => {
+        const anchorInstant = 1_008_000
+        let mergeCalls = 0
+        const steps: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () =>
+            Effect.succeed({
+              _tag: "no_checks" as const,
+              createdAt: new Date(anchorInstant),
+              headSha: "fresh-head",
+              headPushedAt: new Date(anchorInstant),
+              isDraft: false,
+            }),
+          mergePr: () => {
+            mergeCalls += 1
+            return Effect.succeed({ _tag: "merged" as const })
+          },
+        }
+        return Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                yield* TestClock.setTime(1_000_000)
+                const lifecycle = yield* WorkItemLifecycle
+                const { repository, issue } = yield* seedActionableIssue
+                const created = yield* lifecycle.implementNow(
+                  repository.id,
+                  issue.issueNumber,
+                )
+                yield* setWorkItemMergeModeAlways(created.id)
+                yield* driveThroughCreatePrAlreadyReady(created.id)
+
+                yield* TestClock.setTime(anchorInstant)
+                yield* makeQueuedJobsAvailable
+                const early = yield* claimAndRunPending
+                expect(early._tag).toBe("processed")
+                if (early._tag === "processed") {
+                  expect(early.workItem.state).toBe("watch_pr_status_checks")
+                }
+
+                yield* TestClock.setTime(
+                  anchorInstant + CHECK_START_DEADLINE_MS,
+                )
+                yield* makeQueuedJobsAvailable
+                const afterDeadline = yield* claimAndRunPending
+                expect(afterDeadline._tag).toBe("processed")
+                if (afterDeadline._tag === "processed") {
+                  expect(afterDeadline.workItem.state).toBe("merge_pr")
+                  expect(afterDeadline.workItem.failureCode).toBeNull()
+                }
+                expect(mergeCalls).toBe(0)
+              }),
+              makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+            ),
+          ),
+        )
+      })
+
+      it("hands off GitHub EXPECTED under Merge Mode always at the deadline", async () => {
+        const { afterWatch } = await runWatchToDeadline(
+          expectedWatch,
+          ({ createdId }) => setWorkItemMergeModeAlways(createdId),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).toBe("needs_human")
+          expect(afterWatch.workItem.failureMessage).toBe(
+            MISSING_SUCCESSFUL_CHECKS_REASON_EXPECTED,
+          )
+          expect(afterWatch.workItem.stepRuns.at(-1)?.reasonCode).toBe(
+            STEP_RUN_REASON.missingSuccessfulChecks,
+          )
+        }
+      })
+
+      it("keeps Always pending after the deadline until executions finish", async () => {
+        const pendingWatch: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () => Effect.succeed(watchResult("pending")),
+          mergePr: () => Effect.die("Merge PR must not run for pending checks"),
+        }
+        const { afterWatch } = await runWatchToDeadline(
+          pendingWatch,
+          ({ createdId }) => setWorkItemMergeModeAlways(createdId),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).toBe("watch_pr_status_checks")
+        }
+      })
+
+      it("does not authorize Always merge when checks failed after the deadline", async () => {
+        const failedWatch: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () => Effect.succeed(watchResult("failed")),
+          mergePr: () => Effect.die("Merge PR must not run for failed checks"),
+        }
+        const { afterWatch } = await runWatchToDeadline(
+          failedWatch,
+          ({ createdId }) => setWorkItemMergeModeAlways(createdId),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).not.toBe("merge_pr")
+          expect(afterWatch.workItem.state).not.toBe("decide_pr_merge")
+        }
+      })
+
+      it("sends Always merge conflicts to Resolve PR Merge Conflict", async () => {
+        const conflictWatch: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () =>
+            Effect.succeed({
+              _tag: "conflict" as const,
+              retiredCheckIds: [],
+              ...settledTiming,
+            }),
+          mergePr: () =>
+            Effect.die("Merge PR must not run for a conflicting PR"),
+        }
+        const { afterWatch } = await runWatchToDeadline(
+          conflictWatch,
+          ({ createdId }) => setWorkItemMergeModeAlways(createdId),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).toBe("resolve_pr_merge_conflict")
+        }
+      })
+
+      it("does not shortcut waitForReadyForReviewChecks:false Always no_checks before the deadline", () => {
+        let prIsDraft = true
+        let mergeCalls = 0
+        const steps: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () =>
+            Effect.succeed({
+              _tag: "no_checks" as const,
+              createdAt: new Date(0),
+              headSha: "shortcut-no-checks",
+              headPushedAt: new Date(0),
+              isDraft: prIsDraft,
+            }),
+          markPrReadyForReview: () => {
+            prIsDraft = false
+            return Effect.void
+          },
+          mergePr: () => {
+            mergeCalls += 1
+            return Effect.succeed({ _tag: "merged" as const })
+          },
+        }
+
+        return Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                yield* TestClock.setTime(1_000_000)
+                const lifecycle = yield* WorkItemLifecycle
+                const { repository, issue } = yield* seedActionableIssue
+                yield* enableRepositoryAutoMerge(repository, {
+                  waitForReadyForReviewChecks: false,
+                })
+                const created = yield* lifecycle.implementNow(
+                  repository.id,
+                  issue.issueNumber,
+                )
+                yield* setWorkItemMergeModeAlways(created.id)
+
+                for (let index = 0; index < 8; index += 1) {
+                  yield* TestClock.adjust(1_000)
+                  yield* claimAndRunPending
+                }
+                yield* TestClock.adjust(1_000)
+                const afterDraftWatch = yield* claimAndRunPending
+                expect(afterDraftWatch._tag).toBe("processed")
+                if (afterDraftWatch._tag === "processed") {
+                  expect(afterDraftWatch.workItem.state).toBe(
+                    "mark_pr_ready_for_review",
+                  )
+                }
+
+                const afterMarkReady = yield* claimAndRunPending
+                expect(afterMarkReady._tag).toBe("processed")
+                if (afterMarkReady._tag === "processed") {
+                  expect(afterMarkReady.workItem.state).toBe(
+                    "watch_pr_status_checks",
+                  )
+                }
+                expect(mergeCalls).toBe(0)
+
+                yield* TestClock.setTime(1_000_000 + CHECK_START_DEADLINE_MS)
+                yield* makeQueuedJobsAvailable
+                const afterDeadline = yield* claimAndRunPending
+                expect(afterDeadline._tag).toBe("processed")
+                if (afterDeadline._tag === "processed") {
+                  expect(afterDeadline.workItem.state).toBe("merge_pr")
+                }
+                expect(mergeCalls).toBe(0)
+              }),
+              makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+            ),
+          ),
+        )
       })
 
       it("advances Merge Mode always to Merge PR when checks succeeded", async () => {


### PR DESCRIPTION
Always Work Items (Merge Mode Always / Implement All with Auto-merge)
could not merge a pull request that never grew a status-check
aggregate. After #1155 recorded the Always `no_checks` carve-out,
Watch and Merge PR revalidation still treated absence of CI as Needs
Human `missing_successful_checks` (#1156).

Watch and Mark Ready now send Always + `no_checks` to Merge PR once
the Check-Start Deadline has passed. Classify is unchanged:
post-deadline `no_checks` is still Needs Human. Always still waits
before the deadline. Pending, failed, and GitHub `EXPECTED` still do
not authorize merge. Conflicts still go to Resolve PR Merge Conflict.

GitHub and GitLab Merge PR revalidation accept an absent/`no_checks`
aggregate only when the Work Item is Always. `EXPECTED`, pending, and
failed stay fail-closed. Existing Always Work Items still skip Decide
PR Merge.

Verified with `nx test work-item-lifecycle` (758 pass),
`nx test github-service` (161 pass), `nx test gitlab-service`
(67 pass), and harness Keymaxxer/ambient forge-layer tests
(81 pass). Local review found no findings.

This change does not add three-state Repository Merge Policy storage,
live inherit from Repository `always`, or Implement With pins
(siblings #1157 and #1158).

Closes #1156