### PR TITLE
feat: preselect Workflows write on GitHub token creation links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Fine-grained GitHub PATs cannot call the Checks API (including GraphQL
 `statusCheckRollup.contexts`). That 403 is expected: the harness falls back to
 Actions jobs for terminal PR Status Check identity and downloads Actions job
 logs for Status Check Handoff diagnostics (`actions=write` for workflow
-reruns and job-log reads, `statuses=read`).
+reruns and job-log reads, `statuses=read`). Pushing or updating
+`.github/workflows/**` needs `workflows=write` (distinct from Actions write).
 
 ### Triage labels
 

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2651,9 +2651,15 @@ function RepositoryCard({
                         {repository.projectPath.split("/").at(-1)}
                       </code>
                       , and allow <strong>Actions: Read and write</strong>{" "}
-                      (required for workflow reruns and CI logs).
-                      Already-created tokens are not upgraded automatically —
-                      edit or recreate them if Actions is still read-only.
+                      (workflow reruns and CI logs) and{" "}
+                      <strong>Workflows: Read and write</strong> (required to
+                      push{" "}
+                      <code className={ui.guidanceCode}>
+                        .github/workflows/**
+                      </code>
+                      ). Already-created tokens are not upgraded automatically —
+                      edit or recreate them if Workflows is missing, then
+                      replace the secret in Keymaxxer.
                     </p>
                   )}
                   {addGitHubToken.isError ? (

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -133,6 +133,11 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(body).toContain("ui.platePrimary")
     expect(body).toContain("Create GitHub token")
     expect(body).toContain("Store in Keymaxxer")
+    expect(body).toContain("Actions: Read and write")
+    expect(body).toContain("Workflows: Read and write")
+    expect(body).toContain(
+      "Already-created tokens are not upgraded automatically",
+    )
     expect(body).toContain("ui.guidanceCode")
 
     const ui = uiSource()

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -152,7 +152,8 @@ offers the existing Create GitHub token / Store in Keymaxxer flow.
 ### Upgrade an existing GitHub token
 
 New repository token links preselect **Actions: Read and write** (workflow
-reruns and CI job logs), plus Issues, Contents, Pull requests (write), and
+reruns and CI job logs) and **Workflows: Read and write** (push or update
+`.github/workflows/**`), plus Issues, Contents, Pull requests (write), and
 Commit statuses (read). Already-created tokens are **not** upgraded
 automatically when the harness changes its requested permissions. Edit the
 fine-grained token on GitHub (or recreate it), then replace the secret in

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -49,10 +49,12 @@ const githubTokenCreationUrl = (repository: Repository) => {
   url.searchParams.set("issues", "write")
   url.searchParams.set("contents", "write")
   url.searchParams.set("pull_requests", "write")
-  // Actions write enables workflow reruns; read covers CI visibility and job logs.
+  // Actions write enables workflow reruns and job-log reads. Workflows write
+  // is a separate permission required to push `.github/workflows/**`.
   // Commit statuses help with CI visibility. Per-check CheckRun nodes need Checks
   // API access, which fine-grained PATs cannot grant — see AGENTS.md.
   url.searchParams.set("actions", "write")
+  url.searchParams.set("workflows", "write")
   url.searchParams.set("statuses", "read")
   return url.toString()
 }

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1381,6 +1381,7 @@ describe("GraphQL API", () => {
     expect(creationUrl.searchParams.get("contents")).toBe("write")
     expect(creationUrl.searchParams.get("pull_requests")).toBe("write")
     expect(creationUrl.searchParams.get("actions")).toBe("write")
+    expect(creationUrl.searchParams.get("workflows")).toBe("write")
     expect(creationUrl.searchParams.get("statuses")).toBe("read")
     expect(creationUrl.searchParams.get("checks")).toBeNull()
   })


### PR DESCRIPTION
Fine-grained PATs created from the harness previously omitted
`workflows=write`. `contents=write` and `actions=write` are not enough
to push `.github/workflows/**`; GitHub rejects those commits and the
Work Item lands on Status checks Needs Human (seen on
processfocus/monorepo #2479 / PR #2550). GitHub's own "Update code and
open a pull request" template already includes `workflows=write`.

## Changes

- Add `workflows=write` to `githubTokenCreationUrl` next to existing
  `actions=write`. Issues, Contents, Pull requests, and Statuses stay
  as they were; Checks remains unrequested.
- Assert `workflows=write` on the GraphQL `repositoryCredentials`
  creation URL (the product-contract seam from #1163).
- Update operator copy (repos banner, README upgrade section,
  AGENTS.md) so Actions write = reruns and job logs, and Workflows
  write = push/update `.github/workflows/**`.
- Spell out that already-created Keymaxxer tokens are not upgraded
  automatically.

## Verification

- `bunx nx test graphql-api` — 270 passed, including the creation-URL
  permission assertions.
- Harness `repos-interchange` banner-copy test passed.
- `bunx nx run-many -t typecheck lint -p graphql-api,harness` passed.
- Review of uncommitted changes: no findings.

## Limitations

- Existing vault tokens minted from the old URL still lack Workflows
  write until the operator edits or recreates the PAT on GitHub and
  replaces the Keymaxxer secret.
- This ticket does not add a live GitHub push of a workflow file, and
  does not rewrite the GitHub rejection as a credential-setup Needs
  Human reason.

Closes #1163