### PR TITLE
fix(lifecycle): treat high apply deferrals as unresolved without a repair turn

### DIFF
--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -310,6 +310,15 @@ const tryParseApplyReviewLine = (line: string): ApplyReviewResult | null => {
         reason: boundReason(fixedAndDeferred[2]),
       }
     }
+    // High is not a legal deferral, but the marker already states that
+    // high findings remain. Treat it as unresolved high instead of
+    // sending the apply-verdict through another repair turn.
+    if (parseSeverity(fixedAndDeferred[1]) === "high") {
+      return {
+        _tag: "unresolved_high",
+        reason: boundReason(fixedAndDeferred[2]),
+      }
+    }
   }
 
   const deferred = line.match(
@@ -325,6 +334,12 @@ const tryParseApplyReviewLine = (line: string): ApplyReviewResult | null => {
       return {
         _tag: "deferred",
         severity,
+        reason: boundReason(deferred[2]),
+      }
+    }
+    if (parseSeverity(deferred[1]) === "high") {
+      return {
+        _tag: "unresolved_high",
         reason: boundReason(deferred[2]),
       }
     }
@@ -357,6 +372,8 @@ const tryParseApplyReviewLine = (line: string): ApplyReviewResult | null => {
  * Parse the last valid READY_FOR_AGENT_RESULT marker from an apply-findings
  * pass, tolerating explanatory prose and other non-matching candidate lines.
  * Returns null only when no candidate line parses to a known marker.
+ * Recognized REVIEW_DEFERRED and REVIEW_FIXED_AND_DEFERRED lines whose
+ * severity argument is high are normalized to unresolved_high.
  */
 export const parseApplyReviewResult = (
   output: string,

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -328,6 +328,41 @@ describe("parseApplyReviewResult", () => {
     })
   })
 
+  it("normalizes recognized high-severity deferral shapes to unresolved high", () => {
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: cannot defer high",
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
+      reason: "cannot defer high",
+    })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: high: auth bypass remains",
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
+      reason: "auth bypass remains",
+    })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <high>: injection risk remains",
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
+      reason: "injection risk remains",
+    })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: <high>: <auth bypass remains>",
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
+      reason: "auth bypass remains",
+    })
+  })
+
   it("accepts enum and reason arguments wrapped in one pair of placeholder brackets", () => {
     expect(
       parseApplyReviewResult(
@@ -373,9 +408,22 @@ describe("parseApplyReviewResult", () => {
         "READY_FOR_AGENT_RESULT: REVIEW_FIXED\ntrailing prose",
       ),
     ).toEqual({ _tag: "fixed" })
+    expect(
+      parseApplyReviewResult(
+        [
+          "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+          "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: leftover",
+        ].join("\n"),
+      ),
+    ).toEqual({ _tag: "unresolved_high", reason: "leftover" })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: leftover\ntrailing prose",
+      ),
+    ).toEqual({ _tag: "unresolved_high", reason: "leftover" })
   })
 
-  it("rejects missing, blank, high-deferred, or reviewing-only markers", () => {
+  it("rejects missing, blank, invalid-severity, or reviewing-only markers", () => {
     expect(parseApplyReviewResult("no result line")).toBeNull()
     expect(
       parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED:"),
@@ -384,8 +432,21 @@ describe("parseApplyReviewResult", () => {
       parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low:"),
     ).toBeNull()
     expect(
+      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high:"),
+    ).toBeNull()
+    expect(
       parseApplyReviewResult(
-        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: cannot defer high",
+        "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: high:",
+      ),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: critical: leftover nits",
+      ),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: critical: leftover nits",
       ),
     ).toBeNull()
     expect(
@@ -415,6 +476,22 @@ describe("parseApplyReviewResult", () => {
     ).toEqual({
       _tag: "deferred",
       severity: "low",
+      reason: long.slice(0, 500),
+    })
+    expect(
+      parseApplyReviewResult(
+        `READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: ${long}`,
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
+      reason: long.slice(0, 500),
+    })
+    expect(
+      parseApplyReviewResult(
+        `READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: high: ${long}`,
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
       reason: long.slice(0, 500),
     })
     expect(
@@ -937,6 +1014,81 @@ describe("review", () => {
         reason: "injection risk remains",
       })
       expect(REVIEW_UNRESOLVED_HIGH_REASON).toContain("high-severity")
+    }))
+
+  it("returns Needs Human for REVIEW_DEFERRED high without a verdict-repair turn", () =>
+    withTemp(async (root) => {
+      const prompts: string[] = []
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continueTurn: (input) => {
+            prompts.push(input.prompt)
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                prompts.length === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: cannot defer high",
+            })
+          },
+        }),
+      )
+      expect(result).toEqual({
+        _tag: "needs_human",
+        reason: "cannot defer high",
+      })
+      expect(prompts).toHaveLength(2)
+      expect(
+        prompts.some((prompt) =>
+          prompt.includes("The apply pass immediately above is complete"),
+        ),
+      ).toBe(false)
+    }))
+
+  it("returns Needs Human for REVIEW_FIXED_AND_DEFERRED high even when the worktree changed", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      const prompts: string[] = []
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continueTurn: (input) =>
+            Effect.gen(function* () {
+              prompts.push(input.prompt)
+              if (isReviewingTurn(input)) {
+                return {
+                  sessionId: "ses_implement_session",
+                  assistantText:
+                    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high",
+                }
+              }
+              yield* Effect.tryPromise({
+                try: () =>
+                  writeFile(join(root, "fixed.ts"), "export const n = 1\n"),
+                catch: (cause) => cause as Error,
+              })
+              return {
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: high: injection risk remains",
+              }
+            }).pipe(Effect.orDie),
+        }),
+      )
+      expect(result).toEqual({
+        _tag: "needs_human",
+        reason: "injection risk remains",
+      })
+      expect(prompts).toHaveLength(2)
+      expect(
+        prompts.some((prompt) =>
+          prompt.includes("The apply pass immediately above is complete"),
+        ),
+      ).toBe(false)
+      expect(
+        prompts.filter((prompt) => prompt === buildReviewingPrompt()),
+      ).toHaveLength(1)
     }))
 
   it("returns Needs Human when high findings are deferred without a fix", () =>


### PR DESCRIPTION
High-severity Review Findings are not legally deferrable, but apply-findings still emits
`REVIEW_DEFERRED: high: <reason>` and `REVIEW_FIXED_AND_DEFERRED: high: <reason>`. Those markers
already say high findings remain. The parser treated them as unparseable and launched a no-tools
verdict-repair Agent Turn — an extra model call that is unnecessary for the conservative outcome
(Needs Human). In the observed Session that repair turn then stalled at stream start.

`parseApplyReviewResult` now normalizes only those two recognized shapes when the severity argument
is `high` and a reason is present. They become `unresolved_high` with the existing bounded reason
and take the same Needs Human path as an explicit `REVIEW_UNRESOLVED_HIGH`. Neither shape invokes
the apply-verdict repair turn or consumes a Review Fix Round, including when the apply pass changed
the worktree.

Unchanged: explicit `REVIEW_UNRESOLVED_HIGH`; valid low/medium deferrals, fixed, cleared, and
fixed-and-deferred; unknown result names, missing reasons, invalid severities other than this high
normalization; last-valid-wins and trailing prose.

Verified with `bunx nx test work-item-lifecycle` (775 pass, including unchanged and changed
worktrees), plus lint and typecheck on `work-item-lifecycle`. Local Review was clean.

Implements #1138.

Closes #1138