### PR TITLE
feat(lifecycle): skip empty install Agent Turns and detect Python/Rust manifests

### DIFF
--- a/packages/work-item-lifecycle/src/lib/detect-install-plan.ts
+++ b/packages/work-item-lifecycle/src/lib/detect-install-plan.ts
@@ -14,6 +14,7 @@ export type InstallPlan =
       readonly _tag: "Fallback"
       readonly reason: string
     }
+  | { readonly _tag: "NoOp" }
 
 const NODE_LOCKFILES: ReadonlyArray<{
   readonly file: string
@@ -25,6 +26,12 @@ const NODE_LOCKFILES: ReadonlyArray<{
   { file: "pnpm-lock.yaml", manager: "pnpm" },
   { file: "yarn.lock", manager: "yarn" },
 ]
+
+const PYTHON_RUST_MANIFESTS = [
+  "requirements.txt",
+  "pyproject.toml",
+  "Cargo.toml",
+] as const
 
 const installFor = (
   manager: NodePackageManager | "composer",
@@ -101,10 +108,25 @@ const listPresentNodeLockfiles = (worktreePath: string) =>
     return present
   })
 
+const listPresentPythonRustManifests = (worktreePath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
+    const present: string[] = []
+    for (const file of PYTHON_RUST_MANIFESTS) {
+      if (yield* fs.exists(path.join(worktreePath, file))) {
+        present.push(file)
+      }
+    }
+    return present
+  })
+
 /**
  * Derive a direct install command from root metadata and lockfiles only.
  * Never executes repository-controlled shell text; returns Fallback when
- * the layout is ambiguous, conflicting, or unsupported.
+ * the layout is ambiguous, conflicting, or unsupported; returns NoOp when
+ * the worktree root has no recognized Node, Composer, Python, or Rust
+ * dependency manifests.
  */
 export const detectInstallPlan = (worktreePath: string) =>
   Effect.gen(function* () {
@@ -141,9 +163,16 @@ export const detectInstallPlan = (worktreePath: string) =>
             "Node lockfile present without package.json; install manager is unsupported",
         } satisfies InstallPlan
       }
+      const pythonRustManifests =
+        yield* listPresentPythonRustManifests(worktreePath)
+      if (pythonRustManifests.length > 0) {
+        return {
+          _tag: "Fallback",
+          reason: `Detected root dependency manifests without a supported direct install command: ${pythonRustManifests.join(", ")}`,
+        } satisfies InstallPlan
+      }
       return {
-        _tag: "Fallback",
-        reason: "No recognizable root package manager metadata or lockfile",
+        _tag: "NoOp",
       } satisfies InstallPlan
     }
 

