### PR TITLE
style(harness): add pipeline terminus ornament

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -23,6 +23,7 @@ import {
   useNowMs,
 } from "./live-duration.js"
 import { MetalLaneHeader } from "./metal-lane-header.js"
+import { PipelineBottomOrnament } from "./pipeline-bottom-ornament.js"
 import { PIPELINE_LANES, type PipelineLaneId } from "./pipeline-lanes.js"
 import { PipelineRoute, usePipelineRouteFlights } from "./pipeline-route.js"
 import {
@@ -495,6 +496,7 @@ function KanbanJobsBoard() {
               )
             })}
           </div>
+          <PipelineBottomOrnament />
         </section>
       </div>
     </article>

--- a/apps/harness/src/pipeline-bottom-ornament.tsx
+++ b/apps/harness/src/pipeline-bottom-ornament.tsx
@@ -1,0 +1,114 @@
+import { ui } from "./ui.js"
+
+/** Decorative locomotive terminus beneath the six-lane pipeline. */
+export function PipelineBottomOrnament() {
+  return (
+    <div className={ui.pipelineBottomOrnament} aria-hidden="true">
+      <svg
+        className={ui.pipelineBottomOrnamentSvg}
+        aria-hidden="true"
+        viewBox="0 0 1440 154"
+      >
+        <defs>
+          <linearGradient id="rail-steel" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0" stopColor="#58615e" />
+            <stop offset="0.35" stopColor="#252a28" />
+            <stop offset="1" stopColor="#090b0a" />
+          </linearGradient>
+          <linearGradient id="rail-brass" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stopColor="#e2bf6d" />
+            <stop offset="0.5" stopColor="#956c27" />
+            <stop offset="1" stopColor="#49300e" />
+          </linearGradient>
+        </defs>
+        <path
+          fill="url(#rail-steel)"
+          stroke="#090b0a"
+          strokeWidth="4"
+          d="M0 2h1440v20H0z"
+        />
+        <g
+          className={ui.pipelineBottomOrnamentTruss}
+          fill="none"
+          stroke="#151817"
+          strokeWidth="8"
+          strokeLinejoin="round"
+        >
+          <path d="M0 20h1440M0 140h1440M0 20l120 120L240 20l120 120L480 20l120 120L720 20l120 120L960 20l120 120 120-120 120 120 120-120" />
+        </g>
+        <g fill="url(#rail-brass)" stroke="#090b0a" strokeWidth="3">
+          <circle cx="120" cy="140" r="12" />
+          <circle cx="360" cy="140" r="12" />
+          <circle cx="1080" cy="140" r="12" />
+          <circle cx="1320" cy="140" r="12" />
+        </g>
+        <g transform="translate(720 85)">
+          <path
+            fill="#111412"
+            stroke="#090b0a"
+            strokeWidth="5"
+            d="M-150-63h300v121h-300z"
+          />
+          <path
+            fill="url(#rail-steel)"
+            stroke="#090b0a"
+            strokeWidth="4"
+            d="M-132-48h264v89h-264z"
+          />
+          <path
+            fill="none"
+            stroke="url(#rail-brass)"
+            strokeWidth="7"
+            d="M-105 25V-8c0-31 22-49 49-49h112c27 0 49 18 49 49v33"
+          />
+          <path
+            fill="#090b0a"
+            stroke="#090b0a"
+            strokeWidth="3"
+            d="M-170 58 0 12l170 46Z"
+          />
+          <path
+            fill="none"
+            stroke="url(#rail-brass)"
+            strokeWidth="5"
+            d="M-155 52 0 19l155 33M-115 58 0 26l115 32M-68 58 0 34l68 24"
+          />
+          <circle
+            cy="-6"
+            r="39"
+            fill="#161a18"
+            stroke="url(#rail-brass)"
+            strokeWidth="8"
+          />
+          <circle
+            cy="-6"
+            r="24"
+            fill="#f1d890"
+            stroke="#090b0a"
+            strokeWidth="3"
+          />
+          <path d="M-11-16 13-6-11 4Z" fill="#151515" />
+          <rect
+            x="-45"
+            y="-79"
+            width="90"
+            height="18"
+            rx="2"
+            fill="url(#rail-brass)"
+            stroke="#090b0a"
+            strokeWidth="3"
+          />
+          <text
+            x="0"
+            y="-70"
+            textAnchor="middle"
+            dominantBaseline="central"
+            className={ui.pipelineBottomOrnamentSign}
+          >
+            PIPELINE VI
+          </text>
+        </g>
+      </svg>
+    </div>
+  )
+}

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -679,6 +679,18 @@ export const ui = {
   pipelineBoard:
     "mt-[1.6rem] grid gap-[0.55rem] max-[900px]:mt-[0.85rem] max-[900px]:gap-0",
 
+  pipelineBottomOrnament:
+    "relative z-0 -mt-[0.55rem] min-h-[9.625rem] overflow-hidden text-[#151515] max-[900px]:-mt-[0.1rem] max-[900px]:min-h-24",
+
+  pipelineBottomOrnamentSvg:
+    "block h-auto w-full min-w-[54rem] overflow-visible max-[900px]:w-[175%] max-[900px]:min-w-[45rem] max-[900px]:-translate-x-[21.5%]",
+
+  pipelineBottomOrnamentTruss:
+    "[filter:drop-shadow(0_4px_2px_rgb(0_0_0/0.35))]",
+
+  pipelineBottomOrnamentSign:
+    "fill-[#151515] font-mono text-[10px] font-extrabold tracking-[0.12em]",
+
   /**
    * Route spine + pot-belly furnace stops. Spine is a brass pneumatic tube
    * (see pipelineRouteSpine) centered on the furnace belly; stack sits above


### PR DESCRIPTION
## Why

The pipeline ended abruptly at the bottom of its lane grid despite the Harness using a steampunk industrial visual language throughout its masthead, lane headers, route tube, and furnace stops.

## What Changed

- Add a permanent locomotive-terminus ornament beneath the six pipeline lanes.
- Preserve the selected prototype's steel truss, brass arch, central play medallion, rivets, gradients, and `PIPELINE VI` plate.
- Keep the full-width composition on desktop and center the ornament beneath the active lane on narrow screens.
- Treat the SVG as decorative so it does not add noise to the accessibility tree.

## Verification

Manually inspected the finished pipeline at desktop width and at 390px. The ornament remains attached to the lane grid, the full truss composition is visible, and the `PIPELINE VI` lettering has clearance inside its plate at both sizes.
