### PR TITLE
feat(graphql-api): label investigating status checks as addressing findings

### DIFF
--- a/apps/harness/test/work-item-lifecycle-status.test.tsx
+++ b/apps/harness/test/work-item-lifecycle-status.test.tsx
@@ -61,6 +61,36 @@ describe("WorkItemLifecycleStatus", () => {
     expect(html).not.toContain("Explicit Work Item Execution Profile")
   })
 
+  test("renders Addressing status check findings while investigating", () => {
+    const investigating = {
+      ...waitingForGitHubWorkItem,
+      state: "INVESTIGATE_PR_STATUS_CHECKS",
+      stateLabel: "Addressing status check findings",
+      status: "RUNNING",
+      statusLabel: "Running",
+      statusMessage: null,
+      postponedUntil: null,
+      hasActiveStepRun: true,
+      lifecycleLabels: [
+        {
+          phase: "GITHUB_STATUS_CHECKS",
+          label: "Addressing status check findings: Running",
+          status: "RUNNING",
+          durationMs: 45_000,
+        },
+      ],
+    } satisfies WorkItem
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <WorkItemLifecycleStatus workItem={investigating} compact />
+      </QueryClientProvider>,
+    )
+
+    expect(html).toContain("Addressing status check findings: Running")
+    expect(html).not.toContain("Status checks")
+    expect(html).not.toContain(">Retry<")
+  })
+
   test("shows an Explicit Work Item Execution Profile on Work Item detail", () => {
     const profiled = {
       ...waitingForGitHubWorkItem,

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -89,7 +89,10 @@ const lifecyclePhase = (step: OperationalLifecycleStep): LifecyclePhase => {
   return step
 }
 
-const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
+const lifecyclePhaseLabel = (
+  phase: LifecyclePhase,
+  latestStep?: OperationalLifecycleStep,
+): string => {
   switch (phase) {
     case "implement":
       return "Build"
@@ -100,8 +103,11 @@ const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
     case "resolve_pr_merge_conflict":
       return "Resolve PR merge conflict"
     case "github_status_checks":
-      // Forge-neutral: same Watch phase for GitHub checks and GitLab pipeline jobs.
-      return "Status checks"
+      // Same collapsed phase for Watch and Investigate; Investigate uses a
+      // distinct chip. Forge-neutral for GitHub checks and GitLab jobs.
+      return latestStep === "investigate_pr_status_checks"
+        ? "Addressing status check findings"
+        : "Status checks"
     case "mark_pr_ready_for_review":
       return "Mark PR ready for review"
     case "decide_pr_merge":
@@ -385,7 +391,7 @@ export const lifecycleLabels = (workItem: WorkItemRecord) => {
               : statusLabel(status)
     const latestLabel = {
       phase: phase.toUpperCase(),
-      label: `${lifecyclePhaseLabel(phase)}: ${outcome}`,
+      label: `${lifecyclePhaseLabel(phase, stepRun.step)}: ${outcome}`,
       status: status.toUpperCase(),
       durationMs: cumulativeExecutionDurationMs(runsByPhase.get(phase) ?? []),
     }
@@ -411,7 +417,6 @@ export const workItemStateLabel = (workItem: WorkItemRecord): string => {
   if (workItemIsTerminal(workItem)) {
     return statusLabel(workItem.state)
   }
-  return lifecyclePhaseLabel(
-    lifecyclePhase(workItem.state as OperationalLifecycleStep),
-  )
+  const step = workItem.state as OperationalLifecycleStep
+  return lifecyclePhaseLabel(lifecyclePhase(step), step)
 }

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -5535,8 +5535,85 @@ describe("GraphQL API", () => {
             lifecycleLabels: [
               {
                 phase: "GITHUB_STATUS_CHECKS",
-                label: "Status checks: Needs human",
+                label: "Addressing status check findings: Needs human",
                 status: "NEEDS_HUMAN",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("labels investigating status-check activity Addressing status check findings", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const investigating = {
+      ...workItem,
+      state: "investigate_pr_status_checks",
+      stepRuns: [
+        { ...baseRun, step: "implement", status: "succeeded" },
+        { ...baseRun, step: "review", status: "succeeded" },
+        {
+          ...baseRun,
+          step: "watch_pr_status_checks",
+          status: "succeeded",
+        },
+        {
+          ...baseRun,
+          step: "investigate_pr_status_checks",
+          status: "running",
+          finishedAt: null,
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([investigating]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $issueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+            state stateLabel status statusLabel
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            state: "INVESTIGATE_PR_STATUS_CHECKS",
+            stateLabel: "Addressing status check findings",
+            status: "RUNNING",
+            statusLabel: "Running",
+            lifecycleLabels: [
+              {
+                phase: "IMPLEMENT",
+                label: "Build: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "REVIEW",
+                label: "Review: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "GITHUB_STATUS_CHECKS",
+                label: "Addressing status check findings: Running",
+                status: "RUNNING",
               },
             ],
           },
@@ -5813,7 +5890,7 @@ describe("GraphQL API", () => {
         workItems: [
           {
             state: "INVESTIGATE_PR_STATUS_CHECKS",
-            stateLabel: "Status checks",
+            stateLabel: "Addressing status check findings",
             status: "NEEDS_HUMAN_REVIEW",
             statusLabel: "Needs human review",
             statusMessage: reason,
@@ -5828,7 +5905,7 @@ describe("GraphQL API", () => {
               },
               {
                 phase: "GITHUB_STATUS_CHECKS",
-                label: "Status checks: Succeeded",
+                label: "Addressing status check findings: Succeeded",
                 status: "SUCCEEDED",
               },
             ],

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -10,6 +10,7 @@ import {
   workItemLatestStepRunDetail,
   workItemLatestStepRunReason,
   workItemPostponedUntil,
+  workItemStateLabel,
   workItemStatus,
   workItemStatusMessage,
 } from "../src/lib/work-item-projection.js"
@@ -290,6 +291,175 @@ describe("Postponed Step Run projection", () => {
         label: "Status checks: Queued",
         status: "QUEUED",
         durationMs: 2_315_000,
+      },
+    ])
+  })
+})
+
+describe("status-checks phase labels", () => {
+  const watchRun = {
+    ...baseStepRun,
+    id: "srun-watch",
+    step: "watch_pr_status_checks" as const,
+    status: "running" as const,
+    finishedAt: null,
+    executionDurationMs: 12_000,
+  } satisfies WorkItemRecord["stepRuns"][number]
+
+  const investigateRun = {
+    ...baseStepRun,
+    id: "srun-investigate",
+    step: "investigate_pr_status_checks" as const,
+    status: "running" as const,
+    finishedAt: null,
+    executionDurationMs: 45_000,
+  } satisfies WorkItemRecord["stepRuns"][number]
+
+  test.each([
+    ["running", "Running", "RUNNING"],
+    ["succeeded", "Succeeded", "SUCCEEDED"],
+    ["failed", "Failed", "FAILED"],
+    ["queued", "Queued", "QUEUED"],
+  ] as const)(
+    "labels the chip Addressing status check findings when the latest phase run is investigate (%s)",
+    (status, outcome, statusCode) => {
+      const workItem = workItemWith({
+        state: "investigate_pr_status_checks",
+        stepRuns: [
+          {
+            ...investigateRun,
+            status,
+            finishedAt:
+              status === "running" || status === "queued"
+                ? null
+                : new Date("2026-07-14T08:38:36.000Z"),
+          },
+        ],
+      })
+
+      expect(lifecycleLabels(workItem)).toEqual([
+        {
+          phase: "GITHUB_STATUS_CHECKS",
+          label: `Addressing status check findings: ${outcome}`,
+          status: statusCode,
+          durationMs: 45_000,
+        },
+      ])
+    },
+  )
+
+  test("keeps the Status checks chip when the latest phase run is watch", () => {
+    const workItem = workItemWith({
+      state: "watch_pr_status_checks",
+      stepRuns: [watchRun],
+    })
+
+    expect(lifecycleLabels(workItem)).toEqual([
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "Status checks: Running",
+        status: "RUNNING",
+        durationMs: 12_000,
+      },
+    ])
+    expect(workItemStateLabel(workItem)).toBe("Status checks")
+  })
+
+  test("uses the latest run in the collapsed phase after watch then investigate", () => {
+    const workItem = workItemWith({
+      state: "investigate_pr_status_checks",
+      stepRuns: [
+        {
+          ...watchRun,
+          status: "succeeded",
+          finishedAt: new Date("2026-07-14T08:10:00.000Z"),
+          executionDurationMs: 12_000,
+        },
+        investigateRun,
+      ],
+    })
+
+    expect(lifecycleLabels(workItem)).toEqual([
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "Addressing status check findings: Running",
+        status: "RUNNING",
+        durationMs: 12_000 + 45_000,
+      },
+    ])
+  })
+
+  test("returns to Status checks when a later watch run follows investigate", () => {
+    const workItem = workItemWith({
+      state: "watch_pr_status_checks",
+      stepRuns: [
+        {
+          ...investigateRun,
+          status: "succeeded",
+          finishedAt: new Date("2026-07-14T08:20:00.000Z"),
+          executionDurationMs: 45_000,
+        },
+        {
+          ...watchRun,
+          id: "srun-watch-2",
+          status: "queued",
+          finishedAt: null,
+          executionDurationMs: null,
+        },
+      ],
+    })
+
+    expect(lifecycleLabels(workItem)).toEqual([
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "Status checks: Queued",
+        status: "QUEUED",
+        durationMs: 45_000,
+      },
+    ])
+    expect(workItemStateLabel(workItem)).toBe("Status checks")
+  })
+
+  test("standalone investigate state label reads Addressing status check findings", () => {
+    expect(
+      workItemStateLabel(
+        workItemWith({
+          state: "investigate_pr_status_checks",
+          stepRuns: [investigateRun],
+        }),
+      ),
+    ).toBe("Addressing status check findings")
+  })
+
+  test("keeps postponed history on Status checks when latest run is investigate", () => {
+    const postponedUntil = new Date("2026-08-07T12:00:00.000Z")
+    const workItem = workItemWith({
+      state: "investigate_pr_status_checks",
+      holdsWorkerSlot: true,
+      stepRuns: [
+        {
+          ...watchRun,
+          status: "postponed",
+          finishedAt: new Date("2026-08-07T11:00:00.000Z"),
+          postponedUntil,
+          executionDurationMs: 2_315_000,
+        },
+        investigateRun,
+      ],
+    })
+
+    expect(lifecycleLabels(workItem)).toEqual([
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "Status checks: Postponed (1 prior attempt)",
+        status: "POSTPONED",
+        durationMs: null,
+      },
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "Addressing status check findings: Running",
+        status: "RUNNING",
+        durationMs: 2_315_000 + 45_000,
       },
     ])
   })


### PR DESCRIPTION
Operators could not tell an active Investigate PR Status Checks run from ordinary Watch polling:
both collapsed to a **Status checks** chip, so agent fixing looked like a GitHub wait.

The Work Item GraphQL projection is now step-aware for that collapsed phase:

- Latest run is Investigate (any status) → chip **Addressing status check findings: …**
- Latest run is Watch → chip stays **Status checks: …**
- Standalone `stateLabel` for `investigate_pr_status_checks` uses the same wording
- Phase key remains `GITHUB_STATUS_CHECKS`, so PR-lane mapping, kanban collapse, and cumulative
  durations are unchanged

Verified with `bunx nx test graphql-api` (projection and GraphQL label assertions); harness
chip-rendering test for the investigating label; existing pipeline-lane tests still map
`GITHUB_STATUS_CHECKS` to PR; typecheck and lint for `graphql-api` and `harness`.

This is the label-only slice of parent #1180 (issue #1183). Draft-until-green Watch semantics are
out of scope here. Uncommitted-diff review reported no findings.

Closes #1183