### PR TITLE
fix(lifecycle): isolate repository subprocess environment

### DIFF
--- a/packages/agent-backend/src/lib/environment.ts
+++ b/packages/agent-backend/src/lib/environment.ts
@@ -6,8 +6,8 @@ const isGitHubTokenEnvName = (name: string) =>
 const isGitLabTokenEnvName = (name: string) => name.startsWith("GITLAB_TOKEN")
 
 /**
- * Harness operational names that must never reach an Agent Turn or Interactive
- * Session Continuation. Always stripped, independent of Forge-token options.
+ * Harness operational names that must never reach repository-controlled child
+ * processes. Always stripped, independent of Forge-token options.
  */
 export const HARNESS_OWNED_ENVIRONMENT_NAMES = [
   "SQLITE_DATABASE_PATH",

--- a/packages/work-item-lifecycle/src/lib/assess-changes.ts
+++ b/packages/work-item-lifecycle/src/lib/assess-changes.ts
@@ -11,6 +11,7 @@ import {
 } from "./assess-changes-errors.js"
 import { GitCommandError } from "./create-worktree-errors.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
+import { repositoryProcessOptions } from "./repository-process-environment.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
 export type AssessChangesResult =
@@ -83,6 +84,7 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const command = ChildProcess.make("git", args, {
       cwd,
+      ...repositoryProcessOptions(),
       stdin: "ignore",
     })
 

--- a/packages/work-item-lifecycle/src/lib/commit.ts
+++ b/packages/work-item-lifecycle/src/lib/commit.ts
@@ -30,6 +30,7 @@ import {
   publicationCopyFromCommitMessage,
 } from "./publication-copy.js"
 import { rewritePublicationCopyAttachments } from "./publication-copy-attachments.js"
+import { repositoryProcessOptions } from "./repository-process-environment.js"
 import {
   classifyUnparsedResult,
   formatResultLineFailure,
@@ -117,6 +118,7 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const command = ChildProcess.make("git", args, {
       cwd,
+      ...repositoryProcessOptions(),
       stdin: "ignore",
     })
 

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -39,6 +39,10 @@ import {
   publicationCopyFromCommitMessage,
 } from "./publication-copy.js"
 import {
+  SANITIZED_REPOSITORY_SHELL_PREFIX,
+  repositoryProcessOptions,
+} from "./repository-process-environment.js"
+import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleStepCompletion,
 } from "./types.js"
@@ -136,6 +140,7 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const command = ChildProcess.make("git", args, {
       cwd,
+      ...repositoryProcessOptions(),
       stdin: "ignore",
     })
 
@@ -394,6 +399,7 @@ const attemptNativePush = (
     const command = [
       `GH_TOKEN="$${tokenName}"`,
       `GITHUB_TOKEN="$${tokenName}"`,
+      SANITIZED_REPOSITORY_SHELL_PREFIX,
       "git",
       "-C",
       shellQuote(worktreePath),
@@ -462,6 +468,7 @@ const attemptGitLabHttpsPush = (
       const command = [
         `BASIC="$(printf 'oauth2:%s' "$${tokenName}" | (base64 -w0 2>/dev/null || base64 | tr -d '\\n'))"`,
         "&&",
+        SANITIZED_REPOSITORY_SHELL_PREFIX,
         "git",
         "-C",
         shellQuote(worktreePath),

--- a/packages/work-item-lifecycle/src/lib/git.ts
+++ b/packages/work-item-lifecycle/src/lib/git.ts
@@ -1,6 +1,7 @@
 import { Effect, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { GitCommandError } from "./create-worktree-errors.js"
+import { repositoryProcessOptions } from "./repository-process-environment.js"
 
 export type GitRepository = {
   readonly localPath: string
@@ -20,6 +21,7 @@ export const runGit = (
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const fullArgs = [...repositoryPrefix(repository), ...args]
     const command = ChildProcess.make("git", fullArgs, {
+      ...repositoryProcessOptions(),
       stdin: "ignore",
     })
 
@@ -69,6 +71,7 @@ export const gitExitCode = (
     const fullArgs = [...repositoryPrefix(repository), ...args]
     const code = yield* spawner.exitCode(
       ChildProcess.make("git", fullArgs, {
+        ...repositoryProcessOptions(),
         stdin: "ignore",
         stdout: "ignore",
         stderr: "ignore",

--- a/packages/work-item-lifecycle/src/lib/install-dependencies.ts
+++ b/packages/work-item-lifecycle/src/lib/install-dependencies.ts
@@ -13,6 +13,7 @@ import {
   WorktreeContextMissingError,
 } from "./install-dependencies-errors.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
+import { repositoryProcessOptions } from "./repository-process-environment.js"
 import { promptUserContentSection } from "./sanitize-prompt-user-content.js"
 
 const STDERR_DIAGNOSTIC_LIMIT = 4_000
@@ -62,6 +63,7 @@ const runInstallCommand = (cwd: string, install: InstallCommand) =>
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const command = ChildProcess.make(install.command, install.args, {
       cwd,
+      ...repositoryProcessOptions(),
       stdin: "ignore",
       stdout: "ignore",
     })

--- a/packages/work-item-lifecycle/src/lib/pre-commit.ts
+++ b/packages/work-item-lifecycle/src/lib/pre-commit.ts
@@ -10,6 +10,7 @@ import {
   PreCommitStageError,
   PreCommitWorktreeContextMissingError,
 } from "./pre-commit-errors.js"
+import { repositoryProcessOptions } from "./repository-process-environment.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
 const resolveWorktreePath = (context: LifecycleStepContext) =>
@@ -64,6 +65,7 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const command = ChildProcess.make("git", args, {
       cwd,
+      ...repositoryProcessOptions(),
       stdin: "ignore",
     })
 

--- a/packages/work-item-lifecycle/src/lib/repository-process-environment.ts
+++ b/packages/work-item-lifecycle/src/lib/repository-process-environment.ts
@@ -1,0 +1,18 @@
+import {
+  HARNESS_OWNED_ENVIRONMENT_NAMES,
+  sanitizeInheritedEnvironment,
+} from "@ready-for-agent/agent-backend"
+
+/** Repository-controlled commands may run hooks or package lifecycle scripts. */
+export const repositoryProcessOptions = () => ({
+  env: sanitizeInheritedEnvironment(process.env, {
+    stripForgeTokens: false,
+  }),
+  extendEnv: false as const,
+})
+
+/** Shell prefix for commands executed by the separately hosted Keymaxxer child. */
+export const SANITIZED_REPOSITORY_SHELL_PREFIX = [
+  "env",
+  ...HARNESS_OWNED_ENVIRONMENT_NAMES.flatMap((name) => ["-u", name]),
+].join(" ")

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -11,6 +11,7 @@ import { DbService } from "@ready-for-agent/db-service"
 import { CurrentStepRun } from "./agent-turn-limiter.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { preCommit } from "./pre-commit.js"
+import { repositoryProcessOptions } from "./repository-process-environment.js"
 import {
   classifyUnparsedResult,
   formatResultLineFailure,
@@ -420,6 +421,7 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const command = ChildProcess.make("git", args, {
       cwd,
+      ...repositoryProcessOptions(),
       stdin: "ignore",
     })
 

--- a/packages/work-item-lifecycle/test/commit.spec.ts
+++ b/packages/work-item-lifecycle/test/commit.spec.ts
@@ -1,4 +1,11 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
@@ -565,6 +572,73 @@ describe("commit", () => {
       expect(message).toContain("Closes #2039")
       expect(message).not.toContain("Automated draft pull request")
       expect(await git(root, ["status", "--porcelain"])).toBe("")
+    }))
+
+  it("does not expose Harness-owned environment to commit hooks", () =>
+    withTempRepo(async (root, startingOid) => {
+      const databaseRoot = await mkdtemp(join(tmpdir(), "rfa-commit-db-"))
+      const databasePath = join(databaseRoot, "harness.db")
+      const observedEnvironmentPath = join(databaseRoot, "commit-environment")
+      const hooks = join(root, ".git", "hooks")
+      await mkdir(hooks, { recursive: true })
+      const hookPath = join(hooks, "pre-commit")
+      await writeFile(
+        hookPath,
+        [
+          "#!/usr/bin/env bash",
+          "set -eo pipefail",
+          'printf "%s" "$RFA_COMMIT_TEST_VALUE" > "$RFA_COMMIT_OBSERVED_PATH"',
+          'if [[ -n "$SQLITE_DATABASE_PATH" ]]; then',
+          '  rm -f "$SQLITE_DATABASE_PATH" "$SQLITE_DATABASE_PATH-shm" "$SQLITE_DATABASE_PATH-wal"',
+          "fi",
+          "",
+        ].join("\n"),
+      )
+      await chmod(hookPath, 0o755)
+      await writeFile(databasePath, "live harness data\n")
+      await writeFile(join(root, "feature.ts"), "export const n = 1\n")
+
+      const originalDatabasePath = process.env["SQLITE_DATABASE_PATH"]
+      const originalTestValue = process.env["RFA_COMMIT_TEST_VALUE"]
+      const originalObservedPath = process.env["RFA_COMMIT_OBSERVED_PATH"]
+      process.env["SQLITE_DATABASE_PATH"] = databasePath
+      process.env["RFA_COMMIT_TEST_VALUE"] = "preserved"
+      process.env["RFA_COMMIT_OBSERVED_PATH"] = observedEnvironmentPath
+      try {
+        const result = await run(
+          commit(
+            baseContext(root, {
+              startingCommitOid: startingOid,
+              publicationTitle: "fix: protect harness environment",
+              publicationBody:
+                "Keeps Harness state outside repository hooks.\n\nCloses #91",
+            }),
+          ),
+        )
+
+        expect(result.completion).toBe("native")
+        expect(await readFile(databasePath, "utf8")).toBe("live harness data\n")
+        expect(await readFile(observedEnvironmentPath, "utf8")).toBe(
+          "preserved",
+        )
+      } finally {
+        if (originalDatabasePath === undefined) {
+          delete process.env["SQLITE_DATABASE_PATH"]
+        } else {
+          process.env["SQLITE_DATABASE_PATH"] = originalDatabasePath
+        }
+        if (originalTestValue === undefined) {
+          delete process.env["RFA_COMMIT_TEST_VALUE"]
+        } else {
+          process.env["RFA_COMMIT_TEST_VALUE"] = originalTestValue
+        }
+        if (originalObservedPath === undefined) {
+          delete process.env["RFA_COMMIT_OBSERVED_PATH"]
+        } else {
+          process.env["RFA_COMMIT_OBSERVED_PATH"] = originalObservedPath
+        }
+        await rm(databaseRoot, { recursive: true, force: true })
+      }
     }))
 
   it("generates publication copy once then commits natively", () =>

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -375,8 +375,8 @@ describe("createPr", () => {
       )
       expect(pushCommand).not.toContain(" origin ")
       expect(pushCommand).toContain("Authorization: Basic $BASIC")
-      // Real shell assignment before git — not BASIC=… git … $BASIC prefix form.
-      expect(pushCommand).toContain(')" && git ')
+      // Real shell assignment before sanitized git — not BASIC=… git … $BASIC.
+      expect(pushCommand).toContain(')" && env -u SQLITE_DATABASE_PATH ')
     }))
   it("reuses an existing exact-branch open GitLab MR without creation", () =>
     withTemp(async (root) => {
@@ -714,6 +714,7 @@ describe("createPr", () => {
       expect(continueCalls).toBe(0)
       expect(secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
       expect(pushCommand).toContain('GH_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS"')
+      expect(pushCommand).toContain("env -u SQLITE_DATABASE_PATH")
       expect(pushCommand).toContain("git")
       expect(pushCommand).toContain("push")
       // Secret-name expansion in the header (not $GH_TOKEN): bash does not

--- a/packages/work-item-lifecycle/test/pre-commit.spec.ts
+++ b/packages/work-item-lifecycle/test/pre-commit.spec.ts
@@ -197,6 +197,48 @@ describe("preCommit", () => {
       expect(continues).toBe(0)
     }))
 
+  it("does not expose Harness-owned environment to repository hooks", () =>
+    withTempGit(async (root) => {
+      const databasePath = join(root, "harness.db")
+      const observedEnvironmentPath = join(root, ".pre-commit-environment")
+      await writeFile(databasePath, "live harness data\n")
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          "set -eo pipefail",
+          'printf "%s" "$RFA_PRE_COMMIT_TEST_VALUE" > ".pre-commit-environment"',
+          'if [[ -n "$SQLITE_DATABASE_PATH" ]]; then',
+          '  rm -f "$SQLITE_DATABASE_PATH" "$SQLITE_DATABASE_PATH-shm" "$SQLITE_DATABASE_PATH-wal"',
+          "fi",
+          "",
+        ].join("\n"),
+      )
+
+      const originalDatabasePath = process.env["SQLITE_DATABASE_PATH"]
+      const originalTestValue = process.env["RFA_PRE_COMMIT_TEST_VALUE"]
+      process.env["SQLITE_DATABASE_PATH"] = databasePath
+      process.env["RFA_PRE_COMMIT_TEST_VALUE"] = "preserved"
+      try {
+        await run(preCommit(baseContext(root)))
+        expect(await readFile(databasePath, "utf8")).toBe("live harness data\n")
+        expect(await readFile(observedEnvironmentPath, "utf8")).toBe(
+          "preserved",
+        )
+      } finally {
+        if (originalDatabasePath === undefined) {
+          delete process.env["SQLITE_DATABASE_PATH"]
+        } else {
+          process.env["SQLITE_DATABASE_PATH"] = originalDatabasePath
+        }
+        if (originalTestValue === undefined) {
+          delete process.env["RFA_PRE_COMMIT_TEST_VALUE"]
+        } else {
+          process.env["RFA_PRE_COMMIT_TEST_VALUE"] = originalTestValue
+        }
+      }
+    }))
+
   it("asks OpenCode to fix then re-runs until the hook succeeds", () =>
     withTempGit(async (root) => {
       const diagnostic = "format failed: needs fix"


### PR DESCRIPTION
## Why

Repository-controlled Git hooks and package lifecycle scripts inherited the Harness process environment. That exposed operational values such as `SQLITE_DATABASE_PATH`; in the observed incident, a repository hook's cleanup trap interpreted the Harness database as its own and deleted the live database.

The existing environment sanitizer protected Agent Turns and Interactive Session Continuations, but lifecycle subprocesses and Keymaxxer-hosted push commands remained outside that boundary.

## What Changed

- centralize lifecycle subprocess options around the authoritative Harness-owned environment denylist
- sanitize every direct repository-controlled lifecycle subprocess while preserving ordinary environment values and Forge credentials
- add equivalent `env -u` protection to GitHub and GitLab pushes executed through Keymaxxer
- add destructive Pre-Commit and native Commit hook regressions, plus shell-push assertions

## Verification

The new integration tests install hooks that delete the configured SQLite database whenever `SQLITE_DATABASE_PATH` is visible. Both Pre-Commit and native Commit complete while the sentinel database remains intact, and an unrelated environment value still reaches each hook.
