### PR TITLE
feat: pin Implement With Merge Policy on the Work Item

### DIFF
--- a/apps/harness/src/execution-profile-draft.ts
+++ b/apps/harness/src/execution-profile-draft.ts
@@ -91,9 +91,9 @@ export type ImplementWithProfileInput = {
   readonly reviewThinkingLevel: string | null
 }
 
-/** GraphQL `implementWith` options. The dialog always submits both values. */
+/** GraphQL `implementWith` options. The dialog always submits a concrete pin. */
 type ImplementWithOptionsInput = {
-  readonly autoMerge: boolean
+  readonly mergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
   readonly implementLocally: boolean
 }
 

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -295,7 +295,7 @@ export type WorkItem = {
     reviewThinkingLevel: string | null
   } | null
   mergeMode?: "ORDINARY" | "ALWAYS"
-  autoMergeOverride?: boolean | null
+  mergePolicy?: "OFF" | "CLASSIFY" | "ALWAYS" | null
   pauseBeforeStep?: WorkItemState | null
   state: WorkItemState
   stateLabel: string
@@ -345,7 +345,7 @@ const workItemFields = {
     reviewThinkingLevel: true,
   },
   mergeMode: true,
-  autoMergeOverride: true,
+  mergePolicy: true,
   pauseBeforeStep: true,
   state: true,
   stateLabel: true,
@@ -3326,7 +3326,7 @@ function RepositoryIssueRow({
             reviewModel: repository.reviewModel,
             reviewThinkingLevel: repository.reviewThinkingLevel,
           }}