--- a/packages/work-item-lifecycle/src/lib/install-dependencies.ts
+++ b/packages/work-item-lifecycle/src/lib/install-dependencies.ts
@@ -166,13 +166,19 @@ const runOpencodeFallback = (
 
 /**
  * Production Install Dependencies Lifecycle Step.
- * Directly runs an unambiguous package-manager install, or delegates to
- * OpenCode when detection is inconclusive or the direct command fails.
+ * Directly runs an unambiguous package-manager install, completes without
+ * an Agent Turn when no recognized root dependency manifests exist, or
+ * delegates to OpenCode when detection is inconclusive or the direct
+ * command fails.
  */
 export const installDependencies = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveWorktreePath(context)
     const plan = yield* detectInstallPlan(worktreePath)
+
+    if (plan._tag === "NoOp") {
+      return
+    }
 
     if (plan._tag === "Fallback") {
       yield* runOpencodeFallback(

--- a/packages/work-item-lifecycle/test/detect-install-plan.spec.ts
+++ b/packages/work-item-lifecycle/test/detect-install-plan.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
@@ -238,17 +238,14 @@ describe("detectInstallPlan", () => {
       },
     ))
 
-  it("falls back when no recognizable manager exists", () =>
+  it("returns a no-op plan when no recognizable manager exists", () =>
     withTemp(
       async () => {
         // empty directory
       },
       async (root) => {
         const plan = await run(detectInstallPlan(root))
-        expect(plan._tag).toBe("Fallback")
-        if (plan._tag === "Fallback") {
-          expect(plan.reason).toContain("No recognizable")
-        }
+        expect(plan).toEqual({ _tag: "NoOp" })
       },
     ))
 
@@ -260,6 +257,106 @@ describe("detectInstallPlan", () => {
       async (root) => {
         const plan = await run(detectInstallPlan(root))
         expect(plan._tag).toBe("Fallback")
+      },
+    ))
+
+  it("falls back for a root requirements.txt", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "requirements.txt"), "requests==2.32.0\n")
+      },
+      async (root) => {
+        const plan = await run(detectInstallPlan(root))
+        expect(plan._tag).toBe("Fallback")
+        if (plan._tag === "Fallback") {
+          expect(plan.reason).toContain("requirements.txt")
+        }
+      },
+    ))
+
+  it("falls back for a root pyproject.toml", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(
+          join(root, "pyproject.toml"),
+          '[project]\nname = "demo"\n',
+        )
+      },
+      async (root) => {
+        const plan = await run(detectInstallPlan(root))
+        expect(plan._tag).toBe("Fallback")
+        if (plan._tag === "Fallback") {
+          expect(plan.reason).toContain("pyproject.toml")
+        }
+      },
+    ))
+
+  it("falls back for a root Cargo.toml", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "Cargo.toml"), '[package]\nname = "demo"\n')
+      },
+      async (root) => {
+        const plan = await run(detectInstallPlan(root))
+        expect(plan._tag).toBe("Fallback")
+        if (plan._tag === "Fallback") {
+          expect(plan.reason).toContain("Cargo.toml")
+        }
+      },
+    ))
+
+  it("falls back once when multiple Python and Rust manifests are present", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "requirements.txt"), "requests==2.32.0\n")
+        await writeFile(
+          join(root, "pyproject.toml"),
+          '[project]\nname = "demo"\n',
+        )
+        await writeFile(join(root, "Cargo.toml"), '[package]\nname = "demo"\n')
+      },
+      async (root) => {
+        const plan = await run(detectInstallPlan(root))
+        expect(plan._tag).toBe("Fallback")
+        if (plan._tag === "Fallback") {
+          expect(plan.reason).toContain("requirements.txt")
+          expect(plan.reason).toContain("pyproject.toml")
+          expect(plan.reason).toContain("Cargo.toml")
+        }
+      },
+    ))
+
+  it("ignores Python and Rust manifests in subdirectories", () =>
+    withTemp(
+      async (root) => {
+        await mkdir(join(root, "nested"), { recursive: true })
+        await writeFile(join(root, "nested", "requirements.txt"), "requests\n")
+        await writeFile(join(root, "nested", "pyproject.toml"), "[project]\n")
+        await writeFile(join(root, "nested", "Cargo.toml"), "[package]\n")
+      },
+      async (root) => {
+        const plan = await run(detectInstallPlan(root))
+        expect(plan).toEqual({ _tag: "NoOp" })
+      },
+    ))
+
+  it("keeps a Node direct plan when Cargo.toml is also present", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "package.json"), "{}\n")
+        await writeFile(join(root, "bun.lock"), "{}\n")
+        await writeFile(join(root, "Cargo.toml"), '[package]\nname = "demo"\n')
+      },
+      async (root) => {
+        const plan = await run(detectInstallPlan(root))
+        expect(plan).toEqual({
+          _tag: "Direct",
+          install: {
+            command: "bun",
+            args: ["install"],
+            packageManager: "bun",
+          },
+        })
       },
     ))
 })

--- a/packages/work-item-lifecycle/test/install-dependencies.spec.ts
+++ b/packages/work-item-lifecycle/test/install-dependencies.spec.ts
@@ -240,33 +240,177 @@ describe("installDependencies", () => {
       },
     ))
 
