### PR TITLE
fix(agent-backend): omit harness-owned env from Agent Turns

### DIFF
--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -1800,6 +1800,9 @@ if (recordPath !== undefined && recordPath.length > 0) {
       argv1: process.argv[1],
       cwd: process.cwd(),
       envMarker: process.env.RFA_DIRECT_MARKER ?? null,
+      sqliteDatabasePath: process.env.SQLITE_DATABASE_PATH ?? null,
+      keymaxxerSidecarUrl: process.env.KEYMAXXER_SIDECAR_URL ?? null,
+      graphqlUrl: process.env.READY_FOR_AGENT_GRAPHQL_URL ?? null,
       stdinIsTTY: Boolean(process.stdin.isTTY),
       stdoutIsTTY: Boolean(process.stdout.isTTY),
       stderrIsTTY: Boolean(process.stderr.isTTY),
@@ -1832,6 +1835,9 @@ type BackendRecord = {
   readonly argv1: string
   readonly cwd: string
   readonly envMarker: string | null
+  readonly sqliteDatabasePath: string | null
+  readonly keymaxxerSidecarUrl: string | null
+  readonly graphqlUrl: string | null
   readonly stdinIsTTY: boolean
   readonly stdoutIsTTY: boolean
   readonly stderrIsTTY: boolean
@@ -2658,6 +2664,8 @@ process.exit(1)
     TMUX_ARGV_LOG: tmuxLog,
     BACKEND_RECORD: backendRecord,
     RFA_DIRECT_MARKER: "from-parent",
+    SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+    KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
     ...overrides,
   })
 
@@ -2732,6 +2740,9 @@ process.exit(1)
         expect(record.argv).toEqual(expectedResumeArgs[backendId](worktree))
         expect(record.cwd).toBe(worktree)
         expect(record.envMarker).toBe("from-parent")
