### PR TITLE
feat: prefill GitHub token creation names as rfa - <repo>

### DIFF
--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -39,7 +39,7 @@ const tokenSecretName = (repository: Repository) =>
 const githubTokenCreationUrl = (repository: Repository) => {
   const [owner = "", name = ""] = repository.projectPath.split("/")
   const url = new URL("https://github.com/settings/personal-access-tokens/new")
-  url.searchParams.set("name", `${name} - ready-for-agent`)
+  url.searchParams.set("name", `rfa - ${name}`)
   url.searchParams.set(
     "description",
     `Ready For Agent token for ${repository.projectPath}`,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1374,9 +1374,7 @@ describe("GraphQL API", () => {
     const creationUrl = new URL(
       body.data.repositoryCredentials[0]!.githubTokenCreationUrl as string,
     )
-    expect(creationUrl.searchParams.get("name")).toBe(
-      `${repository.projectPath.split("/").at(-1)} - ready-for-agent`,
-    )
+    expect(creationUrl.searchParams.get("name")).toBe("rfa - widgets")
     expect(creationUrl.searchParams.get("issues")).toBe("write")
     expect(creationUrl.searchParams.get("contents")).toBe("write")
     expect(creationUrl.searchParams.get("pull_requests")).toBe("write")


### PR DESCRIPTION
GitHub's token-creation links from the Harness pre-filled the PAT name
as `<repo> - ready-for-agent`. That put the product last and made Ready
for Agent tokens harder to scan in a long GitHub token list.

`repositoryCredentials.githubTokenCreationUrl` now sets `name` to
`rfa - <repo>` (same `projectPath` segment as before). For
`acme/widgets` the pre-filled name is `rfa - widgets`. The Repositories
page and Repository settings already consume that GraphQL URL, so both
entry points agree.

Unchanged: Keymaxxer vault secret names (`GITHUB_TOKEN_<OWNER>_<REPO>`),
vault metadata, GitLab token-creation URLs, token
description/expiry/permissions, and already-stored tokens. See #1169.

Verified by updating the existing GraphQL credentials assertion and
running `bunx nx test graphql-api` (270 pass). The test still checks
the fine-grained PAT page and permission query params.

Limitation: existing tokens keep their current GitHub names. Two
Repositories that share a repo name under different owners still get
the same suggested name.

Closes #1169