-  it("starts OpenCode when no manager is recognizable", () =>
+  it("does not start an Agent Turn when no manager is recognizable", () =>
     withTemp(
       async () => {},
       async (root) => {
-        let started: {
-          prompt: string
-          cwd: string
-          model: string
-          variant: string
-        } | null = null
+        let startTurnCount = 0
         await run(
           installDependencies(baseContext(root)),
           stubOpencode({
-            startTurn: (input) => {
-              started = input
+            startTurn: () => {
+              startTurnCount += 1
               return Effect.succeed({
-                sessionId: "ses_ambiguous",
+                sessionId: "ses_should_not_start",
                 assistantText: "",
               })
             },
           }),
         )
+        expect(startTurnCount).toBe(0)
+      },
+    ))
+
+  it("does not start an Agent Turn for Python and Rust manifests in subdirectories", () =>
+    withTemp(
+      async (root) => {
+        await mkdir(join(root, "nested"), { recursive: true })
+        await writeFile(join(root, "nested", "requirements.txt"), "requests\n")
+        await writeFile(join(root, "nested", "pyproject.toml"), "[project]\n")
+        await writeFile(join(root, "nested", "Cargo.toml"), "[package]\n")
+      },
+      async (root) => {
+        let startTurnCount = 0
+        await run(
+          installDependencies(baseContext(root)),
+          stubOpencode({
+            startTurn: () => {
+              startTurnCount += 1
+              return Effect.succeed({
+                sessionId: "ses_should_not_start",
+                assistantText: "",
+              })
+            },
+          }),
+        )
+        expect(startTurnCount).toBe(0)
+      },
+    ))
+
+  it("starts OpenCode for a root requirements.txt", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "requirements.txt"), "requests==2.32.0\n")
+      },
+      async (root) => {
+        let started: {
+          prompt: string
+          cwd: string
+          model: string
+          thinkingLevel: string
+        } | null = null
+        let startTurnCount = 0
+        await run(
+          installDependencies(baseContext(root)),
+          stubOpencode({
+            startTurn: (input) => {
+              startTurnCount += 1
+              started = input
+              return Effect.succeed({
+                sessionId: "ses_requirements",
+                assistantText: "",
+              })
+            },
+          }),
+        )
+        expect(startTurnCount).toBe(1)
         expect(started).not.toBeNull()
         expect(started!.cwd).toBe(root)
         expect(started!.model).toBe("opencode/test-model")
         expect(started!.thinkingLevel).toBe("high")
         expect(started!.prompt).toContain("could not choose")
+        expect(started!.prompt).toContain("requirements.txt")
+      },
+    ))
+
+  it("starts OpenCode for a root pyproject.toml", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(
+          join(root, "pyproject.toml"),
+          '[project]\nname = "demo"\n',
+        )
+      },
+      async (root) => {
+        let started: { prompt: string } | null = null
+        let startTurnCount = 0
+        await run(
+          installDependencies(baseContext(root)),
+          stubOpencode({
+            startTurn: (input) => {
+              startTurnCount += 1
+              started = { prompt: input.prompt }
+              return Effect.succeed({
+                sessionId: "ses_pyproject",
+                assistantText: "",
+              })
+            },
+          }),
+        )
+        expect(startTurnCount).toBe(1)
+        expect(started).not.toBeNull()
+        expect(started!.prompt).toContain("pyproject.toml")
+      },
+    ))
+
+  it("starts OpenCode for a root Cargo.toml", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "Cargo.toml"), '[package]\nname = "demo"\n')
+      },
+      async (root) => {
+        let started: { prompt: string } | null = null
+        let startTurnCount = 0
+        await run(
+          installDependencies(baseContext(root)),
+          stubOpencode({
+            startTurn: (input) => {
+              startTurnCount += 1
+              started = { prompt: input.prompt }
+              return Effect.succeed({
+                sessionId: "ses_cargo",
+                assistantText: "",
+              })
+            },
+          }),
+        )
+        expect(startTurnCount).toBe(1)
+        expect(started).not.toBeNull()
+        expect(started!.prompt).toContain("Cargo.toml")
+      },
+    ))
+
+  it("starts exactly one Agent Turn when multiple Python and Rust manifests are present", () =>
+    withTemp(
+      async (root) => {
+        await writeFile(join(root, "requirements.txt"), "requests==2.32.0\n")
+        await writeFile(
+          join(root, "pyproject.toml"),
+          '[project]\nname = "demo"\n',
+        )
+        await writeFile(join(root, "Cargo.toml"), '[package]\nname = "demo"\n')
+      },
+      async (root) => {
+        let started: { prompt: string } | null = null
+        let startTurnCount = 0
+        await run(
+          installDependencies(baseContext(root)),
+          stubOpencode({
+            startTurn: (input) => {
+              startTurnCount += 1
+              started = { prompt: input.prompt }
+              return Effect.succeed({
+                sessionId: "ses_multi_manifest",
+                assistantText: "",
+              })
+            },
+          }),
+        )
+        expect(startTurnCount).toBe(1)
+        expect(started).not.toBeNull()
+        expect(started!.prompt).toContain("requirements.txt")
+        expect(started!.prompt).toContain("pyproject.toml")
+        expect(started!.prompt).toContain("Cargo.toml")
       },
     ))
 
