### PR TITLE
test(ready-for-agent): make SIGILL launcher fixture non-dumpable

### DIFF
--- a/apps/ready-for-agent/src/select-platform.test.ts
+++ b/apps/ready-for-agent/src/select-platform.test.ts
@@ -27,6 +27,34 @@ const binDir = dirname(fileURLToPath(import.meta.url))
 const linuxX64Test =
   process.platform === "linux" && process.arch === "x64" ? test : test.skip
 
+// Piped core_pattern still records ulimit -c 0 crashes in coredumpctl.
+// PR_SET_DUMPABLE 0 makes systemd-coredump ignore the process.
+const SIGILL_NONDUMPABLE_C = [
+  "#include <signal.h>",
+  "#include <sys/prctl.h>",
+  "int main(void) {",
+  "  prctl(PR_SET_DUMPABLE, 0);",
+  "  raise(SIGILL);",
+  "}",
+  "",
+].join("\n")
+
+const writeNondumpableSigillBinary = (outputPath: string): void => {
+  const cc = Bun.which("cc") ?? Bun.which("gcc")
+  if (cc === null) {
+    throw new Error("cc is required to build the SIGILL launcher fixture")
+  }
+  const compiled = spawnSync(cc, ["-o", outputPath, "-x", "c", "-"], {
+    encoding: "utf8",
+    input: SIGILL_NONDUMPABLE_C,
+  })
+  if (compiled.status !== 0) {
+    throw new Error(
+      `failed to compile SIGILL launcher fixture: ${compiled.stderr}`,
+    )
+  }
+}
+
 describe("selectPlatformPackage", () => {
   test("selects each supported linux/darwin/win32 × x64/arm64 package", () => {
     const cases = [
@@ -237,7 +265,7 @@ describe("selectPlatformPackage", () => {
         join(platformRoot, "package.json"),
         JSON.stringify({ name: "ready-for-agent-linux-x64" }),
       )
-      writeFileSync(platformBin, "#!/bin/sh\nkill -ILL $$\n")
+      writeNondumpableSigillBinary(platformBin)
       chmodSync(platformBin, 0o755)
 
       const node = Bun.which("node")


### PR DESCRIPTION
The linux-x64 launcher test `launcher reports a signaled platform binary` used a
`/bin/sh` fixture that ran `kill -ILL $$`. Every run on a systemd-coredump host
left a `/usr/bin/bash ... SIGILL` row in `coredumpctl list` even though the crash
is intentional (#1179).

`ulimit -c 0` does not prevent that when `kernel.core_pattern` is a pipe:
systemd-coredump is still invoked (entry appears with `COREFILE none`). The
fixture is now a small C wrapper compiled at test time that calls
`prctl(PR_SET_DUMPABLE, 0)` and then `raise(SIGILL)`.

Assertions are unchanged: status `1`, stderr still contains `SIGILL` and
`bun-linux-x64-baseline`.

Verified on linux-x64:
- `bun test src/select-platform.test.ts` — 11 pass
- `coredumpctl list` and `journalctl` for systemd-coredump showed no new entry
  after the suite

Limitation: this linux-x64 test now requires `cc` or `gcc` on PATH.

Closes #1179