-          initialAutoMerge={repository.mergePolicy !== "OFF"}
+          initialMergePolicy={repository.mergePolicy}
           submitPending={implementWith.isPending}
           submitError={
             implementWith.isError

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -48,7 +48,7 @@ export type ImplementWithDialogProps = {
   readonly initialDraft: ExecutionProfileDraft
   readonly catalog: ImplementWithCatalog
   readonly prefsError?: string | null
-  readonly initialAutoMerge: boolean
+  readonly initialMergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
   readonly submitPending: boolean
   readonly submitError: string | null
   readonly onSubmit: (input: ImplementWithSubmitInput) => void
@@ -127,7 +127,7 @@ export function ImplementWithDialog({
   initialDraft,
   catalog,
   prefsError = null,
-  initialAutoMerge,
+  initialMergePolicy,
   submitPending,
   submitError,
   onSubmit,
@@ -141,7 +141,7 @@ export function ImplementWithDialog({
       models: catalog.models,
     }),
   )
-  const [autoMerge, setAutoMerge] = useState(initialAutoMerge)
+  const [mergePolicy, setMergePolicy] = useState(initialMergePolicy)
   const [implementLocally, setImplementLocally] = useState(false)
   const titleId = `implement-with-title-${issueNumber}`
   const backendLabel =
@@ -267,7 +267,7 @@ export function ImplementWithDialog({
         draft,
       }),
       options: {
-        autoMerge,
+        mergePolicy,
         implementLocally,
       },
     })
@@ -546,20 +546,33 @@ export function ImplementWithDialog({
               </h3>
               <span className={ui.dialogSectionMeta}>This Work Item</span>
             </div>
-            <label className={ui.dialogCheck}>
-              <input
-                type="checkbox"
-                className={ui.dialogCheckInput}
-                name="autoMerge"
-                checked={autoMerge}
+            <label className={ui.dialogField}>
+              Merge Policy
+              <select
+                name="mergePolicy"
+                className={ui.dialogInput}
+                value={mergePolicy}
                 disabled={submitPending}
-                onChange={(event) => setAutoMerge(event.target.checked)}
-              />
-              Auto-merge
-              <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
-                Permit risk-assessed Auto-merge for this Work Item. Unchecked
-                requires a human merge even if Repository Auto-merge later
-                changes.
+                onChange={(event) => {
+                  const next = event.target.value
+                  if (
+                    next === "OFF" ||
+                    next === "CLASSIFY" ||
+                    next === "ALWAYS"
+                  ) {
+                    setMergePolicy(next)
+                  }
+                }}
+              >
+                <option value="OFF">Off — human merge</option>
+                <option value="CLASSIFY">Classify — risk-assessed merge</option>
+                <option value="ALWAYS">Always — skip classify</option>
+              </select>
+              <span className={ui.dialogFieldHint}>
+                Off requires a human merge. Classify runs Decide PR Merge.
+                Always skips Classify and treats missing CI as green after the
+                Check-Start Deadline. This pin stays on the Work Item even if
+                Repository Merge Policy later changes.
               </span>
             </label>
             <label className={ui.dialogCheck}>

--- a/apps/harness/src/implement-with-issue-dialog.tsx
+++ b/apps/harness/src/implement-with-issue-dialog.tsx
@@ -37,7 +37,7 @@ export type ImplementWithIssueDialogProps = {
   readonly repositoryId: string
   readonly initialBackendId: string
   readonly repositoryPrefs: ExecutionProfilePrefSource
-  readonly initialAutoMerge: boolean
+  readonly initialMergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
   readonly submitPending: boolean
   readonly submitError: string | null
   readonly onSubmit: (input: ImplementWithSubmitInput) => void
@@ -54,7 +54,7 @@ export function ImplementWithIssueDialog({
   repositoryId,
   initialBackendId,
   repositoryPrefs,
-  initialAutoMerge,
+  initialMergePolicy,
   submitPending,
   submitError,
   onSubmit,
@@ -251,7 +251,7 @@ export function ImplementWithIssueDialog({
       initialDraft={initialDraft}
       catalog={catalog}
       prefsError={prefsError}
-      initialAutoMerge={initialAutoMerge}
+      initialMergePolicy={initialMergePolicy}
       submitPending={submitPending}
       submitError={submitError}
       onSubmit={onSubmit}

--- a/apps/harness/src/pipeline-page.tsx
+++ b/apps/harness/src/pipeline-page.tsx
@@ -227,7 +227,7 @@ export function AddRepositoryGuidance({
           defaultThinkingLevel: true,
           reviewModel: true,
           reviewThinkingLevel: true,
-          autoMerge: true,
+          mergePolicy: true,
           includeAllIssueAuthors: true,
           waitForReadyForReviewChecks: true,
           issuesReconciledAt: true,

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -124,7 +124,7 @@ const baseProps = {
     reviewSameAsBuild: true as const,
   },
   catalog: readyCatalog,
-  initialAutoMerge: false,
+  initialMergePolicy: "OFF",
   submitPending: false,
   submitError: null,
   onSubmit: () => undefined,
@@ -150,23 +150,31 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).not.toContain("Recheck")
     expect(html).not.toContain('href="/settings"')
     expect(html).not.toContain("<datalist")
-    expect(html).toContain('name="autoMerge"')
+    expect(html).toContain('name="mergePolicy"')
+    expect(html).toContain("Off — human merge")
+    expect(html).toContain("Classify — risk-assessed merge")
+    expect(html).toContain("Always — skip classify")
     expect(html).toContain('name="implementLocally"')
     expect(html).toContain("inspect the worktree")
+    expect(html).not.toContain("Auto-merge")
   })
 
-  test("initializes Auto-merge from the Repository setting and Implement locally to false", () => {
-    const disabled = renderToStaticMarkup(
-      <ImplementWithDialog {...baseProps} initialAutoMerge={false} />,
+  test("prefills Merge Policy from the live Repository and Implement locally to false", () => {
+    const off = renderToStaticMarkup(
+      <ImplementWithDialog {...baseProps} initialMergePolicy="OFF" />,
     )
-    expect(disabled).toContain('name="autoMerge"')
-    expect(disabled).not.toMatch(/name="autoMerge"[^>]*checked/)
-    expect(disabled).not.toMatch(/name="implementLocally"[^>]*checked/)
-    const enabled = renderToStaticMarkup(
-      <ImplementWithDialog {...baseProps} initialAutoMerge={true} />,
+    expect(off).toContain('name="mergePolicy"')
+    expect(off).toContain('value="OFF" selected=""')
+    expect(off).not.toMatch(/name="implementLocally"[^>]*checked/)
+    const classify = renderToStaticMarkup(
+      <ImplementWithDialog {...baseProps} initialMergePolicy="CLASSIFY" />,
     )
-    expect(enabled).toMatch(/name="autoMerge"[^>]*checked/)
-    expect(enabled).not.toMatch(/name="implementLocally"[^>]*checked/)
+    expect(classify).toContain('value="CLASSIFY" selected=""')
+    expect(classify).not.toMatch(/name="implementLocally"[^>]*checked/)
+    const always = renderToStaticMarkup(
+      <ImplementWithDialog {...baseProps} initialMergePolicy="ALWAYS" />,
+    )
+    expect(always).toContain('value="ALWAYS" selected=""')
   })
 
   test("starts from pre-filled build values and Same as build", () => {
@@ -287,9 +295,9 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).toContain('value="high"')
     expect(html).toContain(">Same as build</option>")
     expect(html).not.toMatch(/type="submit"[^>]*\sdisabled=/)
-    expect(html).toMatch(/name="autoMerge"/)
+    expect(html).toMatch(/name="mergePolicy"/)
     expect(html).toMatch(/name="implementLocally"/)
-    expect(html).not.toMatch(/name="autoMerge"[^>]*checked/)
+    expect(html).toContain('value="OFF" selected=""')
     expect(html).not.toMatch(/name="implementLocally"[^>]*checked/)
   })
 
@@ -516,6 +524,17 @@ describe("ImplementWithDialog interaction", () => {
     return select as HTMLSelectElement
   }
 
+  test("submitting the prefilled Merge Policy always writes that pin", () => {
+    const { node, submitted } = render({ initialMergePolicy: "ALWAYS" })
+    flushSync(() => {
+      fire(node.querySelector("form"), "submit")
+    })
+    expect(submitted.at(-1)?.options).toEqual({
+      mergePolicy: "ALWAYS",
+      implementLocally: false,
+    })
+  })
+
   test("submitting unchanged pre-filled values still creates an explicit profile", () => {
     const { node, submitted } = render()
     const form = node.querySelector("form")
@@ -532,7 +551,7 @@ describe("ImplementWithDialog interaction", () => {
           reviewModel: null,
           reviewThinkingLevel: null,
         },
-        options: { autoMerge: false, implementLocally: false },
+        options: { mergePolicy: "OFF", implementLocally: false },
       },
     ])
   })
@@ -562,7 +581,7 @@ describe("ImplementWithDialog interaction", () => {
         reviewModel: "haiku",
         reviewThinkingLevel: "low",
       },
-      options: { autoMerge: false, implementLocally: false },
+      options: { mergePolicy: "OFF", implementLocally: false },
     })
   })
 
@@ -580,7 +599,7 @@ describe("ImplementWithDialog interaction", () => {
     expect(submitted.at(-1)?.profile.buildThinkingLevel).toBeNull()
   })
 
-  test("pending submission disables Implement, Cancel, and the option checkboxes", () => {
+  test("pending submission disables Implement, Cancel, Merge Policy, and Implement locally", () => {
     const { node } = render({ submitPending: true })
     const implement = [...node.querySelectorAll("button")].find(
       (button) => button.textContent === "Starting...",
@@ -588,15 +607,15 @@ describe("ImplementWithDialog interaction", () => {
     const cancel = [...node.querySelectorAll("button")].find(
       (button) => button.textContent === "Cancel",
     )
-    const autoMerge = node.querySelector(
-      'input[name="autoMerge"]',
-    ) as HTMLInputElement | null
+    const mergePolicy = node.querySelector(
+      'select[name="mergePolicy"]',
+    ) as HTMLSelectElement | null
     const implementLocally = node.querySelector(
       'input[name="implementLocally"]',
     ) as HTMLInputElement | null
     expect(implement?.disabled).toBe(true)
     expect(cancel?.disabled).toBe(true)
-    expect(autoMerge?.disabled).toBe(true)
+    expect(mergePolicy?.disabled).toBe(true)
     expect(implementLocally?.disabled).toBe(true)
   })
 
@@ -677,7 +696,7 @@ describe("ImplementWithDialog interaction", () => {
         reviewModel: null,
         reviewThinkingLevel: null,
       },
-      options: { autoMerge: false, implementLocally: false },
+      options: { mergePolicy: "OFF", implementLocally: false },
     })
     rerender({
       backendId: "grok",
@@ -700,25 +719,26 @@ describe("ImplementWithDialog interaction", () => {
         reviewModel: null,
         reviewThinkingLevel: null,
       },
-      options: { autoMerge: false, implementLocally: false },
+      options: { mergePolicy: "OFF", implementLocally: false },
     })
   })
 
   test("toggling options does not change model drafts and survives backend switching", () => {
-    const { node, submitted, rerender } = render({ initialAutoMerge: true })
-    const autoMerge = node.querySelector(
-      'input[name="autoMerge"]',
-    ) as HTMLInputElement
+    const { node, submitted, rerender } = render({
+      initialMergePolicy: "CLASSIFY",
+    })
+    const mergePolicy = selectNamed(node, "mergePolicy")
     const implementLocally = node.querySelector(
       'input[name="implementLocally"]',
     ) as HTMLInputElement
-    expect(autoMerge.checked).toBe(true)
+    expect(mergePolicy.value).toBe("CLASSIFY")
     expect(implementLocally.checked).toBe(false)
     flushSync(() => {
-      toggleCheckbox(autoMerge, false)
+      mergePolicy.value = "OFF"
+      fire(mergePolicy, "change")
       toggleCheckbox(implementLocally, true)
     })
-    expect(autoMerge.checked).toBe(false)
+    expect(selectNamed(node, "mergePolicy").value).toBe("OFF")
     expect(implementLocally.checked).toBe(true)
     rerender({
       backendId: "grok",
@@ -728,12 +748,9 @@ describe("ImplementWithDialog interaction", () => {
         buildThinkingLevel: "low",
         reviewSameAsBuild: true,
       },
-      initialAutoMerge: true,
+      initialMergePolicy: "CLASSIFY",
     })
-    expect(
-      (node.querySelector('input[name="autoMerge"]') as HTMLInputElement)
-        .checked,
-    ).toBe(false)
+    expect(selectNamed(node, "mergePolicy").value).toBe("OFF")
     expect(
       (node.querySelector('input[name="implementLocally"]') as HTMLInputElement)
         .checked,
@@ -742,7 +759,7 @@ describe("ImplementWithDialog interaction", () => {
       fire(node.querySelector("form"), "submit")
     })
     expect(submitted.at(-1)?.options).toEqual({
-      autoMerge: false,
+      mergePolicy: "OFF",
       implementLocally: true,
     })
     rerender({
@@ -754,29 +771,28 @@ describe("ImplementWithDialog interaction", () => {
         warnings: [],
       },
     })
-    expect(
-      (node.querySelector('input[name="autoMerge"]') as HTMLInputElement)
-        .checked,
-    ).toBe(false)
+    expect(selectNamed(node, "mergePolicy").value).toBe("OFF")
     expect(
       (node.querySelector('input[name="implementLocally"]') as HTMLInputElement)
         .checked,
     ).toBe(true)
   })
 
-  test("reopening restores Auto-merge from the current Repository value", () => {
+  test("reopening restores Merge Policy from the live Repository value", () => {
     const first = renderToStaticMarkup(
-      <ImplementWithDialog {...baseProps} initialAutoMerge={true} />,
+      <ImplementWithDialog {...baseProps} initialMergePolicy="ALWAYS" />,
     )
-    expect(first).toMatch(/name="autoMerge"[^>]*checked/)
+    expect(first).toContain('name="mergePolicy"')
+    expect(first).toContain('value="ALWAYS" selected=""')
     const second = renderToStaticMarkup(
-      <ImplementWithDialog {...baseProps} initialAutoMerge={false} />,
+      <ImplementWithDialog {...baseProps} initialMergePolicy="OFF" />,
     )
-    expect(second).not.toMatch(/name="autoMerge"[^>]*checked/)
+    expect(second).toContain('name="mergePolicy"')
+    expect(second).toContain('value="OFF" selected=""')
     expect(second).not.toMatch(/name="implementLocally"[^>]*checked/)
   })
 
-  test("catalog pinning does not reset Auto-merge or Implement locally", () => {
+  test("catalog pinning does not reset Merge Policy or Implement locally", () => {
     const firstReady = {
       kind: "READY",
       models: catalogModels,
@@ -793,7 +809,7 @@ describe("ImplementWithDialog interaction", () => {
       previewFailed: false,
       pin,
     })
-    const { node, rerender } = render({ initialAutoMerge: true })
+    const { node, rerender } = render({ initialMergePolicy: "ALWAYS" })
     const implementLocally = node.querySelector(
       'input[name="implementLocally"]',
     ) as HTMLInputElement
@@ -809,10 +825,7 @@ describe("ImplementWithDialog interaction", () => {
         warnings: [],
       },
     })
-    expect(
-      (node.querySelector('input[name="autoMerge"]') as HTMLInputElement)
-        .checked,
-    ).toBe(true)
+    expect(selectNamed(node, "mergePolicy").value).toBe("ALWAYS")
     expect(
       (node.querySelector('input[name="implementLocally"]') as HTMLInputElement)
         .checked,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -47,6 +47,7 @@ import {
   WorkItemLifecycle,
   type WorkItemRecord,
   type WorkItemsListKind,
+  decodeWorkItemMergePolicy,
   filterWorkItemsByListKind,
   isJobsCompletedWorkItemState,
   isJobsWorkingWorkItem,
@@ -393,7 +394,7 @@ type ImplementWithArgs = ImplementNowArgs & {
     readonly reviewThinkingLevel?: string | null
   }
   options?: {
-    readonly autoMerge: boolean
+    readonly mergePolicy: GraphqlMergePolicy
     readonly implementLocally: boolean
   } | null
 }
@@ -1246,6 +1247,13 @@ export const createGraphqlApi = <R>(
             toGraphqlBackend(resolveWorkItemBackend(workItem.agentBackend)),
           mergeMode: (workItem: { mergeMode: string }) =>
             workItem.mergeMode.toUpperCase(),
+          mergePolicy: (workItem: WorkItemRecord) => {
+            const pin = decodeWorkItemMergePolicy({
+              workItemMergeMode: workItem.mergeMode,
+              workItemAutoMergeOverride: workItem.autoMergeOverride,
+            })
+            return pin === null ? null : toGraphqlMergePolicy(pin)
+          },
           executionProfile: (workItem: WorkItemRecord) => {
             const profile = workItem.executionProfile
             if (profile === null || profile === undefined) return null
@@ -1261,8 +1269,6 @@ export const createGraphqlApi = <R>(
               reviewThinkingLevel: selection.reviewThinkingLevel,
             }
           },
-          autoMergeOverride: (workItem: WorkItemRecord) =>
-            workItem.autoMergeOverride ?? null,
           pauseBeforeStep: (workItem: WorkItemRecord) =>
             workItem.pauseBeforeStep == null
               ? null
@@ -2111,7 +2117,9 @@ export const createGraphqlApi = <R>(
                   args.options === undefined || args.options === null
                     ? undefined
                     : {
-                        autoMerge: args.options.autoMerge,
+                        mergePolicy: fromGraphqlMergePolicy(
+                          args.options.mergePolicy,
+                        ),
                         implementLocally: args.options.implementLocally,
                       },
                 )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -4572,6 +4572,7 @@ describe("GraphQL API", () => {
           expect(options).toBeUndefined()
           return Effect.succeed({
             ...profiled,
+            mergeMode: "ordinary" as const,
             autoMergeOverride: null,
             pauseBeforeStep: null,
           })
@@ -4599,7 +4600,8 @@ describe("GraphQL API", () => {
               reviewModel
               reviewThinkingLevel
             }
-            autoMergeOverride
+            mergePolicy
+            mergeMode
             pauseBeforeStep
           }
         }`,
@@ -4627,14 +4629,64 @@ describe("GraphQL API", () => {
             reviewModel: "build-model",
             reviewThinkingLevel: "high",
           },
-          autoMergeOverride: null,
+          mergePolicy: null,
+          mergeMode: "ORDINARY",
           pauseBeforeStep: null,
         },
       },
     })
   })
 
-  test("implementWith forwards concrete options for both boolean values", async () => {
+  test("implementWith no longer exposes autoMerge or autoMergeOverride", async () => {
+    const unknownOptions = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation ImplementWith(
+          $repositoryId: ID!
+          $issueNumber: Int!
+          $profile: ExplicitWorkItemExecutionProfileInput!
+          $options: ImplementWithOptionsInput
+        ) {
+          implementWith(
+            repositoryId: $repositoryId
+            issueNumber: $issueNumber
+            profile: $profile
+            options: $options
+          ) { id }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+          profile: {
+            agentBackendId: "opencode",
+            buildModel: "build-model",
+            reviewSameAsBuild: true,
+          },
+          options: { autoMerge: true, implementLocally: false },
+        },
+      }),
+    )
+    const unknownOptionsPayload = (await unknownOptions.json()) as {
+      errors?: ReadonlyArray<{ message: string }>
+    }
+    expect(unknownOptionsPayload.errors?.[0]?.message).toMatch(/autoMerge/)
+
+    const unknownField = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!) {
+          workItems(repositoryId: $repositoryId) { autoMergeOverride }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+    const unknownFieldPayload = (await unknownField.json()) as {
+      errors?: ReadonlyArray<{ message: string }>
+    }
+    expect(unknownFieldPayload.errors?.[0]?.message).toMatch(
+      /autoMergeOverride/,
+    )
+  })
+
+  test("implementWith forwards a concrete Merge Policy pin", async () => {
     const profiled = {
       ...workItem,
       executionProfile: {
@@ -4642,6 +4694,7 @@ describe("GraphQL API", () => {
         build: { model: "build-model", thinkingLevel: null },
         review: { kind: "same_as_build" as const },
       },
+      mergeMode: "ordinary" as const,
       autoMergeOverride: true,
       pauseBeforeStep: "commit",
     } as WorkItemRecord
@@ -4653,7 +4706,7 @@ describe("GraphQL API", () => {
       {
         implementWith: (_repositoryId, _issueNumber, _profile, options) => {
           expect(options).toEqual({
-            autoMerge: true,
+            mergePolicy: "classify",
             implementLocally: true,
           })
           return Effect.succeed(profiled)
@@ -4674,7 +4727,8 @@ describe("GraphQL API", () => {
             profile: $profile
             options: $options
           ) {
-            autoMergeOverride
+            mergePolicy
+            mergeMode
             pauseBeforeStep
           }
         }`,
@@ -4686,21 +4740,22 @@ describe("GraphQL API", () => {
             buildModel: "build-model",
             reviewSameAsBuild: true,
           },
-          options: { autoMerge: true, implementLocally: true },
+          options: { mergePolicy: "CLASSIFY", implementLocally: true },
         },
       }),
     )
     expect(await response.json()).toEqual({
       data: {
         implementWith: {
-          autoMergeOverride: true,
+          mergePolicy: "CLASSIFY",
+          mergeMode: "ORDINARY",
           pauseBeforeStep: "COMMIT",
         },
       },
     })
   })
 
-  test("implementWith projects a false Auto-merge override without a pause target", async () => {
+  test("implementWith projects an always pin as Merge Mode Always", async () => {
     const profiled = {
       ...workItem,
       executionProfile: {
@@ -4708,7 +4763,8 @@ describe("GraphQL API", () => {
         build: { model: "build-model", thinkingLevel: null },
         review: { kind: "same_as_build" as const },
       },
-      autoMergeOverride: false,
+      mergeMode: "always" as const,
+      autoMergeOverride: null,
       pauseBeforeStep: null,
     } as WorkItemRecord
     await runtime.dispose()
@@ -4719,7 +4775,7 @@ describe("GraphQL API", () => {
       {
         implementWith: (_repositoryId, _issueNumber, _profile, options) => {
           expect(options).toEqual({
-            autoMerge: false,
+            mergePolicy: "always",
             implementLocally: false,
           })
           return Effect.succeed(profiled)
@@ -4740,7 +4796,8 @@ describe("GraphQL API", () => {
             profile: $profile
             options: $options
           ) {
-            autoMergeOverride
+            mergePolicy
+            mergeMode
             pauseBeforeStep
           }
         }`,
@@ -4752,14 +4809,84 @@ describe("GraphQL API", () => {
             buildModel: "build-model",
             reviewSameAsBuild: true,
           },
-          options: { autoMerge: false, implementLocally: false },
+          options: { mergePolicy: "ALWAYS", implementLocally: false },
         },
       }),
     )
     expect(await response.json()).toEqual({
       data: {
         implementWith: {
-          autoMergeOverride: false,
+          mergePolicy: "ALWAYS",
+          mergeMode: "ALWAYS",
+          pauseBeforeStep: null,
+        },
+      },
+    })
+  })
+
+  test("implementWith projects an off pin without a pause target", async () => {
+    const profiled = {
+      ...workItem,
+      executionProfile: {
+        agentBackend: "opencode",
+        build: { model: "build-model", thinkingLevel: null },
+        review: { kind: "same_as_build" as const },
+      },
+      mergeMode: "ordinary" as const,
+      autoMergeOverride: false,
+      pauseBeforeStep: null,
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        implementWith: (_repositoryId, _issueNumber, _profile, options) => {
+          expect(options).toEqual({
+            mergePolicy: "off",
+            implementLocally: false,
+          })
+          return Effect.succeed(profiled)
+        },
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation ImplementWith(
+          $repositoryId: ID!
+          $issueNumber: Int!
+          $profile: ExplicitWorkItemExecutionProfileInput!
+          $options: ImplementWithOptionsInput
+        ) {
+          implementWith(
+            repositoryId: $repositoryId
+            issueNumber: $issueNumber
+            profile: $profile
+            options: $options
+          ) {
+            mergePolicy
+            mergeMode
+            pauseBeforeStep
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+          profile: {
+            agentBackendId: "opencode",
+            buildModel: "build-model",
+            reviewSameAsBuild: true,
+          },
+          options: { mergePolicy: "OFF", implementLocally: false },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        implementWith: {
+          mergePolicy: "OFF",
+          mergeMode: "ORDINARY",
           pauseBeforeStep: null,
         },
       },
@@ -7458,7 +7585,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `mutation ImplementAllWithAutoMerge($repositoryId: ID!, $issueNumber: Int!) {
           implementAllWithAutoMerge(repositoryId: $repositoryId, issueNumber: $issueNumber) {
-            id issueNumber mergeMode state status statusLabel
+            id issueNumber mergeMode mergePolicy state status statusLabel
           }
         }`,
         variables: {
@@ -7475,6 +7602,7 @@ describe("GraphQL API", () => {
             id: actionableChild.id,
             issueNumber: 43,
             mergeMode: "ALWAYS",
+            mergePolicy: "ALWAYS",
             state: "CREATE_WORKTREE",
             status: "RUNNING",
             statusLabel: "Running",
@@ -7483,6 +7611,7 @@ describe("GraphQL API", () => {
             id: blockedChild.id,
             issueNumber: 44,
             mergeMode: "ALWAYS",
+            mergePolicy: "ALWAYS",
             state: "CREATE_WORKTREE",
             status: "WAITING_FOR_BLOCKERS",
             statusLabel: "Waiting for blockers",

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -203,15 +203,16 @@ input ExplicitWorkItemExecutionProfileInput {
 
 """
 Implement With options, separate from the Explicit Work Item Execution Profile.
-Omission keeps repository-inherited Auto-merge and the remote path. The Harness
-dialog always submits both concrete checkbox values.
+Omission leaves Work Item Merge Policy unset and keeps the remote path. The
+Harness dialog always submits a concrete Merge Policy pin.
 """
 input ImplementWithOptionsInput {
   """
-  Concrete Work Item Auto-merge override. True permits risk-assessed Auto-merge
-  for this Work Item; false requires human merge. Distinct from Merge Mode Always.
+  Concrete Work Item Merge Policy pin. OFF requires a human merge, CLASSIFY
+  runs Decide PR Merge, ALWAYS skips Classify. Survives later Repository
+  Merge Policy flips.
   """
-  autoMerge: Boolean!
+  mergePolicy: MergePolicy!
   """
   When true, run through Review then pause before Commit (or Close Issue for a
   No-Change Outcome) so the operator can inspect the worktree.
@@ -880,9 +881,8 @@ enum MergePolicy {
 }
 
 """
-Durable Work Item merge policy.
-ORDINARY follows the live Repository Merge Policy and Decide PR Merge.
-ALWAYS skips Decide PR Merge after pre-merge checks settle.
+Derived skip-Decide signal. ALWAYS iff the Work Item Merge Policy pin is
+ALWAYS. ORDINARY covers an unset pin, OFF, and CLASSIFY.
 """
 enum MergeMode {
   ORDINARY
@@ -936,7 +936,8 @@ type WorkItem {
   """
   agentBackend: AgentBackendInfo!
   """
-  Durable merge policy for this Work Item.
+  Derived skip-Decide signal. ALWAYS iff the Work Item Merge Policy pin is
+  ALWAYS; otherwise ORDINARY (unset, OFF, or CLASSIFY).
   """
   mergeMode: MergeMode!
   """
@@ -945,11 +946,11 @@ type WorkItem {
   """
   executionProfile: WorkItemExecutionProfile
   """
-  Work Item Auto-merge override. Null follows the live Repository Merge
-  Policy. True permits risk-assessed Classify; false requires human merge.
-  Distinct from Merge Mode Always.
+  Work Item Merge Policy pin. Null inherits the live Repository Merge Policy
+  at merge-routing time. A concrete pin is the effective policy regardless of
+  later Repository flips.
   """
-  autoMergeOverride: Boolean
+  mergePolicy: MergePolicy
   """
   When set, successful advancement into this Lifecycle Step pauses the Work
   Item so the operator can inspect local work.

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -200,15 +200,16 @@ input ExplicitWorkItemExecutionProfileInput {
 
 """
 Implement With options, separate from the Explicit Work Item Execution Profile.
-Omission keeps repository-inherited Auto-merge and the remote path. The Harness
-dialog always submits both concrete checkbox values.
+Omission leaves Work Item Merge Policy unset and keeps the remote path. The
+Harness dialog always submits a concrete Merge Policy pin.
 """
 input ImplementWithOptionsInput {
   """
-  Concrete Work Item Auto-merge override. True permits risk-assessed Auto-merge
-  for this Work Item; false requires human merge. Distinct from Merge Mode Always.
+  Concrete Work Item Merge Policy pin. OFF requires a human merge, CLASSIFY
+  runs Decide PR Merge, ALWAYS skips Classify. Survives later Repository
+  Merge Policy flips.
   """
-  autoMerge: Boolean!
+  mergePolicy: MergePolicy!
   """
   When true, run through Review then pause before Commit (or Close Issue for a
   No-Change Outcome) so the operator can inspect the worktree.
@@ -858,9 +859,8 @@ enum MergePolicy {
 }
 
 """
-Durable Work Item merge policy.
-ORDINARY follows the live Repository Merge Policy and Decide PR Merge.
-ALWAYS skips Decide PR Merge after pre-merge checks settle.
+Derived skip-Decide signal. ALWAYS iff the Work Item Merge Policy pin is
+ALWAYS. ORDINARY covers an unset pin, OFF, and CLASSIFY.
 """
 enum MergeMode {
   ORDINARY
@@ -914,7 +914,8 @@ type WorkItem {
   """
   agentBackend: AgentBackendInfo!
   """
-  Durable merge policy for this Work Item.
+  Derived skip-Decide signal. ALWAYS iff the Work Item Merge Policy pin is
+  ALWAYS; otherwise ORDINARY (unset, OFF, or CLASSIFY).
   """
   mergeMode: MergeMode!
   """
@@ -923,11 +924,11 @@ type WorkItem {
   """
   executionProfile: WorkItemExecutionProfile
   """
-  Work Item Auto-merge override. Null follows the live Repository Merge
-  Policy. True permits risk-assessed Classify; false requires human merge.
-  Distinct from Merge Mode Always.
+  Work Item Merge Policy pin. Null inherits the live Repository Merge Policy
+  at merge-routing time. A concrete pin is the effective policy regardless of
+  later Repository flips.
   """
-  autoMergeOverride: Boolean
+  mergePolicy: MergePolicy
   """
   When set, successful advancement into this Lifecycle Step pauses the Work
   Item so the operator can inspect local work.

--- a/packages/work-item-lifecycle/src/lib/execution-profile.ts
+++ b/packages/work-item-lifecycle/src/lib/execution-profile.ts
@@ -1,4 +1,5 @@
 import { InvalidExecutionProfileError } from "./errors.js"
+import type { MergePolicy } from "./merge-policy.js"
 import type { AgentModelSelection } from "./resolve-agent-models.js"
 
 /** Review selection stored as intent, not only resolved values. */
@@ -35,23 +36,22 @@ export type ImplementWithProfileInput = {
 }
 
 /**
- * Separate Implement With options. Omission keeps repository-inherited
- * Auto-merge and the remote path. Concrete values persist a Work Item
- * Auto-merge override and optional local inspection pause.
+ * Separate Implement With options. Omission leaves Work Item Merge Policy
+ * unset (inherit) and keeps the remote path. A concrete `mergePolicy` is
+ * a durable pin; Implement Locally is an optional inspection pause.
  */
 export type ImplementWithOptionsInput = {
-  readonly autoMerge?: boolean
+  readonly mergePolicy?: MergePolicy
   readonly implementLocally?: boolean
 }
 
 export const decodeImplementWithOptions = (
   options?: ImplementWithOptionsInput,
 ): {
-  readonly autoMergeOverride: boolean | null
+  readonly mergePolicy: MergePolicy | null
   readonly implementLocally: boolean
 } => ({
-  autoMergeOverride:
-    options?.autoMerge === undefined ? null : options.autoMerge,
+  mergePolicy: options?.mergePolicy ?? null,
   implementLocally: options?.implementLocally === true,
 })
 

--- a/packages/work-item-lifecycle/src/lib/merge-policy.ts
+++ b/packages/work-item-lifecycle/src/lib/merge-policy.ts
@@ -19,18 +19,17 @@ export const decodeWorkItemAutoMergeOverride = (
   value === null || value === undefined ? null : Boolean(value)
 
 /**
- * Effective Merge Policy at merge-routing time.
- * A concrete pin wins; an unset pin inherits the live Repository policy.
+ * Decode the stored Merge Mode + override columns as a Work Item Merge
+ * Policy pin. `null` means inherit the live Repository Merge Policy.
  *
  * Encoding: Merge Mode `always` = pin `always`; ordinary + override true =
  * pin `classify`; ordinary + override false = pin `off`; ordinary +
  * override null = unpinned.
  */
-export const resolveEffectiveMergePolicy = (input: {
-  readonly repositoryMergePolicy: MergePolicy
+export const decodeWorkItemMergePolicy = (input: {
   readonly workItemMergeMode: string | null | undefined
   readonly workItemAutoMergeOverride: boolean | number | null | undefined
-}): MergePolicy => {
+}): MergePolicy | null => {
   if (decodeMergeMode(input.workItemMergeMode) === "always") {
     return "always"
   }
@@ -43,8 +42,36 @@ export const resolveEffectiveMergePolicy = (input: {
   if (override === true) {
     return "classify"
   }
-  return input.repositoryMergePolicy
+  return null
 }
+
+/** Persist a concrete Work Item Merge Policy pin in the existing columns. */
+export const encodeWorkItemMergePolicyPin = (
+  pin: MergePolicy,
+): {
+  readonly mergeMode: "ordinary" | "always"
+  readonly autoMergeOverride: boolean | null
+} => {
+  switch (pin) {
+    case "always":
+      return { mergeMode: "always", autoMergeOverride: null }
+    case "classify":
+      return { mergeMode: "ordinary", autoMergeOverride: true }
+    case "off":
+      return { mergeMode: "ordinary", autoMergeOverride: false }
+  }
+}
+
+/**
+ * Effective Merge Policy at merge-routing time.
+ * A concrete pin wins; an unset pin inherits the live Repository policy.
+ */
+export const resolveEffectiveMergePolicy = (input: {
+  readonly repositoryMergePolicy: MergePolicy
+  readonly workItemMergeMode: string | null | undefined
+  readonly workItemAutoMergeOverride: boolean | number | null | undefined
+}): MergePolicy =>
+  decodeWorkItemMergePolicy(input) ?? input.repositoryMergePolicy
 
 export const nextStateAfterReadyForMerge = (
   policy: MergePolicy,

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -71,9 +71,9 @@ export const StepRunStatus = Schema.Literals([
 export type StepRunStatus = typeof StepRunStatus.Type
 
 /**
- * Durable Work Item merge policy.
- * `ordinary` follows Repository Auto-merge and Decide PR Merge.
- * `always` skips Decide PR Merge after pre-merge lifecycle settles.
+ * Derived skip-Decide signal for a Work Item Merge Policy pin.
+ * `always` iff the pin is `always`; `ordinary` covers unset, `off`, and
+ * `classify`.
  */
 export const MergeMode = Schema.Literals(["ordinary", "always"])
 export type MergeMode = typeof MergeMode.Type
@@ -147,12 +147,15 @@ export interface WorkItemRecord {
    */
   readonly waitingForBlockers: boolean
   /**
-   * Durable merge policy. `always` skips Decide PR Merge; `ordinary` does not.
+   * Derived skip-Decide signal. `always` iff the Work Item Merge Policy pin
+   * is `always`; otherwise `ordinary`.
    */
   readonly mergeMode: MergeMode
   /**
-   * Work Item Auto-merge override. Null follows the live Repository
-   * Auto-merge setting; true/false is a concrete Decide PR Merge policy.
+   * Storage encoding of a Work Item Merge Policy pin together with
+   * `mergeMode`. Null with ordinary Merge Mode means inherit; true is
+   * pin `classify`; false is pin `off`. Merge Mode `always` is pin
+   * `always` regardless of this field.
    */
   readonly autoMergeOverride: boolean | null
   /** Whether this Work Item currently occupies a Worker Slot (Admitted). */

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -117,6 +117,7 @@ import {
   decodeMergeMode,
   decodeMergePolicy,
   decodeWorkItemAutoMergeOverride,
+  encodeWorkItemMergePolicyPin,
   isAlwaysNoChecksCarveOut,
   isAutonomousMergePolicy,
   nextStateAfterReadyForMerge,
@@ -7200,10 +7201,18 @@ export const makeWorkItemLifecycleLive = (
             return yield* decoded
           }
           const options = decodeImplementWithOptions(optionsInput)
+          const pin =
+            options.mergePolicy === null
+              ? {
+                  mergeMode: "ordinary" as const,
+                  autoMergeOverride: null,
+                }
+              : encodeWorkItemMergePolicyPin(options.mergePolicy)
           return yield* createWorkItem(repositoryId, issueNumber, {
             pauseBeforeStep: options.implementLocally ? "commit" : null,
             executionProfile: decoded,
-            autoMergeOverride: options.autoMergeOverride,
+            mergeMode: pin.mergeMode,
+            autoMergeOverride: pin.autoMergeOverride,
           })
         },
       )

--- a/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
+++ b/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
@@ -11,6 +11,8 @@ import {
 import {
   type LifecycleStepContext,
   decidePrMerge,
+  decodeWorkItemMergePolicy,
+  encodeWorkItemMergePolicyPin,
   makeWorkItemId,
   parseDecidePrMergeResult,
   resolveEffectiveMergePolicy,
@@ -100,6 +102,55 @@ describe("parseDecidePrMergeResult", () => {
         "READY_FOR_AGENT_RESULT: CLANKER_MERGE\nAdditional output",
       ),
     ).toBeNull()
+  })
+})
+
+describe("decodeWorkItemMergePolicy", () => {
+  it("decodes existing overrides and Merge Mode Always as classify / off / inherit / always", () => {
+    expect(
+      decodeWorkItemMergePolicy({
+        workItemMergeMode: "ordinary",
+        workItemAutoMergeOverride: true,
+      }),
+    ).toBe("classify")
+    expect(
+      decodeWorkItemMergePolicy({
+        workItemMergeMode: "ordinary",
+        workItemAutoMergeOverride: false,
+      }),
+    ).toBe("off")
+    expect(
+      decodeWorkItemMergePolicy({
+        workItemMergeMode: "ordinary",
+        workItemAutoMergeOverride: null,
+      }),
+    ).toBeNull()
+    expect(
+      decodeWorkItemMergePolicy({
+        workItemMergeMode: "always",
+        workItemAutoMergeOverride: null,
+      }),
+    ).toBe("always")
+    expect(
+      decodeWorkItemMergePolicy({
+        workItemMergeMode: "always",
+        workItemAutoMergeOverride: false,
+      }),
+    ).toBe("always")
+  })
+})
+
+describe("encodeWorkItemMergePolicyPin", () => {
+  it("encodes each pin so decode recovers it", () => {
+    for (const pin of ["always", "classify", "off"] as const) {
+      const encoded = encodeWorkItemMergePolicyPin(pin)
+      expect(
+        decodeWorkItemMergePolicy({
+          workItemMergeMode: encoded.mergeMode,
+          workItemAutoMergeOverride: encoded.autoMergeOverride,
+        }),
+      ).toBe(pin)
+    }
   })
 })
 

--- a/packages/work-item-lifecycle/test/execution-profile.spec.ts
+++ b/packages/work-item-lifecycle/test/execution-profile.spec.ts
@@ -101,32 +101,41 @@ describe("decodeImplementWithProfile", () => {
 describe("decodeImplementWithOptions", () => {
   it("treats omitted options as repository-inherited remote behavior", () => {
     expect(decodeImplementWithOptions()).toEqual({
-      autoMergeOverride: null,
+      mergePolicy: null,
       implementLocally: false,
     })
     expect(decodeImplementWithOptions({})).toEqual({
-      autoMergeOverride: null,
+      mergePolicy: null,
       implementLocally: false,
     })
   })
 
-  it("persists concrete Auto-merge values and the local inspection pause", () => {
+  it("persists a concrete Merge Policy pin and the local inspection pause", () => {
     expect(
       decodeImplementWithOptions({
-        autoMerge: true,
+        mergePolicy: "classify",
         implementLocally: true,
       }),
     ).toEqual({
-      autoMergeOverride: true,
+      mergePolicy: "classify",
       implementLocally: true,
     })
     expect(
       decodeImplementWithOptions({
-        autoMerge: false,
+        mergePolicy: "off",
         implementLocally: false,
       }),
     ).toEqual({
-      autoMergeOverride: false,
+      mergePolicy: "off",
+      implementLocally: false,
+    })
+    expect(
+      decodeImplementWithOptions({
+        mergePolicy: "always",
+        implementLocally: false,
+      }),
+    ).toEqual({
+      mergePolicy: "always",
       implementLocally: false,
     })
   })

--- a/packages/work-item-lifecycle/test/implement-with.spec.ts
+++ b/packages/work-item-lifecycle/test/implement-with.spec.ts
@@ -656,6 +656,7 @@ describe("implementWith", () => {
           repo.id,
           9,
           sameAsBuildProfile,
+          { mergePolicy: "always", implementLocally: false },
         )
         const paused = yield* lifecycle.pause(created.id)
         expect(paused.executionProfile).toEqual({
@@ -663,8 +664,10 @@ describe("implementWith", () => {
           build: { model: "build-model", thinkingLevel: "high" },
           review: { kind: "same_as_build" },
         })
+        expect(paused.mergeMode).toBe("always")
         const started = yield* lifecycle.start(paused.id)
         expect(started.executionProfile).toEqual(paused.executionProfile)
+        expect(started.mergeMode).toBe("always")
         const queuedCreate = started.stepRuns.find(
           (run) => run.step === "create_worktree" && run.status === "queued",
         )
@@ -678,6 +681,7 @@ describe("implementWith", () => {
         expect(afterFail._tag).toBe("processed")
         const retried = yield* lifecycle.retry(created.id)
         expect(retried.executionProfile).toEqual(paused.executionProfile)
+        expect(retried.mergeMode).toBe("always")
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer(), failingInstall))),
     )
   })
@@ -783,13 +787,14 @@ describe("implementWith", () => {
           build: { model: "build-model", thinkingLevel: "high" },
           review: { kind: "same_as_build" },
         })
+        expect(waiter.mergeMode).toBe("ordinary")
         expect(waiter.autoMergeOverride).toBeNull()
         expect(waiter.pauseBeforeStep).toBeNull()
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
     )
   })
 
-  it("omitted options keep repository-inherited Auto-merge and the remote path", async () => {
+  it("omitted options leave Work Item Merge Policy unset and keep the remote path", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const db = yield* DbService
@@ -811,16 +816,18 @@ describe("implementWith", () => {
           20,
           sameAsBuildProfile,
         )
+        expect(created.mergeMode).toBe("ordinary")
         expect(created.autoMergeOverride).toBeNull()
         expect(created.pauseBeforeStep).toBeNull()
         const reloaded = yield* lifecycle.getWorkItem(created.id)
+        expect(reloaded.mergeMode).toBe("ordinary")
         expect(reloaded.autoMergeOverride).toBeNull()
         expect(reloaded.pauseBeforeStep).toBeNull()
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
     )
   })
 
-  it("persists a concrete Auto-merge override that can disagree with the Repository setting", async () => {
+  it("persists a concrete off pin that can disagree with the Repository Merge Policy", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const db = yield* DbService
@@ -852,18 +859,19 @@ describe("implementWith", () => {
           repo.id,
           21,
           sameAsBuildProfile,
-          { autoMerge: false, implementLocally: false },
+          { mergePolicy: "off", implementLocally: false },
         )
         expect(created.autoMergeOverride).toBe(false)
         expect(created.mergeMode).toBe("ordinary")
         expect(created.pauseBeforeStep).toBeNull()
         const reloaded = yield* lifecycle.getWorkItem(created.id)
         expect(reloaded.autoMergeOverride).toBe(false)
+        expect(reloaded.mergeMode).toBe("ordinary")
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
     )
   })
 
-  it("keeps a checked Auto-merge override after Repository Auto-merge is disabled", async () => {
+  it("keeps a classify pin after the Repository Merge Policy is turned off", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const db = yield* DbService
@@ -895,7 +903,7 @@ describe("implementWith", () => {
           repo.id,
           22,
           sameAsBuildProfile,
-          { autoMerge: true, implementLocally: false },
+          { mergePolicy: "classify", implementLocally: false },
         )
         yield* db.updateRepositorySettings({
           repositoryId: repo.id,
@@ -910,7 +918,51 @@ describe("implementWith", () => {
         })
         const reloaded = yield* lifecycle.getWorkItem(created.id)
         expect(reloaded.autoMergeOverride).toBe(true)
+        expect(reloaded.mergeMode).toBe("ordinary")
         expect(reloaded.executionProfile).toEqual(created.executionProfile)
+      }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+    )
+  })
+
+  it("persists an always pin that skips Classify even when the Repository is off", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          localPath: "/repos/acme/widgets-always-pin.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          defaultModel: null,
+          defaultThinkingLevel: null,
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          mergePolicy: "off",
+          includeAllIssueAuthors: false,
+          waitForReadyForReviewChecks: true,
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 25)
+        const created = yield* lifecycle.implementWith(
+          repo.id,
+          25,
+          sameAsBuildProfile,
+          { mergePolicy: "always", implementLocally: false },
+        )
+        expect(created.mergeMode).toBe("always")
+        expect(created.autoMergeOverride).toBeNull()
+        const reloaded = yield* lifecycle.getWorkItem(created.id)
+        expect(reloaded.mergeMode).toBe("always")
+        expect(reloaded.autoMergeOverride).toBeNull()
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
     )
   })
@@ -936,9 +988,10 @@ describe("implementWith", () => {
           repo.id,
           23,
           explicitReviewProfile,
-          { autoMerge: true, implementLocally: true },
+          { mergePolicy: "classify", implementLocally: true },
         )
         expect(created.executionProfile).not.toBeNull()
+        expect(created.mergeMode).toBe("ordinary")
         expect(created.autoMergeOverride).toBe(true)
         expect(created.pauseBeforeStep).toBe("commit")
         let stepRunId = created.stepRuns[0]!.id
@@ -977,6 +1030,7 @@ describe("implementWith", () => {
         expect(started.paused).toBe(false)
         expect(started.state).toBe("commit")
         expect(started.executionProfile).toEqual(created.executionProfile)
+        expect(started.mergeMode).toBe("ordinary")
         expect(started.autoMergeOverride).toBe(true)
         expect(started.stepRuns.at(-1)).toMatchObject({
           step: "commit",
@@ -1015,7 +1069,7 @@ describe("implementWith", () => {
           repo.id,
           24,
           sameAsBuildProfile,
-          { autoMerge: false, implementLocally: true },
+          { mergePolicy: "off", implementLocally: true },
         )
         const afterCreate = yield* advanceToQueued(
           lifecycle,
@@ -1047,6 +1101,7 @@ describe("implementWith", () => {
         expect(started.paused).toBe(false)
         expect(started.state).toBe("close_issue")
         expect(started.executionProfile).toEqual(created.executionProfile)
+        expect(started.mergeMode).toBe("ordinary")
         expect(started.autoMergeOverride).toBe(false)
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer(), noChangeSteps))),
     )

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -3055,6 +3055,75 @@ describe("WorkItemLifecycle", () => {
         )
       })
 
+      it("pin off requires a human even when the live Repository Merge Policy is always", async () => {
+        const steps: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () => Effect.succeed(watchResult("no_checks")),
+          mergePr: () =>
+            Effect.die("Merge PR must not run for a pinned off Work Item"),
+        }
+        const { afterWatch } = await runWatchToDeadline(
+          steps,
+          ({ repository, createdId }) =>
+            Effect.gen(function* () {
+              yield* setWorkItemAutoMergeOverride(createdId, false)
+              yield* setRepositoryMergePolicy(repository, "always")
+            }),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).toBe("decide_pr_merge")
+          expect(afterWatch.workItem.mergeMode).toBe("ordinary")
+          expect(afterWatch.workItem.autoMergeOverride).toBe(false)
+        }
+      })
+
+      it("pin classify runs Decide PR Merge even when the live Repository Merge Policy is always", async () => {
+        const steps: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () => Effect.succeed(watchResult("succeeded")),
+          mergePr: () =>
+            Effect.die("Merge PR must not run for a pinned classify Work Item"),
+        }
+        const { afterWatch } = await runWatchToDeadline(
+          steps,
+          ({ repository, createdId }) =>
+            Effect.gen(function* () {
+              yield* setWorkItemAutoMergeOverride(createdId, true)
+              yield* setRepositoryMergePolicy(repository, "always")
+            }),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).toBe("decide_pr_merge")
+          expect(afterWatch.workItem.mergeMode).toBe("ordinary")
+          expect(afterWatch.workItem.autoMergeOverride).toBe(true)
+        }
+      })
+
+      it("pin always skips Decide even when the live Repository Merge Policy is classify", async () => {
+        const steps: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () => Effect.succeed(watchResult("no_checks")),
+          decidePrMerge: () =>
+            Effect.die("Decide PR Merge must not run for a pinned Always"),
+          mergePr: () => Effect.succeed({ _tag: "merged" as const }),
+        }
+        const { afterWatch } = await runWatchToDeadline(
+          steps,
+          ({ repository, createdId }) =>
+            Effect.gen(function* () {
+              yield* setWorkItemMergeModeAlways(createdId)
+              yield* setRepositoryMergePolicy(repository, "classify")
+            }),
+        )
+        expect(afterWatch._tag).toBe("processed")
+        if (afterWatch._tag === "processed") {
+          expect(afterWatch.workItem.state).toBe("merge_pr")
+          expect(afterWatch.workItem.mergeMode).toBe("always")
+        }
+      })
+
       it("flipping live always to off does not revoke a Merge Mode Always pin", async () => {
         const steps: LifecycleStepsShape = {
           ...successfulSteps,


### PR DESCRIPTION
Repository settings already use three-state Merge Policy (`off` / `classify` /
`always`). Implement With still used a boolean Auto-merge checkbox, so a later
Repository flip could change work the operator had configured explicitly, and
Always was not an Implement With choice.

This change gives Implement With the same three-way control, prefilled from the
live Repository Merge Policy. Sending options always writes a concrete Work Item
Merge Policy pin; omitting options still inherits.

- GraphQL `ImplementWithOptionsInput` takes `mergePolicy: MergePolicy!` instead
  of `autoMerge`
- `WorkItem.mergePolicy` is nullable (`null` = inherit); `mergeMode` stays
  derived (`ALWAYS` only when the pin is `always`)
- Pins survive a later Repository flip: `off` stays human, `classify` still
  runs Decide, `always` still skips Classify
- Existing true / false / null overrides and Merge Mode Always decode as
  `classify` / `off` / inherit / `always`
- Implement All with Auto-merge still pins Always on create and adopt and does
  not clear a merge-related Needs Human
- Retry and Start keep the pin

Verified with Work Item lifecycle pin-routing tests, the GraphQL API suite, and
Implement With dialog tests (including selected-option prefill and encode/decode
round-trip). Completes the Implement With half of #1158 after Repository live
inherit.

Closes #1158