@@ -406,7 +550,12 @@ describe("installDependencies", () => {
 
   it("does not return or require a Session id on successful fallback", () =>
     withTemp(
-      async () => {},
+      async (root) => {
+        await writeFile(
+          join(root, "pyproject.toml"),
+          '[project]\nname = "demo"\n',
+        )
+      },
       async (root) => {
         const outcome = await run(
           installDependencies(baseContext(root)).pipe(
@@ -433,6 +582,7 @@ describe("installDependencies fallback failure", () => {
     )
     const root = await mkdtemp(join(tmpdir(), "rfa-install-fallback-fail-"))
     try {
+      await writeFile(join(root, "Cargo.toml"), '[package]\nname = "demo"\n')
       const error = await Effect.runPromise(
         installDependencies(baseContext(root)).pipe(
           Effect.flip,


### PR DESCRIPTION
## Why

Install Dependencies treated a worktree with no recognized root metadata
as an ambiguous Fallback and started an Agent Turn. Repositories with
nothing to install paid for that turn. Non-Node ecosystems still need the
fallback, but Python and Rust root manifests were invisible, so they used
the same "no recognizable metadata" path as an empty tree.

## What Changed

- Add a distinct `NoOp` `InstallPlan`. A root with no Node, Composer,
  Python, or Rust marker completes Install Dependencies with zero Agent
  Turns.
- Recognize root-only `requirements.txt`, `pyproject.toml`, and
  `Cargo.toml`. One or more of those files selects the existing agent
  fallback. Diagnostics name the detected marker(s). Multiple markers
  still start exactly one turn.
- Do not add `pip`, `uv`, `poetry`, or `cargo` commands. Detection still
  inspects file presence only and does not execute repository-controlled
  shell text.
- Existing Node/Composer conflict handling and failed-direct-command
  fallback are unchanged. A Node lockfile plus `Cargo.toml` still takes
  the Node path.

## Verification

- `bunx nx test work-item-lifecycle` — 786 passed, including detector
  and Install Dependencies tests for each marker, multiple markers,
  subdirectory ignore, and the empty-root no-op.
- `bunx nx lint work-item-lifecycle` — clean.
- Local review of uncommitted changes: no findings.

## Limitations

- Python and Rust still go through the agent fallback; this ticket does
  not install those ecosystems directly.
- Manifests in subdirectories are ignored by design.

See #1174.

Closes #1174