### PR TITLE
fix(codex): read tails with large session metadata

### DIFF
--- a/packages/codex/src/lib/session-store.ts
+++ b/packages/codex/src/lib/session-store.ts
@@ -943,6 +943,22 @@ type PeekedRollout =
   | { readonly kind: "corrupt" }
   | { readonly kind: "identity"; readonly sessionId: string }
 
+const identityFromSessionMetaPrefix = (line: string): string | null => {
+  if (!/"type"\s*:\s*"session_meta"/.test(line)) {
+    return null
+  }
+  const payloadStart = /"payload"\s*:\s*\{/.exec(line)
+  if (payloadStart === null) {
+    return null
+  }
+  const payloadPrefix = line.slice(
+    payloadStart.index + payloadStart[0].length,
+    payloadStart.index + payloadStart[0].length + 1_024,
+  )
+  const identity = /"id"\s*:\s*"([^"\\]+)"/.exec(payloadPrefix)?.[1]
+  return identity === undefined ? null : nonEmptyString(identity)
+}
+
 const peekCodexRolloutIdentity = (path: string): PeekedRollout => {
   let fd: number | undefined
   try {
@@ -950,7 +966,8 @@ const peekCodexRolloutIdentity = (path: string): PeekedRollout => {
     const buf = Buffer.alloc(IDENTITY_PEEK_BYTES)
     const bytesRead = readSync(fd, buf, 0, IDENTITY_PEEK_BYTES, 0)
     const raw = buf.subarray(0, bytesRead).toString("utf8")
-    for (const line of raw.split("\n")) {
+    const lines = raw.split("\n")
+    for (const [index, line] of lines.entries()) {
       if (line.trim() === "") {
         continue
       }
@@ -967,7 +984,16 @@ const peekCodexRolloutIdentity = (path: string): PeekedRollout => {
         if (sessionId !== null) {
           return { kind: "identity", sessionId }
         }
-      } catch {}
+      } catch {
+        const lineMayBeTruncated =
+          bytesRead === IDENTITY_PEEK_BYTES && index === lines.length - 1
+        if (lineMayBeTruncated) {
+          const sessionId = identityFromSessionMetaPrefix(line)
+          if (sessionId !== null) {
+            return { kind: "identity", sessionId }
+          }
+        }
+      }
     }
     return { kind: "corrupt" }
   } catch {

--- a/packages/codex/test/session-store.spec.ts
+++ b/packages/codex/test/session-store.spec.ts
@@ -1282,6 +1282,46 @@ describe("CodexSessionStore Agent Turn Tail", () => {
     }
   })
 
+  it("reads a tail when session metadata exceeds the bounded identity peek", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
+    try {
+      const sessionId = "large-session-metadata"
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "08", "21"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            timestamp: "2026-08-21T01:45:35.450Z",
+            type: "session_meta",
+            payload: {
+              session_id: "parent-session",
+              id: sessionId,
+              base_instructions: { text: "x".repeat(20_000) },
+            },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-21T01:45:36.000Z",
+            type: "event_msg",
+            payload: { type: "user_message", message: "go" },
+          }),
+          JSON.stringify({
+            timestamp: "2026-08-21T01:45:37.000Z",
+            type: "event_msg",
+            payload: { type: "agent_message", message: "working" },
+          }),
+        ].join("\n"),
+      })
+
+      await expect(getTail({ codexHome, sessionId })).resolves.toMatchObject({
+        availability: "available",
+        items: [{ kind: "assistant_text", text: "working" }],
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
   it("returns MISSING when the Codex Session record is absent", async () => {
     const codexHome = mkdtempSync(join(tmpdir(), "codex-session-tail-"))
     try {


### PR DESCRIPTION
## Why

Codex Agent Turn Tail incorrectly reported valid Sessions as temporarily unavailable when the first `session_meta` JSONL record exceeded the bounded 16 KiB identity peek. Current Codex rollouts can embed large base instructions in that record, so parsing the truncated prefix as complete JSON failed even though the rollout existed and was readable.

## What Changed

- Recover `payload.id` from a bounded, truncated `session_meta` prefix when the complete JSON parser cannot run.
- Preserve the rollout identity semantics when metadata also contains a different parent `session_id`.
- Cover oversized metadata and differing parent/current Session IDs with a regression test.

## Verification

Replayed the Session that exposed the bug. Before the change its tail returned `UNAVAILABLE`; after the change it returns `AVAILABLE` with the recent tool events.