+        expect(record.sqliteDatabasePath).toBeNull()
+        expect(record.keymaxxerSidecarUrl).toBeNull()
+        expect(record.graphqlUrl).toBeNull()
         expect(record.stdinIsTTY).toBe(true)
         expect(record.stdoutIsTTY).toBe(true)
       } finally {

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -2466,11 +2466,14 @@ describe("operator binary jump command", () => {
     backendId: "opencode",
   } as const
 
-  const omittedTmuxEnvPrefixes = [
+  const omittedPaneEnvironmentPrefixes = [
     "TMUX=",
     "TMUX_PANE=",
     "TERM=",
     "PWD=",
+    "SQLITE_DATABASE_PATH=",
+    "KEYMAXXER_SIDECAR_URL=",
+    "READY_FOR_AGENT_GRAPHQL_URL=",
   ] as const
 
   const tmuxFlagEnvAssignments = (
@@ -2510,7 +2513,7 @@ describe("operator binary jump command", () => {
   const expectForwardedPaneEnvironment = (args: readonly string[]) => {
     const assignments = tmuxFlagEnvAssignments(args)
     expect(assignments).toContain("CLAUDE_CODE_USE_BEDROCK=1")
-    for (const prefix of omittedTmuxEnvPrefixes) {
+    for (const prefix of omittedPaneEnvironmentPrefixes) {
       expect(
         assignments.some((assignment) => assignment.startsWith(prefix)),
       ).toBe(false)
@@ -2527,6 +2530,9 @@ describe("operator binary jump command", () => {
     TMUX_PANE: "%9",
     TERM: "xterm-256color",
     PWD: "/tmp/wrong-pwd",
+    SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+    KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
+    READY_FOR_AGENT_GRAPHQL_URL: "http://127.0.0.1:7000/graphql",
   } as const
 
   const withProcessEnv = (

--- a/apps/ready-for-agent/src/jump-pane-environment.test.ts
+++ b/apps/ready-for-agent/src/jump-pane-environment.test.ts
@@ -1,0 +1,75 @@
+import { jumpPaneEnvironmentFlags } from "./jump-pane-environment.ts"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const assignedNames = (flags: readonly string[]): string[] => {
+  const names: string[] = []
+  for (let i = 0; i < flags.length; i++) {
+    if (flags[i] !== "-e") {
+      continue
+    }
+    const assignment = flags[i + 1]
+    if (assignment !== undefined) {
+      names.push(assignment.split("=")[0] ?? assignment)
+    }
+    i += 1
+  }
+  return names
+}
+
+describe("jumpPaneEnvironmentFlags", () => {
+  const previous: Record<string, string | undefined> = {}
+  const overrideNames = [
+    "CLAUDE_CODE_USE_BEDROCK",
+    "SQLITE_DATABASE_PATH",
+    "KEYMAXXER_SIDECAR_URL",
+    "KEYMAXXER_SIDECAR_PORT",
+    "KEYMAXXER_ENABLED",
+    "KEYMAXXER_MASTER_KEY",
+    "KEYMAXXER_APPROVE",
+    "READY_FOR_AGENT_GRAPHQL_URL",
+    "KEYMAXXER_ENTRYPOINT",
+    "GH_TOKEN",
+  ] as const
+
+  afterEach(() => {
+    for (const name of overrideNames) {
+      const value = previous[name]
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+      delete previous[name]
+    }
+  })
+
+  test("strips Harness-owned names and keeps operator tooling and ambient Forge tokens", () => {
+    for (const name of overrideNames) {
+      previous[name] = process.env[name]
+    }
+    process.env.CLAUDE_CODE_USE_BEDROCK = "1"
+    process.env.SQLITE_DATABASE_PATH = "/tmp/ready-for-agent.db"
+    process.env.KEYMAXXER_SIDECAR_URL = "http://127.0.0.1:6057/cap/mcp"
+    process.env.KEYMAXXER_SIDECAR_PORT = "6057"
+    process.env.KEYMAXXER_ENABLED = "true"
+    process.env.KEYMAXXER_MASTER_KEY = "master"
+    process.env.KEYMAXXER_APPROVE = "deny"
+    process.env.READY_FOR_AGENT_GRAPHQL_URL = "http://127.0.0.1:7000/graphql"
+    process.env.KEYMAXXER_ENTRYPOINT = "/usr/bin/keymaxxer"
+    process.env.GH_TOKEN = "ambient"
+
+    const names = assignedNames(
+      jumpPaneEnvironmentFlags({ backendId: "opencode" }),
+    )
+    expect(names).toContain("CLAUDE_CODE_USE_BEDROCK")
+    expect(names).toContain("KEYMAXXER_ENTRYPOINT")
+    expect(names).toContain("GH_TOKEN")
+    expect(names).not.toContain("SQLITE_DATABASE_PATH")
+    expect(names).not.toContain("KEYMAXXER_SIDECAR_URL")
+    expect(names).not.toContain("KEYMAXXER_SIDECAR_PORT")
+    expect(names).not.toContain("KEYMAXXER_ENABLED")
+    expect(names).not.toContain("KEYMAXXER_MASTER_KEY")
+    expect(names).not.toContain("KEYMAXXER_APPROVE")
+    expect(names).not.toContain("READY_FOR_AGENT_GRAPHQL_URL")
+  })
+})

--- a/apps/ready-for-agent/src/services/direct-terminal.ts
+++ b/apps/ready-for-agent/src/services/direct-terminal.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process"
 import { constants } from "node:os"
 import { Context, Effect, Layer } from "effect"
+import { sanitizeInheritedEnvironment } from "@ready-for-agent/agent-backend"
 import { JumpFailed } from "../jump-error.ts"
 
 export type DirectLaunchInput = {
@@ -91,7 +92,9 @@ export class DirectTerminal extends Context.Service<
         try {
           child = spawn(input.agentExecutable, [...input.agentArguments], {
             cwd: input.workingDirectory,
-            env: process.env,
+            env: sanitizeInheritedEnvironment(process.env, {
+              stripForgeTokens: false,
+            }),
             stdio: "inherit",
             shell: false,
             detached: false,

--- a/packages/agent-backend/src/lib/environment.ts
+++ b/packages/agent-backend/src/lib/environment.ts
@@ -5,6 +5,27 @@ const isGitHubTokenEnvName = (name: string) =>
 
 const isGitLabTokenEnvName = (name: string) => name.startsWith("GITLAB_TOKEN")
 
+/**
+ * Harness operational names that must never reach an Agent Turn or Interactive
+ * Session Continuation. Always stripped, independent of Forge-token options.
+ */
+export const HARNESS_OWNED_ENVIRONMENT_NAMES = [
+  "SQLITE_DATABASE_PATH",
+  "KEYMAXXER_SIDECAR_URL",
+  "KEYMAXXER_SIDECAR_PORT",
+  "KEYMAXXER_ENABLED",
+  "KEYMAXXER_MASTER_KEY",
+  "KEYMAXXER_APPROVE",
+  "READY_FOR_AGENT_GRAPHQL_URL",
+] as const
+
+const harnessOwnedEnvironmentNameSet = new Set<string>(
+  HARNESS_OWNED_ENVIRONMENT_NAMES,
+)
+
+const isHarnessOwnedEnvironmentName = (name: string) =>
+  harnessOwnedEnvironmentNameSet.has(name)
+
 export type SanitizeInheritedEnvironmentOptions = {
   /**
    * When true (default), strip GitHub and GitLab token variables.
@@ -23,8 +44,9 @@ export type SanitizeInheritedEnvironmentOptions = {
 }
 
 /**
- * Inherit process environment, dropping undefined entries. Optionally strip
- * Forge token variables when the backend receives vault-backed credentials.
+ * Inherit process environment, dropping undefined entries. Always strip
+ * Harness-owned operational names. Optionally strip Forge token variables when
+ * the backend receives vault-backed credentials.
  */
 export const sanitizeInheritedEnvironment = (
   environment: Readonly<Record<string, string | undefined>> = process.env,
@@ -38,6 +60,7 @@ export const sanitizeInheritedEnvironment = (
     Object.entries(environment).filter(
       (entry): entry is [string, string] =>
         entry[1] !== undefined &&
+        !isHarnessOwnedEnvironmentName(entry[0]) &&
         !(stripGitHubTokens && isGitHubTokenEnvName(entry[0])) &&
         !(stripGitLabTokens && isGitLabTokenEnvName(entry[0])),
     ),

--- a/packages/agent-backend/test/environment.spec.ts
+++ b/packages/agent-backend/test/environment.spec.ts
@@ -1,8 +1,93 @@
-import { sanitizeInheritedEnvironment } from "../src/index.js"
+import {
+  HARNESS_OWNED_ENVIRONMENT_NAMES,
+  sanitizeInheritedEnvironment,
+} from "../src/lib/environment.js"
 import { describe, expect, it } from "bun:test"
 
+const HARNESS_OWNED_ENVIRONMENT_NAME_SET = [
+  "SQLITE_DATABASE_PATH",
+  "KEYMAXXER_SIDECAR_URL",
+  "KEYMAXXER_SIDECAR_PORT",
+  "KEYMAXXER_ENABLED",
+  "KEYMAXXER_MASTER_KEY",
+  "KEYMAXXER_APPROVE",
+  "READY_FOR_AGENT_GRAPHQL_URL",
+] as const
+
 describe("sanitizeInheritedEnvironment", () => {
-  it("drops only Forge token names by default", () => {
+  it("names the full Harness-owned operational set", () => {
+    expect([...HARNESS_OWNED_ENVIRONMENT_NAMES]).toEqual([
+      ...HARNESS_OWNED_ENVIRONMENT_NAME_SET,
+    ])
+  })
+
+  it("always strips Harness-owned operational names", () => {
+    const result = sanitizeInheritedEnvironment({
+      PATH: "/usr/bin",
+      HOME: "/home/op",
+      PORT: "3000",
+      HOST: "localhost",
+      PWD: "/work",
+      AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      KEYMAXXER_ENTRYPOINT: "/usr/bin/keymaxxer",
+      SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+      KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
+      KEYMAXXER_SIDECAR_PORT: "6057",
+      KEYMAXXER_ENABLED: "true",
+      KEYMAXXER_MASTER_KEY: "master",
+      KEYMAXXER_APPROVE: "deny",
+      READY_FOR_AGENT_GRAPHQL_URL: "http://127.0.0.1:7000/graphql",
+    })
+    expect(result).toEqual({
+      PATH: "/usr/bin",
+      HOME: "/home/op",
+      PORT: "3000",
+      HOST: "localhost",
+      PWD: "/work",
+      AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+      CLAUDE_CODE_USE_BEDROCK: "1",
+      KEYMAXXER_ENTRYPOINT: "/usr/bin/keymaxxer",
+    })
+  })
+
+  it("strips Harness-owned names even when Forge tokens must remain", () => {
+    const result = sanitizeInheritedEnvironment(
+      {
+        HOME: "/home/op",
+        GH_TOKEN: "ambient",
+        GITHUB_TOKEN: "ambient-github",
+        GITLAB_TOKEN: "ambient-gitlab",
+        SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+        KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
+        KEYMAXXER_MASTER_KEY: "master",
+        READY_FOR_AGENT_GRAPHQL_URL: "http://127.0.0.1:7000/graphql",
+      },
+      { stripForgeTokens: false },
+    )
+    expect(result).toEqual({
+      HOME: "/home/op",
+      GH_TOKEN: "ambient",
+      GITHUB_TOKEN: "ambient-github",
+      GITLAB_TOKEN: "ambient-gitlab",
+    })
+  })
+
+  it("still strips Forge tokens together with Harness-owned names", () => {
+    const result = sanitizeInheritedEnvironment({
+      HOME: "/home/op",
+      GH_TOKEN: "secret",
+      GITHUB_TOKEN: "secret-github",
+      GITLAB_TOKEN: "secret-gitlab",
+      SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+      KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
+    })
+    expect(result).toEqual({
+      HOME: "/home/op",
+    })
+  })
+
+  it("drops Forge token names by default", () => {
     const result = sanitizeInheritedEnvironment({
       HOME: "/home/user",
       GH_TOKEN: "a",

--- a/packages/claude/src/lib/environment.ts
+++ b/packages/claude/src/lib/environment.ts
@@ -9,10 +9,11 @@ export type MakeClaudeEnvironmentOptions = {
  * (Forge tokens, ANTHROPIC_API_KEY, and Amazon Bedrock / AWS credential
  * chain vars such as CLAUDE_CODE_USE_BEDROCK, AWS_ACCESS_KEY_ID,
  * AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION / AWS_DEFAULT_REGION,
- * AWS_PROFILE, AWS_BEARER_TOKEN_BEDROCK). The shared sanitizer only strips
- * optional Forge tokens when requested; Claude never requests that strip, so
- * Bedrock enablement and AWS credentials reach inspect and turn spawns the
- * same way they would for a hand-run `claude` (issue #803 / epic #799).
+ * AWS_PROFILE, AWS_BEARER_TOKEN_BEDROCK). The shared sanitizer always strips
+ * Harness-owned operational names and only strips optional Forge tokens when
+ * requested; Claude never requests that Forge strip, so Bedrock enablement
+ * and AWS credentials reach inspect and turn spawns the same way they would
+ * for a hand-run `claude` (issue #803 / epic #799).
  *
  * Force DISABLE_AUTOUPDATER so Harness operation cannot replace the CLI under
  * active work (ADR 0047). No Keymaxxer integration for Anthropic or AWS

--- a/packages/claude/test/environment.spec.ts
+++ b/packages/claude/test/environment.spec.ts
@@ -12,6 +12,7 @@ describe("makeClaudeEnvironment", () => {
         GITLAB_TOKEN: "secret3",
         GITLAB_TOKEN_ACME_WIDGETS: "secret4",
         ANTHROPIC_API_KEY: "sk-ant-test",
+        SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
         KEEP: "yes",
       },
     })
@@ -23,6 +24,7 @@ describe("makeClaudeEnvironment", () => {
     expect(env.GITLAB_TOKEN).toBe("secret3")
     expect(env.GITLAB_TOKEN_ACME_WIDGETS).toBe("secret4")
     expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test")
+    expect(env.SQLITE_DATABASE_PATH).toBeUndefined()
   })
 
   it("preserves Bedrock enablement and standard AWS credential chain env vars", () => {

--- a/packages/codex/src/lib/environment.ts
+++ b/packages/codex/src/lib/environment.ts
@@ -7,7 +7,8 @@ export type MakeCodexEnvironmentOptions = {
 /**
  * Codex Build Agent Turns use ambient Forge authentication: inherit process
  * env (including ambient Forge tokens and OPENAI_API_KEY). Codex does not
- * support KeymaxxerMcp, so tokens are never stripped.
+ * support KeymaxxerMcp, so Forge tokens are never stripped. Harness-owned
+ * operational names are still stripped by the shared sanitizer.
  */
 export const makeCodexEnvironment = (
   options: MakeCodexEnvironmentOptions = {},

--- a/packages/codex/test/environment.spec.ts
+++ b/packages/codex/test/environment.spec.ts
@@ -12,6 +12,7 @@ describe("makeCodexEnvironment", () => {
         GITLAB_TOKEN: "secret3",
         GITLAB_TOKEN_ACME_WIDGETS: "secret4",
         OPENAI_API_KEY: "sk-test",
+        SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
         KEEP: "yes",
       },
     })
@@ -22,5 +23,6 @@ describe("makeCodexEnvironment", () => {
     expect(env.GITLAB_TOKEN).toBe("secret3")
     expect(env.GITLAB_TOKEN_ACME_WIDGETS).toBe("secret4")
     expect(env.OPENAI_API_KEY).toBe("sk-test")
+    expect(env.SQLITE_DATABASE_PATH).toBeUndefined()
   })
 })

--- a/packages/grok/src/lib/environment.ts
+++ b/packages/grok/src/lib/environment.ts
@@ -7,7 +7,9 @@ export type MakeGrokEnvironmentOptions = {
 /**
  * Grok Build Agent Turns use ambient Forge authentication: inherit process env
  * (including ambient Forge tokens), and force auto-update off for the process
- * lifetime. Grok does not support KeymaxxerMcp, so tokens are never stripped.
+ * lifetime. Grok does not support KeymaxxerMcp, so Forge tokens are never
+ * stripped. Harness-owned operational names are still stripped by the shared
+ * sanitizer.
  */
 export const makeGrokEnvironment = (
   options: MakeGrokEnvironmentOptions = {},

--- a/packages/grok/test/environment.spec.ts
+++ b/packages/grok/test/environment.spec.ts
@@ -12,6 +12,8 @@ describe("makeGrokEnvironment", () => {
         GITHUB_TOKEN_repo: "secret3",
         GITLAB_TOKEN: "secret4",
         GITLAB_TOKEN_repo: "secret5",
+        SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+        KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
         KEEP: "yes",
       },
     })
@@ -23,6 +25,8 @@ describe("makeGrokEnvironment", () => {
     expect(env.GITHUB_TOKEN_repo).toBe("secret3")
     expect(env.GITLAB_TOKEN).toBe("secret4")
     expect(env.GITLAB_TOKEN_repo).toBe("secret5")
+    expect(env.SQLITE_DATABASE_PATH).toBeUndefined()
+    expect(env.KEYMAXXER_SIDECAR_URL).toBeUndefined()
     expect(env.OPENCODE_CONFIG_CONTENT).toBeUndefined()
   })
 })

--- a/packages/opencode/test/environment.spec.ts
+++ b/packages/opencode/test/environment.spec.ts
@@ -69,6 +69,8 @@ describe("makeOpencodeEnvironment", () => {
         GITHUB_TOKEN_ACME_WIDGETS: "secret",
         GITLAB_TOKEN: "secret",
         GITLAB_TOKEN_ACME_WIDGETS: "secret",
+        SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+        KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
         KEEP: "yes",
       },
     })
@@ -79,6 +81,11 @@ describe("makeOpencodeEnvironment", () => {
     expect(env.GITHUB_TOKEN_ACME_WIDGETS).toBeUndefined()
     expect(env.GITLAB_TOKEN).toBeUndefined()
     expect(env.GITLAB_TOKEN_ACME_WIDGETS).toBeUndefined()
+    expect(env.SQLITE_DATABASE_PATH).toBeUndefined()
+    expect(env.KEYMAXXER_SIDECAR_URL).toBeUndefined()
+    expect(JSON.parse(env.OPENCODE_CONFIG_CONTENT).mcp.keymaxxer.url).toBe(
+      "http://127.0.0.1:6057/cap/mcp",
+    )
   })
 
   it("preserves ambient Forge tokens when vault MCP is not configured", () => {
@@ -90,6 +97,8 @@ describe("makeOpencodeEnvironment", () => {
         GITHUB_TOKEN_ACME_WIDGETS: "secret",
         GITLAB_TOKEN: "secret",
         GITLAB_TOKEN_ACME_WIDGETS: "secret",
+        SQLITE_DATABASE_PATH: "/tmp/ready-for-agent.db",
+        KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/cap/mcp",
         KEEP: "yes",
       },
     })
@@ -100,6 +109,8 @@ describe("makeOpencodeEnvironment", () => {
     expect(env.GITHUB_TOKEN_ACME_WIDGETS).toBe("secret")
     expect(env.GITLAB_TOKEN).toBe("secret")
     expect(env.GITLAB_TOKEN_ACME_WIDGETS).toBe("secret")
+    expect(env.SQLITE_DATABASE_PATH).toBeUndefined()
+    expect(env.KEYMAXXER_SIDECAR_URL).toBeUndefined()
   })
 
   it("does not configure Keymaxxer when its capability URL is missing", () => {


### PR DESCRIPTION
An Agent Turn inherited the Harness process environment, including
`SQLITE_DATABASE_PATH` aimed at the live operator database. A target-repo
fixture script that treats that variable as disposable then deleted the
operator store (issue #1166).

`sanitizeInheritedEnvironment` now always drops Harness-owned operational
names, independently of Forge-token flags:

- `SQLITE_DATABASE_PATH`
- `KEYMAXXER_SIDECAR_URL` and `KEYMAXXER_SIDECAR_PORT`
- `KEYMAXXER_ENABLED`, `KEYMAXXER_MASTER_KEY`, and `KEYMAXXER_APPROVE`
- `READY_FOR_AGENT_GRAPHQL_URL`

Every Agent Backend already calls that sanitizer. Interactive Session
Continuation does too (tmux Jump panes and direct no-tmux continuation).
Forge-token policy is unchanged. OpenCode still receives Keymaxxer MCP
through `OPENCODE_CONFIG_CONTENT`, not leftover Sidecar URL env. Ambient
`PATH`, `HOME`, `AWS_*`, Bedrock, `PORT`, `HOST`, and `KEYMAXXER_ENTRYPOINT`
remain.

Sanitizer tests fail if `SQLITE_DATABASE_PATH` or the rest of the named set
survives. OpenCode, Grok, Claude, and Codex environment tests, plus Jump
pane and direct-continuation process tests, prove the shared sanitizer is
applied.

Does not recover already-lost databases, sandbox Agent Turn filesystems,
or strip generic names such as `PORT` / `HOST`.

Closes #1166