### PR TITLE
feat(skills): add ready-for-agent operator skill

### DIFF
--- a/.agents/skills/ready-for-agent/SKILL.md
+++ b/.agents/skills/ready-for-agent/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: ready-for-agent
+description: Operate and report on the Ready for Agent harness — the local metaharness that turns `ready-for-agent`-labelled GitHub/GitLab issues into merged PRs by driving a coding agent (OpenCode, Codex, Grok Build, Claude Code) through a Work Item lifecycle. Use this whenever the user asks what the harness is doing, how their issues/work items/PRs are progressing, why something is stuck, blocked, failed, or needs human attention, or wants to start, retry, reset, pause, or reconfigure work — and also when they just say things like "what's running", "check the queue", "how's the pipeline", "is it done yet", "why did #123 fail", "how many PRs this week", or mention the kanban board, lanes, work items, agent backends, or localhost:6056, even if they never say "ready-for-agent" by name.
+---
+
+# Ready for Agent
+
+Ready for Agent is a **metaharness**: a deterministic loop that steers a coding
+agent from a labelled issue to a merged pull request. It runs locally, on the
+user's machine, against their real clone — so everything you observe is live
+production state, and everything you change is real.
+
+Your two jobs are **reporting** (what is happening, and what needs a human) and
+**operating** (starting, retrying, unblocking work). Reporting is the more
+common one, and the one users are most often disappointed by, because the
+obvious surface — `ready-for-agent status` — is a *windowed* view that silently
+omits work. Getting reporting right is mostly about knowing which surface
+answers which question.
+
+## Mental model
+
+An **Issue** labelled `ready-for-agent` on the forge is the source of truth. The
+harness projects it locally and, when started, creates a **Work Item**: one
+attempt to carry that issue through the lifecycle.
+
+A Work Item has a **state** (where it is in the lifecycle: `IMPLEMENT`,
+`REVIEW`, `COMMIT`, `MERGE_PR`, …) and a **status** (how that step is going:
+`RUNNING`, `QUEUED`, `FAILED`, `NEEDS_HUMAN`, …). The pair is what you report —
+`IMPLEMENT/RUNNING` and `IMPLEMENT/FAILED` are very different situations. The
+board groups the pair into six **lanes**: Queue, Build, Review, PR, Attention,
+Merged.
+
+Work happens in a throwaway git worktree under `/tmp/ready-for-agent/...`, in a
+backend **Session** you can reattach to. A Work Item that the harness cannot
+advance alone stops in **Needs Human** and records why.
+
+Read `references/lifecycle.md` for the full state, status, lane, and reason-code
+vocabulary — reach for it whenever you need to explain precisely what a state
+means, or map a reason code to a cause.
+
+## Before anything else: is it running?
+
+Every command here talks to a harness that must already be running. Check once:
+
+```bash
+ready-for-agent status >/dev/null 2>&1 && echo up || echo down
+```
+
+If it is down, start it detached and without stealing the user's browser —
+`ready-for-agent` in the foreground blocks, which is almost never what you want
+from a tool call:
+
+```bash
+ready-for-agent start --no-open   # run in background; UI at http://127.0.0.1:6056/
+```
+
+The finite commands (`status`, `candidates`, `intake`, `retry`, `add`, `jump`)
+are thin GraphQL clients — they do **not** start the harness, and they fail with
+a connection error if nothing is listening. A non-default port needs
+`READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:<port>/graphql`.
+
+## Reporting
+
+Use the bundled script. It makes one round trip, then renders lane occupancy,
+per-step timing, stall flags, blocked reasons, and next actions:
+
+```bash
+python3 scripts/rfa_report.py                    # everything
+python3 scripts/rfa_report.py --repo acme-web    # one repo (substring match)
+python3 scripts/rfa_report.py --throughput       # + merged-PR counts and archive
+python3 scripts/rfa_report.py --issue 412 --repo acme-web   # one issue, deeply
+python3 scripts/rfa_report.py --json             # raw, for your own analysis
+```
+
+The script exists because the interesting reporting data is spread across
+`kanbanStatus`, `repositories`, `config`, and `agentBackendStatuses`, and
+because per-step durations only become meaningful once you render them together.
+Reproducing that inline every time wastes a turn and tends to drop the fields
+that matter.
+
+### The windowing trap
+
+`ready-for-agent status` and the kanban board share one **windowed** projection.
+It deliberately includes only:
+
+- every *unfinished* Work Item (plus retryable failures and Needs Human), and
+- the newest 15 *non-retryable terminal failures*, and
+- Complete/Abandoned items whose terminal moment falls in the **last 24 hours**.
+
+Two consequences you must hold onto when reporting:
+
+- **"Nothing in Merged" does not mean nothing merged.** It means nothing merged
+  *in the last 24 hours*. For real throughput use `--throughput`, which reads
+  `committedPullRequestsCount` and the full `completedWorkItems` archive.
+- **A terminal-failed Work Item can vanish from every repo-wide listing.** The
+  repo-wide query only shows items that are completed, working, or whose issue
+  is still in the relevant-issue store. Close the issue on the forge and a
+  failed attempt becomes invisible to `status` *and* to `workItems` — but a
+  direct `--issue N` query still finds it.
+
+So when a user says "issue #N disappeared" or "where did that failure go",
+reach for `--issue N` before concluding anything was deleted.
+
+### What a good report says
+
+Lead with what needs a human, not with a lane dump. A useful report answers:
+what is actively running and for how long; what is blocked and on what; what
+finished; and what the operator should do next. Per-step durations are the
+evidence — `IMPLEMENT[OK/1.3h] REVIEW[OK/30m] COMMIT[!!/2m]` tells the story
+that "needs human" alone does not.
+
+**Lifecycle chips collapse repeated attempts.** `lifecycleLabels` carries one
+entry per *phase*, not per run: the status is the **latest** attempt's and
+`durationMs` is the **sum** across every attempt. A phase that failed for 50
+minutes and then succeeded on retry in 3 renders as a single `IMPLEMENT[OK/54m]`
+— the failure is nowhere in the chip row. So a clean-looking chip row does not
+mean a clean run, and a long duration on an `OK` phase is often a retry story
+rather than one slow attempt. When the history matters, say the duration is
+cumulative, and read `step_run` in the SQLite database
+(`~/.local/share/ready-for-agent/ready-for-agent.db`, one row per attempt) for
+the actual sequence — the GraphQL API exposes no per-attempt step-run history.
+
+Flag a **stall** when a `RUNNING` item has sat in one state far longer than that
+step warrants (the script does this: ~90 min for agent-driven steps like
+Implement and Review, ~10 min for mechanical ones like worktree creation).
+Agent steps genuinely take a long time, so a raw duration is not itself alarming
+— the comparison to the step's own norm is what makes it informative.
+
+## Operating
+
+You have full autonomy here, but the operations differ enormously in cost and
+reversibility, so choose deliberately rather than reaching for the first one
+that clears the error.
+
+**Retry** creates a new Step Run for a failed or retryable Needs Human item,
+keeping the worktree, branch, PR, and session. It is the cheap, safe,
+almost-always-correct first move when `canRetry` is true. Most failures are
+budget exhaustion or a malformed agent response, and simply run clean the
+second time.
+
+```bash
+ready-for-agent retry <repo> --issue 412          # one issue
+ready-for-agent retry <repo> --work-item wi-...   # one work item
+ready-for-agent retry <repo> --all-retryable      # every retryable item
+```
+
+`--all-retryable` is an *Autonomous Retry* and is capped by the Autonomous Retry
+Budget (default 3 attempts per Work Item at its current step); explicit
+single-issue and single-work-item retries are not capped. Prefer the targeted
+form when you already know which item you mean — it is bounded by intent rather
+than by budget.
+
+**Reset is destructive and has no undo.** It stops the run, deletes the git
+worktree and branch, and erases the Work Item *and its entire Step Run history*,
+returning the issue to Not Implemented. Unlike Abandon it preserves nothing.
+Reset is the right call when the harness explicitly asks for it — most commonly
+"Open Issue-closing PR #N is not owned by this Work Item", where a competing PR
+already exists and the local attempt is genuinely worthless. Before resetting,
+look at the PR the message names and tell the user what you found; erasing a
+long Implement run to fix a message you have not read is how real work is lost.
+
+Reset has no CLI verb — it is a GraphQL mutation (see `references/graphql-api.md`).
+
+**Starting work** spends the user's real agent tokens and subscription quota, so
+scale matters: starting one issue is routine, starting an entire backlog is not.
+
+```bash
+ready-for-agent candidates <repo>   # read-only: what would start
+ready-for-agent intake <repo>       # starts EVERY current candidate
+```
+
+Run `candidates` before `intake`, every time, and say how many items `intake`
+would launch. `intake` on a large backlog can start dozens of concurrent agent
+runs. For a single issue use the `implementNow` mutation, or `implementLocally`
+when the user wants to inspect the work before any commit or PR exists.
+
+**Pause / Start** hold and release a Work Item without destroying anything, and
+are the right tool when the user wants to stop the bleeding while they think.
+Pause does not interrupt a step that is already running.
+
+Repository selectors accept `github.com/owner/repo`, `owner/repo`, or just a
+unique final segment like `repo` — the short form is fine and much easier to
+read.
+
+## Triage playbook
+
+When something is stuck, the reason code and status message carry the diagnosis;
+your job is to translate them into an action rather than re-deriving them.
+
+| What you see | What it means | Do |
+| --- | --- | --- |
+| `canRetry: true` | The step failed but the path forward is intact | Retry |
+| "Open Issue-closing PR #N is not owned by this Work Item" | Another PR closes this issue and the harness does not recognise it as its own | **Check the PR before Reset** — see below |
+| "Issue #N is no longer present in the Issue store" | Issue was closed or unlabelled mid-flight | Nothing to fix; report it. Reopen/relabel to retry |
+| `handler_failed` + "did not report valid READY_FOR_AGENT_RESULT" | The agent's final message was malformed | Retry; if it repeats, the model is too weak — suggest a stronger one |
+| `agent_backend_unavailable` / `agent_backend_auth_rejected` | CLI missing from PATH, or not authenticated | Fix the CLI, then Recheck in Settings |
+| `agent_model_not_in_catalog` | Configured model is gone from the backend catalog | Pick a current model in Settings |
+| `missing_successful_checks` | Autonomous merge wanted green CI and did not get it | Retryable — returns to watching checks |
+| `github_throttled` | Rate limited; stopped cleanly at GitHub's retry time | Wait for `retryAt`; do not hammer it |
+| Paused | An operator held it | Start (Retry is rejected while paused) |
+
+### The "unowned PR" message is not self-explanatory
+
+`issue_closing_pull_request_unowned` invites a reflexive Reset, and that is
+often wrong. The message is captured when the PR is observed and **goes stale**:
+by the time you read it the PR has usually been merged, so "Open PR #N" may
+describe something that closed days ago. Check the PR's real state and, more
+importantly, its head branch:
+
+```bash
+gh pr view <N> --repo <owner/repo> --json number,state,headRefName,mergedAt
+```
+
+The harness names its own branches `rfa/<owner>-<repo>/<issue>/<work-item-id>`.
+If the head branch carries **this Work Item's own id**, the PR *is* this Work
+Item's work — it shipped, and ownership detection simply failed to reconnect it.
+Nothing was lost, and Reset is just bookkeeping. If the branch is unrelated
+(`fix/...`, someone else's work), a genuine competing PR closed the issue and
+the local attempt really is redundant.
+
+Either way the conclusion is usually Reset, but what you tell the user differs
+completely: "your agent's work merged as PR #280, the harness lost track of it"
+is a very different report from "someone else fixed this first". Say which.
+
+To inspect what the agent actually did, reattach to its session — this is the
+fastest way to answer "why did it do *that*":
+
+```bash
+ready-for-agent jump <session-id>   # takes over the terminal
+opencode -s <session-id>            # or the backend CLI directly
+```
+
+Repeated failures across *different* issues usually indict configuration — a
+weak model, an unavailable backend — rather than the issues. Say so, instead of
+retrying each one in turn.
+
+## Details on demand
+
+- `references/lifecycle.md` — every state, status, lane rule, reason code, and
+  failure code, with what each one implies for the operator.
+- `references/graphql-api.md` — the full GraphQL surface at
+  `http://127.0.0.1:6056/graphql`: queries, mutations, input shapes, and
+  ready-to-run examples. Read this whenever you need something the CLI has no
+  verb for — Reset, Pause, Start, `implementNow`, `implementLocally`, session
+  token/cost telemetry, or per-repository settings.
+
+## Facts worth not re-deriving
+
+- The GraphQL endpoint is the complete surface; the CLI exposes only six verbs
+  and every one of them is a thin client over it.
+- CLI JSON output carries `schemaVersion` and, on failure, an `error` object
+  with a `code` (for example `REPOSITORY_NOT_FOUND`) — parse it rather than
+  matching on prose.
+- Issues on the forge are authoritative. The local SQLite database is
+  bookkeeping, and reconciliation runs on a poll — a freshly labelled issue takes
+  a moment to appear, and `issuesReconciledAt` tells you how stale the view is.
+- The API is versioned with the binary, and fields do move between releases
+  (older releases exposed `autoMerge` where current ones carry a three-state
+  `mergePolicy`). If a query
+  fails validation, introspect the live schema rather than trusting this
+  document:
+
+  ```bash
+  curl -s -X POST http://127.0.0.1:6056/graphql -H 'Content-Type: application/json' \
+    -d '{"query":"{ __type(name:\"WorkItem\"){ fields { name } } }"}'
+  ```

--- a/.agents/skills/ready-for-agent/agents/openai.yaml
+++ b/.agents/skills/ready-for-agent/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Ready for Agent"
+  short_description: "Operate the Harness and report Work Item progress"

--- a/.agents/skills/ready-for-agent/references/graphql-api.md
+++ b/.agents/skills/ready-for-agent/references/graphql-api.md
@@ -1,0 +1,314 @@
+# GraphQL API reference
+
+`http://127.0.0.1:6056/graphql` (override with `READY_FOR_AGENT_GRAPHQL_URL`).
+No authentication — it binds loopback only unless started with `--host`.
+
+This is the **complete** harness surface. The six CLI verbs are thin clients
+over it, so anything the CLI cannot do (Reset, Pause, Start, `implementNow`,
+session telemetry, settings) is available here.
+
+## Contents
+
+- [Calling it](#calling-it)
+- [Queries](#queries)
+- [Mutations](#mutations)
+- [Input shapes](#input-shapes)
+- [Recipes](#recipes)
+- [Introspection](#introspection)
+
+## Calling it
+
+```bash
+curl -s -X POST http://127.0.0.1:6056/graphql \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ version health }"}'
+```
+
+For anything with quotes or variables, write the payload to a file and use
+`--data-binary @file.json` — shell-escaping a GraphQL document inline is a
+reliable way to waste a turn.
+
+Validation errors come back as `errors[].message` naming the offending field.
+Trust them: they mean the running binary's schema differs from your query, and
+the fix is [introspection](#introspection), not guessing.
+
+## Queries
+
+### Health and config
+
+| Query | Returns |
+| --- | --- |
+| `version` | Harness version string, e.g. `"0.24.0"` |
+| `health` | Boolean |
+| `config` | `selectedAgentBackend`, `defaultModel`, `defaultThinkingLevel`, `reviewModel`, `reviewThinkingLevel`, `maxConcurrentAgentTurns`, `maxConcurrentWorkItems`, `unfinishedWorkItemCount`, `blockingUnfinishedWorkItemCount` |
+| `agentBackends` | Installed backends |
+| `agentBackendStatuses` | Per backend: `kind` (`READY` / unavailable), `reason`, `backend { id label }`, `models`, `warnings` |
+| `models` | Model catalog |
+
+### Repositories
+
+`repositories` returns: `id`, `forge`, `forgeHost`, `projectPath`, `localPath`,
+`isBare`, `paused`, `selectedAgentBackend`, `effectiveAgentBackend`,
+`defaultModel`, `defaultThinkingLevel`, `reviewModel`, `reviewThinkingLevel`,
+`mergePolicy`, `includeAllIssueAuthors`, `waitForReadyForReviewChecks`,
+`issuesReconciledAt`, `blockingUnfinishedWorkItemCount`, `pullRequestCount`.
+
+`issuesReconciledAt` is how fresh the issue projection is. If it is far in the
+past, the harness has not polled the forge recently and the view is stale.
+
+**`pullRequestCount` is a trap, twice over.** It counts **open non-draft PRs on
+the forge**, regardless of Work Item ownership — not a merged-PR or throughput
+number. Reporting it as "merged PRs" is wrong and makes a productive repository
+look idle. For throughput use `committedPullRequestsCount` and
+`completedWorkItems`.
+
+It is also the riskiest field to select. It reaches the Forge API on every
+request and it is `Int!`, so when that call fails — rate limit, auth, offline, a
+repository the token cannot see — the non-null propagates up through
+`[Repository!]!` and **nulls the entire response**: `data` comes back `null` and
+every unrelated field in the same query is lost with it. Select it in its own
+query and treat failure as unknown, rather than letting one Forge lookup cost a
+whole progress report.
+
+### Work Items
+
+```graphql
+workItems(
+  repositoryId: ID!        # required
+  issueNumber: Int         # one issue — bypasses the visibility filter
+  listKind: WorkItemsListKind   # WORKING | FAILED | COMPLETED
+  limit: Int
+)
+```
+
+Fields:
+
+| Field | Notes |
+| --- | --- |
+| `id` | `wi-...` |
+| `issueNumber`, `issueTitle` | |
+| `state`, `stateLabel` | Lifecycle position |
+| `status`, `statusLabel` | How the step is going |
+| `statusMessage` | Human-readable stop reason — often the whole diagnosis |
+| `canRetry` | Whether Retry is available now |
+| `isTerminal`, `paused` | |
+| `pullRequestNumber` | |
+| `sessionId` | Feed to `ready-for-agent jump` or the backend CLI |
+| `worktreePath` | Usually under `/tmp/ready-for-agent/...` |
+| `stateResidenceMs` | Time in current state — the stall signal |
+| `lifecycleLabels` | `{ phase, label, status, durationMs }` per step |
+| `latestStepRunReason` | `{ code, message, detail { code causeChain { name message } }, retryAt }` |
+| `mergeMode` | `ORDINARY` \| `ALWAYS` |
+| `failureCode` | Terminal failure classification |
+| `executionProfile` | Pinned backend/model override, or null |
+| `agentBackend` | `{ id label }` |
+| `createdAt`, `updatedAt` | |
+
+**Visibility:** without `issueNumber`, results are filtered to items that are in
+a completed state, or working, **or** whose issue is still in the relevant-issue
+store. Passing `issueNumber` skips that filter — use it to find a terminal
+failure whose issue was closed.
+
+### Kanban projection
+
+```graphql
+kanbanStatus(repositoryId: ID) {
+  lanes { id label count workItems { repository { id projectPath } workItem { ... } } }
+}
+```
+
+Same windowing as `ready-for-agent status` (see `lifecycle.md`). `workItems`
+here is a `KanbanWorkItem` wrapper — the Work Item fields live under
+`.workItem`, which is a common source of validation errors.
+
+### Completed archive and throughput
+
+```graphql
+completedWorkItems(page: Int, pageSize: Int) { totalCount page pageSize items { ... } }
+committedPullRequestsCount(from: String!, to: String!)   # ISO-8601, e.g. "2026-08-01T00:00:00Z"
+```
+
+Neither is subject to the 24-hour window — these are the honest throughput
+numbers.
+
+### Sessions and intake
+
+```graphql
+session(workItemId: ID!) {
+  id availability backend { id label } model { ... } cost
+  tokens { input output reasoning cacheRead cacheWrite }
+  createdAt updatedAt
+}
+workItemBySessionId(sessionId: String!)
+intakeCandidates(repositoryId: ID!)
+issues(repositoryId: ID!)
+```
+
+`availability` is `AVAILABLE` | `MISSING` | `UNAVAILABLE` | `UNSUPPORTED`.
+Backends prune old sessions, so token and cost telemetry on an older Work Item
+frequently comes back `MISSING` with null fields — that is expected, not a bug.
+
+## Mutations
+
+### Starting work — spends real tokens
+
+| Mutation | Effect |
+| --- | --- |
+| `implementNow(repositoryId, issueNumber)` | Full run: implement → review → PR → merge if allowed |
+| `implementLocally(repositoryId, issueNumber)` | Stops before commit/PR so a human can inspect |
+| `implementWith(repositoryId, issueNumber, profile, options)` | Run with a pinned backend/model profile |
+| `implementAllWithAutoMerge(repositoryId, issueNumber)` | Parent issue → implements all children, merge policy Always |
+| `queue(repositoryId, issueNumber)` | Enqueue rather than start immediately |
+| `startRepositoryIntake(repositoryId)` | Start **every** current candidate — check `intakeCandidates` first |
+
+### Controlling a Work Item
+
+| Mutation | Reversible | Effect |
+| --- | --- | --- |
+| `retryWorkItem(workItemId): WorkItem!` | yes | New Step Run, keeps everything |
+| `retryWorkItems(repositoryId, selector, maxAutonomousRetries)` | yes | Bulk retry |
+| `startWorkItem(workItemId): WorkItem!` | yes | Clear Pause, resume |
+| `pauseWorkItem(workItemId): WorkItem!` | yes | Hold; does not interrupt a running step |
+| `interruptWorkItem(workItemId): WorkItem!` | yes | Stop a *running* step on an already-paused item |
+| `resetWorkItem(workItemId): ID!` | **NO** | Deletes worktree, branch, Work Item, and all history |
+
+### Repositories and config
+
+`addRepository(input)`, `addLocalRepository(path)`,
+`inspectLocalRepository(path)`, `removeRepository(repositoryId)`,
+`refreshRepository(repositoryId)` (forces issue reconciliation),
+`pauseRepository` / `unpauseRepository`, `updateRepositorySettings(input)`,
+`updateConfig(input)`, `recheckAgentBackend(backendId)`,
+`addRepositoryGitHubToken` / `addRepositoryGitLabToken`.
+
+## Input shapes
+
+```graphql
+input UpdateConfigInput {
+  selectedAgentBackend: String
+  defaultModel: String
+  defaultThinkingLevel: String
+  reviewModel: String
+  reviewThinkingLevel: String
+  maxConcurrentAgentTurns: Int
+  maxConcurrentWorkItems: Int
+}
+
+input UpdateRepositorySettingsInput {
+  repositoryId: ID!
+  forge: String
+  forgeHost: String
+  projectPath: String
+  paused: Boolean
+  selectedAgentBackend: String
+  defaultModel: String
+  defaultThinkingLevel: String
+  reviewModel: String
+  reviewThinkingLevel: String
+  mergePolicy: MergePolicy!      # OFF | CLASSIFY | ALWAYS
+  includeAllIssueAuthors: Boolean!
+  waitForReadyForReviewChecks: Boolean!
+}
+
+input RetryWorkItemsSelector {
+  issueNumber: Int
+  workItemId: ID
+  allRetryable: Boolean
+}
+
+input ExplicitWorkItemExecutionProfileInput {
+  agentBackendId: String
+  buildModel: String
+  buildThinkingLevel: String
+  reviewSameAsBuild: Boolean
+  reviewModel: String
+  reviewThinkingLevel: String
+}
+
+input ImplementWithOptionsInput {
+  mergePolicy: MergePolicy!      # OFF | CLASSIFY | ALWAYS
+  implementLocally: Boolean!
+}
+```
+
+Models must come from the backend's live catalog (`agentBackendStatuses.models`)
+— an invented model id fails closed at the step rather than silently
+substituting.
+
+## Recipes
+
+**Full pipeline snapshot** (what `rfa_report.py` runs):
+
+```graphql
+{
+  config { selectedAgentBackend maxConcurrentWorkItems unfinishedWorkItemCount }
+  repositories { id projectPath paused mergePolicy issuesReconciledAt }
+  kanbanStatus {
+    lanes { id label count
+      workItems { repository { projectPath }
+        workItem {
+          issueNumber issueTitle state status statusMessage canRetry
+          stateResidenceMs pullRequestNumber sessionId
+          lifecycleLabels { phase status durationMs }
+          latestStepRunReason { code message retryAt }
+        } } }
+  }
+}
+```
+
+**Find a Work Item hidden from listings:**
+
+```json
+{"query":"query($r:ID!,$n:Int!){ workItems(repositoryId:$r, issueNumber:$n){ id state status statusMessage failureCode lifecycleLabels { phase status durationMs } } }",
+ "variables":{"r":"repo-...","n":412}}
+```
+
+**Reset a Work Item** (destructive — read `statusMessage` first):
+
+```json
+{"query":"mutation($id:ID!){ resetWorkItem(workItemId:$id) }",
+ "variables":{"id":"wi-..."}}
+```
+
+`resetWorkItem` alone returns a bare `ID!` scalar, so it takes **no selection
+set** — `resetWorkItem(workItemId:$id){ id }` fails validation with "must not
+have a selection since type ID! has no subfields". Its siblings differ:
+`retryWorkItem`, `pauseWorkItem`, `startWorkItem`, and `interruptWorkItem` all
+return `WorkItem!` and *do* take one. A validation failure is safe either way —
+the mutation never executes, so a malformed Reset destroys nothing.
+
+**Full error detail on a failure:**
+
+```graphql
+{ workItems(repositoryId:"repo-...", issueNumber: 412) {
+    latestStepRunReason { code message retryAt
+      detail { code causeChain { name message } } } } }
+```
+
+The `causeChain` names the concrete error types (`ImplementOpenCodeError`,
+`AgentBackendExitError`, `CommitPublicationCopyError`) and is the most precise
+signal available for why a step failed.
+
+## Introspection
+
+Field names move between releases. When a query fails validation, ask the live
+schema:
+
+```bash
+# fields on a type
+curl -s -X POST http://127.0.0.1:6056/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ __type(name:\"WorkItem\"){ fields { name } } }"}'
+
+# enum values
+curl -s -X POST http://127.0.0.1:6056/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ __type(name:\"WorkItemState\"){ enumValues { name } } }"}'
+
+# input object shape
+curl -s -X POST http://127.0.0.1:6056/graphql -H 'Content-Type: application/json' \
+  -d '{"query":"{ __type(name:\"UpdateConfigInput\"){ inputFields { name } } }"}'
+```
+
+Known drift: older releases exposed `Repository.autoMerge` (Boolean) where
+current schemas carry `mergePolicy: MergePolicy!` (`OFF` / `CLASSIFY` /
+`ALWAYS`). Check `version` and introspect before writing merge-related
+mutations against an older harness.

--- a/.agents/skills/ready-for-agent/references/lifecycle.md
+++ b/.agents/skills/ready-for-agent/references/lifecycle.md
@@ -1,0 +1,212 @@
+# Work Item lifecycle reference
+
+The vocabulary below is generated from a versioned ontology (`ontology/rfa.ttl`
+in the harness source), so these names are exact — they appear verbatim in
+GraphQL responses, CLI JSON, and the UI.
+
+## Contents
+
+- [State vs status](#state-vs-status)
+- [Lifecycle states](#lifecycle-states)
+- [Statuses](#statuses)
+- [Kanban lanes](#kanban-lanes)
+- [Source windows](#source-windows-why-work-disappears)
+- [Step Run reason codes](#step-run-reason-codes)
+- [Failure codes](#failure-codes)
+- [Operator actions](#operator-actions)
+
+## State vs status
+
+A Work Item carries both, and reporting either alone is misleading.
+
+- **State** — where it is in the lifecycle (`IMPLEMENT`, `REVIEW`, `MERGE_PR`).
+- **Status** — how the current step is going (`RUNNING`, `FAILED`, `QUEUED`).
+
+`IMPLEMENT/RUNNING` is healthy work in progress. `IMPLEMENT/FAILED` is a
+stopped attempt. `IMPLEMENT/NEEDS_HUMAN` is a handoff. Always report the pair.
+
+`stateResidenceMs` is how long it has sat in the current state — the single most
+useful number for spotting a stall.
+
+**`lifecycleLabels` is per phase, not per attempt.** Its `status` is the latest
+attempt's outcome and `durationMs` is the sum over all attempts, so a retried
+step hides its earlier failures. Verified example: a 49.96-minute failed
+Implement plus a 3.6-minute successful retry renders as one
+`IMPLEMENT SUCCEEDED 3213281ms`. For real per-attempt history read the
+`step_run` table in `~/.local/share/ready-for-agent/ready-for-agent.db`
+(columns `step`, `status`, `reason_code`, `started_at`, `finished_at`) — open it
+read-only, and note the harness runs in WAL mode, so copy the `-wal` file too or
+query the original with a read-only URI rather than copying the `.db` alone.
+The `autonomous_retry` table records budget-tracked retries.
+
+## Lifecycle states
+
+In lifecycle order. Each maps to the lane shown.
+
+| State | Lane | What happens |
+| --- | --- | --- |
+| `CREATE_WORKTREE` | Build | Fresh git worktree for this attempt |
+| `INSTALL_DEPENDENCIES` | Build | Package install in the worktree |
+| `IMPLEMENT` | Build | **Agent turn** — writes the implementation |
+| `ASSESS_CHANGES` | Build | Harness checks whether anything actually changed |
+| `PRE_COMMIT` | Build | Pre-commit hooks / checks |
+| `REVIEW` | Review | **Agent turn** — local code review, may loop applying findings |
+| `COMMIT` | PR | **Agent turn** for commit copy, then the native commit |
+| `CREATE_PR` | PR | Opens the pull request |
+| `WATCH_PR_STATUS_CHECKS` | PR | Polls CI (`QUEUED` here is normal, not stuck) |
+| `RESOLVE_PR_MERGE_CONFLICT` | PR | **Agent turn** — resolves conflicts |
+| `INVESTIGATE_PR_STATUS_CHECKS` | PR | **Agent turn** — diagnoses failing CI |
+| `MARK_PR_READY_FOR_REVIEW` | PR | Flips draft → ready |
+| `DECIDE_PR_MERGE` | PR | **Agent turn** — risk classification for autonomous merge |
+| `MERGE_PR` | PR | Performs the merge |
+| `CLOSE_ISSUE` | PR | Closes the issue when the merge did not |
+| `LOCAL_CLEANUP` | PR | Removes worktree and branch |
+
+Terminal states:
+
+| State | Lane | Meaning |
+| --- | --- | --- |
+| `COMPLETE` | Merged | Succeeded end to end |
+| `ABANDONED` | Merged | Deliberately given up, history preserved |
+| `FAILED` | Attention | Terminal failure |
+| `NEEDS_HUMAN` | Attention | Harness stopped and handed back, with a reason |
+
+Steps marked **agent turn** invoke the coding-agent CLI and routinely take
+minutes to hours. Do not treat their duration as a stall on its own.
+
+## Statuses
+
+| Status | Meaning |
+| --- | --- |
+| `QUEUED` | Step enqueued, not yet running. Normal; not stuck |
+| `RUNNING` | Executing now |
+| `SUCCEEDED` | Step finished cleanly |
+| `FAILED` | Step failed. Often retryable — check `canRetry` |
+| `INTERRUPTED` | Stopped mid-run (Interrupt Work Item, or worker restart) |
+| `CANCELLED` | Cancelled before completion |
+| `POSTPONED` | Deferred to `retryAt`. Retry is unavailable until then |
+| `COMPLETE` | Terminal success |
+| `ABANDONED` | Terminal abandonment |
+| `NEEDS_HUMAN` | Handoff to the operator |
+| `NEEDS_HUMAN_REVIEW` | Handoff specifically for human code review |
+| `WAITING_FOR_WORKER_SLOT` | Admitted, waiting for concurrency capacity |
+| `WAITING_FOR_BLOCKERS` | Blocked by other issues; no worktree yet |
+| `WAITING_FOR_GITHUB` | Waiting on the forge (often rate limiting) |
+
+## Kanban lanes
+
+Lane assignment is a pure function of state and status:
+
+1. **Attention and Merged win over everything.** Status `FAILED`,
+   `INTERRUPTED`, `NEEDS_HUMAN`, or `NEEDS_HUMAN_REVIEW`, or state `FAILED` /
+   `NEEDS_HUMAN` → **Attention**, regardless of how far the lifecycle got.
+   `COMPLETE` / `ABANDONED` → **Merged**.
+2. **Queue is only genuine holds** — `WAITING_FOR_BLOCKERS` and
+   `WAITING_FOR_WORKER_SLOT`.
+3. Otherwise the lifecycle state decides Build / Review / PR. A `QUEUED` status
+   on a later step keeps the item in its current lane; it never falls back to
+   Queue.
+
+So a Work Item that reached `MERGE_PR` but went Needs Human reports in
+**Attention**, not PR. Its lifecycle chips still show how far it got.
+
+## Source windows (why work disappears)
+
+The shared projection behind `ready-for-agent status`, `kanbanStatus`, and the
+board is deliberately windowed:
+
+- **Working** — every unfinished Work Item, plus retryable failures and Needs
+  Human handoffs. No cap.
+- **Failed** — only the newest **15** non-retryable terminal failures, ordered
+  by creation. Older ones drop off.
+- **Completed** — `COMPLETE` / `ABANDONED` only if terminal within the last
+  **24 hours**.
+
+On top of that, the repo-wide `workItems` query filters to items that are in a
+completed state, or working, **or whose issue is still in the relevant-issue
+store**. A terminal-failed Work Item whose issue was closed or unlabelled on the
+forge satisfies none of these and becomes invisible to every repo-wide listing.
+
+Querying `workItems(repositoryId:, issueNumber:)` bypasses the visibility filter
+and still returns it. This is the only reliable way to answer "what happened to
+issue N".
+
+For real throughput use `committedPullRequestsCount` and `completedWorkItems`
+(a full paginated archive, no 24-hour window).
+
+## Step Run reason codes
+
+The complete vocabulary. `latestStepRunReason.code` carries one of these.
+
+**Mid-run progress** (informational — the step is working, not stuck):
+
+| Code | Meaning |
+| --- | --- |
+| `native` | Step is doing its non-agent native work |
+| `waiting_for_agent_turn` | Queued for an agent-turn slot |
+| `copy_generation` | Commit is generating PR/commit copy via an agent turn |
+| `review_reviewing` | Review pass in progress |
+| `review_assessing_rerun` | Deciding whether another review round is needed |
+| `review_applying_findings` | Applying review findings |
+| `review_pre_commit` | Pre-commit work inside review |
+| `review_deferred` | Review deferred |
+| `agent_fallback` | Native path missed its postcondition; one repair agent turn ran |
+
+**Clean outcomes:**
+
+| Code | Meaning |
+| --- | --- |
+| `review_clean` / `review_cleared` | Review found nothing blocking |
+| `review_accepted` | Review findings accepted |
+| `pr_merged` | PR merged |
+| `merge_revalidation` | Merge preconditions being revalidated |
+| `green-no-review-evidence` | CI green, but no positive automated-review evidence found |
+
+**Stops needing a decision:**
+
+| Code | Meaning | Action |
+| --- | --- | --- |
+| `handler_failed` | The step's handler failed — most commonly the agent returned a malformed `READY_FOR_AGENT_RESULT`, or exited non-zero | Retry; repeated failures indict the model |
+| `handler_defect` | Internal harness defect | Report it; retry rarely helps |
+| `timeout` | Step exceeded its budget | Retry |
+| `interrupted` | Interrupted mid-run | Retry once Pause is cleared |
+| `worker_restarted` | Harness restarted under it | Retry |
+| `paused` | Operator paused it | Start, then Retry |
+| `abandoned` | Operator abandoned it | Terminal |
+| `reset` | Operator reset it | Work Item is gone |
+| `agent_backend_unavailable` | Backend CLI missing or broken | Fix PATH/auth, Recheck |
+| `agent_backend_auth_rejected` | Credentials missing, expired, invalid | Re-authenticate the CLI |
+| `agent_model_not_in_catalog` | Configured model absent from the live catalog | Pick a current model |
+| `thinking_level_not_in_catalog` | Configured effort absent from the catalog | Pick a current effort |
+| `build_model_not_configured` | No build model configured | Set one in Settings |
+| `github_throttled` | Rate limited; stopped at GitHub's retry time | Wait for `retryAt` |
+| `missing_successful_checks` | Autonomous merge required green CI, did not get it | Retryable |
+| `pr_status_checks_unresolved` | Status checks never resolved | Retryable |
+| `issue_closed_while_pr_open` | Issue closed while its PR is still open | Human decision |
+| `issue_closed_pr_closed_unmerged` | Issue closed, PR closed unmerged | Human decision |
+
+## Failure codes
+
+`failureCode` on a terminal Work Item:
+
+| Code | Meaning |
+| --- | --- |
+| `issue_not_found` | The issue left the relevant-issue store mid-flight (closed, unlabelled, or deleted). The attempt is abandoned; nothing to repair locally |
+| `issue_closing_pull_request_unowned` | Another open PR already closes this issue and this Work Item does not own it. Review that PR, then Reset |
+| `pr_status_checks_unresolved` | Legacy terminal record; still retryable — restores status-check watching |
+
+## Operator actions
+
+| Action | Reversible | What it does |
+| --- | --- | --- |
+| **Retry** | yes | New Step Run; keeps worktree, branch, PR, session. Must re-acquire a worker slot. Rejected while paused or postponed |
+| **Start** | yes | Clears Pause and resumes the current step |
+| **Pause** | yes | Marks the item paused; does **not** interrupt a running step. Cancels queued steps |
+| **Interrupt** | yes | Stops a *running* step on an already-paused item; keeps worktree and session |
+| **Abandon** | no | Terminal give-up; **preserves** history |
+| **Reset** | **no** | Stops runs, deletes worktree and branch, erases the Work Item and all Step Run history. Issue returns to Not Implemented |
+
+**Autonomous Retry Budget:** `--all-retryable` retries are capped (default 3 per
+Work Item at its current step) and report `LIMIT_REACHED` on exhaustion. The
+budget resets only when the item advances to a different step. Explicit
+single-issue, single-work-item, and UI retries are not capped.

--- a/.agents/skills/ready-for-agent/scripts/rfa_report.py
+++ b/.agents/skills/ready-for-agent/scripts/rfa_report.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Detailed progress report for a running Ready for Agent harness.
+
+One GraphQL round trip per section, then a dense operator-readable report:
+lane occupancy, per-work-item lifecycle timing, stall detection, blocked
+reasons, and throughput.
+
+Usage:
+  rfa_report.py                         # every repository
+  rfa_report.py --repo acme-web         # one repository (substring of project path)
+  rfa_report.py --issue 412             # one issue, including items hidden from listings
+  rfa_report.py --json                  # machine-readable
+  rfa_report.py --endpoint http://127.0.0.1:7000/graphql
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+DEFAULT_ENDPOINT = os.environ.get(
+    "READY_FOR_AGENT_GRAPHQL_URL", "http://127.0.0.1:6056/graphql"
+)
+
+# Steps that run an agent turn; these legitimately take many minutes, so the
+# stall thresholds below are deliberately generous for them.
+AGENT_STEPS = {"IMPLEMENT", "REVIEW", "COMMIT", "DECIDE_PR_MERGE",
+               "INVESTIGATE_PR_STATUS_CHECKS", "RESOLVE_PR_MERGE_CONFLICT"}
+AGENT_STALL_MS = 90 * 60 * 1000      # 90 min inside an agent step
+OTHER_STALL_MS = 10 * 60 * 1000      # 10 min inside a mechanical step
+
+# Repository merge configuration changed shape between releases: older harnesses
+# expose `autoMerge: Boolean`, current ones a three-state `mergePolicy`. Probe
+# once and build the query around whichever this harness actually serves, so the
+# report works across versions instead of failing validation on one of them.
+MERGE_FIELD_MODERN = "mergePolicy"
+MERGE_FIELD_LEGACY = "autoMerge"
+
+KANBAN_QUERY = """
+{
+  config {
+    selectedAgentBackend maxConcurrentAgentTurns maxConcurrentWorkItems
+    unfinishedWorkItemCount blockingUnfinishedWorkItemCount
+  }
+  repositories {
+    id projectPath forgeHost localPath paused __MERGE_FIELD__
+    effectiveAgentBackend defaultModel defaultThinkingLevel reviewModel
+    includeAllIssueAuthors issuesReconciledAt
+    blockingUnfinishedWorkItemCount
+  }
+  agentBackendStatuses { kind reason backend { id label } }
+  kanbanStatus {
+    lanes {
+      id label count
+      workItems {
+        repository { id projectPath }
+        workItem {
+          id issueNumber issueTitle state stateLabel status statusLabel
+          statusMessage canRetry isTerminal paused pullRequestNumber
+          sessionId worktreePath stateResidenceMs mergeMode failureCode
+          createdAt updatedAt
+          agentBackend { id label }
+          lifecycleLabels { phase label status durationMs }
+          latestStepRunReason { code message retryAt }
+        }
+      }
+    }
+  }
+}
+"""
+
+ISSUE_QUERY = """
+query ($repositoryId: ID!, $issueNumber: Int!) {
+  workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+    id issueNumber issueTitle state stateLabel status statusLabel
+    statusMessage canRetry isTerminal paused pullRequestNumber
+    sessionId worktreePath stateResidenceMs mergeMode failureCode
+    createdAt updatedAt
+    agentBackend { id label }
+    lifecycleLabels { phase label status durationMs }
+    latestStepRunReason { code message retryAt }
+  }
+}
+"""
+
+# `pullRequestCount` is `Int!` and reaches the Forge API, so when that call
+# fails the non-null propagates and nulls the WHOLE query — one rate-limited
+# lookup would otherwise cost the entire progress report. Fetch it on its own
+# and treat failure as "unknown".
+PR_COUNT_QUERY = """
+{ repositories { id pullRequestCount } }
+"""
+
+THROUGHPUT_QUERY = """
+query ($from: String!, $to: String!) {
+  committedPullRequestsCount(from: $from, to: $to)
+  completedWorkItems(page: 1, pageSize: 10) {
+    totalCount
+    items { id issueNumber issueTitle state pullRequestNumber updatedAt }
+  }
+}
+"""
+
+
+def gql(endpoint: str, query: str, variables: dict | None = None) -> dict:
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        endpoint, data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.load(resp)
+    except urllib.error.URLError as exc:
+        sys.exit(
+            f"Cannot reach the harness at {endpoint}: {exc}\n"
+            "Is `ready-for-agent` running? Start it with `ready-for-agent --no-open`."
+        )
+    errors = body.get("errors")
+    data = body.get("data")
+    if errors and data is None:
+        sys.exit("GraphQL errors:\n" + json.dumps(errors, indent=2))
+    if errors:
+        # Field-level failures are routine: `pullRequestCount` reaches the Forge
+        # API and dies on rate limits, auth, or a network blip. GraphQL still
+        # returns every field that resolved, so report the gap and keep going
+        # rather than discarding a whole progress report over one nullable field.
+        for err in errors:
+            path = ".".join(str(p) for p in err.get("path") or []) or "query"
+            print(f"  ! partial data — {path}: {err.get('message')}", file=sys.stderr)
+    return data
+
+
+def fetch_pr_counts(endpoint: str) -> dict[str, int]:
+    """Best-effort open-PR counts, keyed by repository id; {} when the Forge call fails."""
+    payload = json.dumps({"query": PR_COUNT_QUERY}).encode()
+    req = urllib.request.Request(
+        endpoint, data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.load(resp)
+        repos = (body.get("data") or {}).get("repositories") or []
+        return {r["id"]: r["pullRequestCount"] for r in repos}
+    except Exception:
+        return {}
+
+
+def detect_merge_field(endpoint: str) -> str:
+    """Return whichever Repository merge field this harness serves."""
+    data = gql(endpoint,
+               '{ __type(name: "Repository") { fields { name } } }')
+    names = {f["name"] for f in (data["__type"] or {}).get("fields", [])}
+    return MERGE_FIELD_MODERN if MERGE_FIELD_MODERN in names else MERGE_FIELD_LEGACY
+
+
+def render_merge(repo: dict, field: str) -> str:
+    value = repo.get(field)
+    if field == MERGE_FIELD_MODERN:
+        return str(value).lower() if value else "unknown"
+    return "always" if value else "off/classify"
+
+
+def human_ms(ms) -> str:
+    if ms is None:
+        return "-"
+    s = ms / 1000.0
+    if s < 60:
+        return f"{s:.0f}s"
+    m = s / 60.0
+    if m < 60:
+        return f"{m:.0f}m"
+    return f"{m / 60.0:.1f}h"
+
+
+def age_ms(iso: str | None) -> float | None:
+    if not iso:
+        return None
+    try:
+        dt = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return (datetime.now(timezone.utc) - dt).total_seconds() * 1000
+
+
+def stall_note(wi: dict) -> str | None:
+    """Flag work that has sat in one state longer than its step warrants."""
+    if wi["status"] != "RUNNING":
+        return None
+    resident = wi.get("stateResidenceMs")
+    if resident is None:
+        return None
+    limit = AGENT_STALL_MS if wi["state"] in AGENT_STEPS else OTHER_STALL_MS
+    if resident > limit:
+        return f"STALL? {human_ms(resident)} in {wi['state']}"
+    return None
+
+
+def chip_line(labels: list[dict]) -> str:
+    mark = {"SUCCEEDED": "OK", "RUNNING": ">>", "FAILED": "XX",
+            "NEEDS_HUMAN": "!!", "QUEUED": "..", "INTERRUPTED": "--"}
+    return "  ".join(
+        f"{c['phase']}[{mark.get(c['status'], c['status'][:2])}"
+        f"{'/' + human_ms(c['durationMs']) if c['durationMs'] else ''}]"
+        for c in labels
+    )
+
+
+def render_work_item(wi: dict, repo_label: str | None, indent: str = "   ") -> list[str]:
+    out = []
+    head = f"{indent}#{wi['issueNumber']} {wi['state']}/{wi['status']}"
+    if repo_label:
+        head += f"  [{repo_label}]"
+    flags = []
+    if wi.get("paused"):
+        flags.append("PAUSED")
+    if wi.get("canRetry"):
+        flags.append("retryable")
+    if wi.get("pullRequestNumber"):
+        flags.append(f"PR#{wi['pullRequestNumber']}")
+    if wi.get("failureCode"):
+        flags.append(f"failure={wi['failureCode']}")
+    if flags:
+        head += "  (" + ", ".join(flags) + ")"
+    out.append(head)
+    out.append(f"{indent}  {(wi.get('issueTitle') or '')[:100]}")
+
+    stall = stall_note(wi)
+    if stall:
+        out.append(f"{indent}  ** {stall}")
+    if wi.get("stateResidenceMs") is not None:
+        out.append(f"{indent}  in state: {human_ms(wi['stateResidenceMs'])}")
+    if wi.get("lifecycleLabels"):
+        out.append(f"{indent}  {chip_line(wi['lifecycleLabels'])}")
+    if wi.get("statusMessage"):
+        out.append(f"{indent}  message: {wi['statusMessage'][:200]}")
+    reason = wi.get("latestStepRunReason") or {}
+    if reason.get("code"):
+        out.append(f"{indent}  reason[{reason['code']}]: {(reason.get('message') or '')[:160]}")
+        if reason.get("retryAt"):
+            out.append(f"{indent}  retryAt: {reason['retryAt']}")
+    if wi.get("sessionId"):
+        out.append(f"{indent}  session: {wi['sessionId']}  worktree: {wi.get('worktreePath') or '-'}")
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    ap.add_argument("--repo", help="substring match on project path, e.g. 'acme-web'")
+    ap.add_argument("--issue", type=int,
+                    help="report one issue, including items hidden from repo-wide listings")
+    ap.add_argument("--json", action="store_true", dest="as_json")
+    ap.add_argument("--throughput", action="store_true",
+                    help="include merged-PR counts and the completed archive")
+    args = ap.parse_args()
+
+    merge_field = detect_merge_field(args.endpoint)
+    pr_counts = fetch_pr_counts(args.endpoint)
+    data = gql(args.endpoint,
+               KANBAN_QUERY.replace("__MERGE_FIELD__", merge_field))
+    repos = data["repositories"]
+
+    def repo_match(path: str) -> bool:
+        return not args.repo or args.repo.lower() in path.lower()
+
+    selected = [r for r in repos if repo_match(r["projectPath"])]
+    if args.repo and not selected:
+        sys.exit(f"No configured repository matches {args.repo!r}. "
+                 f"Configured: {', '.join(r['projectPath'] for r in repos) or '(none)'}")
+
+    # Single-issue mode bypasses the kanban window entirely: a terminal-failed
+    # Work Item whose Issue left the relevant set is invisible to repo-wide
+    # listings but still answers a direct issueNumber query.
+    if args.issue is not None:
+        if len(selected) != 1:
+            sys.exit("--issue needs exactly one repository; narrow it with --repo")
+        repo = selected[0]
+        items = gql(args.endpoint, ISSUE_QUERY,
+                    {"repositoryId": repo["id"], "issueNumber": args.issue})["workItems"]
+        if args.as_json:
+            print(json.dumps({"repository": repo, "workItems": items}, indent=2))
+            return
+        print(f"Issue #{args.issue} in {repo['projectPath']} — {len(items)} work item(s)\n")
+        for wi in items:
+            print("\n".join(render_work_item(wi, None, indent="  ")))
+            print()
+        if not items:
+            print("  No Work Item exists for this issue "
+                  "(never started, or Reset erased it).")
+        return
+
+    if args.as_json:
+        print(json.dumps(data, indent=2))
+        return
+
+    cfg = data["config"]
+    selected_ids = {r["id"] for r in selected}
+
+    print("=" * 78)
+    print("READY FOR AGENT — PROGRESS REPORT")
+    print("=" * 78)
+    print(f"backend: {cfg['selectedAgentBackend']}   "
+          f"slots: {cfg['unfinishedWorkItemCount']}/{cfg['maxConcurrentWorkItems']} work items, "
+          f"max {cfg['maxConcurrentAgentTurns']} concurrent agent turns")
+
+    for st in data["agentBackendStatuses"]:
+        if st["kind"] != "READY":
+            print(f"  ! backend {st['backend']['label']}: {st['kind']} "
+                  f"{st.get('reason') or ''}")
+
+    print("\nRepositories")
+    for r in selected:
+        recon = age_ms(r["issuesReconciledAt"])
+        print(f"  {r['projectPath']} ({r['forgeHost']})"
+              f"  merge={render_merge(r, merge_field)}"
+              f"{'  PAUSED' if r['paused'] else ''}")
+        print(f"    agent={r['effectiveAgentBackend']} "
+              f"model={r['defaultModel'] or 'inherit'}"
+              f"/{r['defaultThinkingLevel'] or '-'}"
+              f"  review={r['reviewModel'] or 'same as build'}")
+        print(f"    blocking unfinished={r['blockingUnfinishedWorkItemCount']}"
+              f"  open PRs on forge={pr_counts.get(r['id'], '?')}"
+              f"  issues reconciled {human_ms(recon)} ago"
+              f"{'  (STALE)' if recon and recon > 30 * 60 * 1000 else ''}")
+
+    print("\nPipeline")
+    attention = []
+    for lane in data["kanbanStatus"]["lanes"]:
+        rows = [kw for kw in lane["workItems"]
+                if kw["repository"]["id"] in selected_ids]
+        print(f"\n[{lane['id']:9}] {len(rows)}")
+        if not rows:
+            print("   lane clear")
+            continue
+        for kw in rows:
+            wi = kw["workItem"]
+            label = kw["repository"]["projectPath"] if len(selected) > 1 else None
+            print("\n".join(render_work_item(wi, label)))
+            if lane["id"] == "ATTENTION":
+                attention.append((kw["repository"]["projectPath"], wi))
+
+    if attention:
+        print("\n" + "=" * 78)
+        print(f"NEEDS ATTENTION — {len(attention)} item(s)")
+        print("=" * 78)
+        for path, wi in attention:
+            action = ("Retry" if wi["canRetry"]
+                      else "Start" if wi["paused"]
+                      else "Reset (erases the attempt) or resolve on the forge")
+            print(f"  {path}#{wi['issueNumber']}: {wi['state']} -> {action}")
+            if wi.get("statusMessage"):
+                print(f"     {wi['statusMessage'][:160]}")
+
+    if args.throughput:
+        now = datetime.now(timezone.utc)
+        frm = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        tp = gql(args.endpoint, THROUGHPUT_QUERY,
+                 {"from": frm.isoformat().replace("+00:00", "Z"),
+                  "to": now.isoformat().replace("+00:00", "Z")})
+        print("\n" + "=" * 78)
+        print("THROUGHPUT")
+        print("=" * 78)
+        print(f"  merged PRs since {frm:%Y-%m-%d}: {tp['committedPullRequestsCount']}")
+        print(f"  completed work items (all time): {tp['completedWorkItems']['totalCount']}")
+        for it in tp["completedWorkItems"]["items"][:10]:
+            print(f"    #{it['issueNumber']:>5} {it['state']:9} "
+                  f"PR#{it['pullRequestNumber'] or '-':<6} {it['updatedAt'][:16]}  "
+                  f"{(it['issueTitle'] or '')[:60]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/ready-for-agent
+++ b/.claude/skills/ready-for-agent
@@ -1,0 +1,1 @@
+../../.agents/skills/ready-for-agent


### PR DESCRIPTION
Adds a skill that teaches agents to operate the Harness and report detailed progress on its activity.

## The problem this solves

An agent asked "what is the harness doing?" reaches for `ready-for-agent status` and reports what it sees. That answer is frequently, confidently wrong — because `status` is a **windowed** projection, and nothing about its output says so.

Three ways it misleads, all hit while building this:

- **"Merged lane is empty, so nothing shipped."** Merged covers a rolling 24 hours. A repository with 31 merged PRs that month showed `Merged 0` simply because the last one landed three days earlier.
- **"Issue #285 vanished, it must have been deleted."** It hadn't been. Repo-wide `workItems` filters to items that are completed, working, or whose Issue is still in the relevant-Issue store. A terminal-failed Work Item whose Issue was closed on the Forge satisfies none of those and disappears from `status` *and* from `workItems` — while still existing, worktree and all. Only a direct `issueNumber` query finds it.
- **"That step ran clean."** `lifecycleLabels` is per *phase*, not per attempt: `status` is the latest attempt's, `durationMs` is the **sum**. A 49.96-minute failed Implement plus a 3.6-minute successful retry renders as one `IMPLEMENT[OK/54m]` chip, with the failure nowhere in the row.

None of this is a defect — the windows are deliberate and documented in `docs/kanban.md`. But an agent reading the obvious surface has no way to know, so it reports a stalled or idle pipeline as fact. The skill exists to make the agent reach for the right surface for the question, and to say when a number is windowed.

The same applies to acting. `issue_closing_pull_request_unowned` invites a reflexive Reset, and Reset is irreversible. In practice the named "competing" PR is often the Work Item's *own* branch (`rfa/<owner>-<repo>/<issue>/<work-item-id>`) that ownership detection failed to reconnect — the message is captured at observation time and goes stale, so "Open PR #N" may describe something merged days ago. Checking `headRefName` first is the difference between reporting "your agent's work merged and the harness lost track of it" and "someone else fixed this first".

## Other findings baked in

- `Repository.pullRequestCount` counts **open non-draft PRs on the Forge**, not merged ones — not a throughput number. It is also `Int!` and reaches the Forge API, so a failed lookup propagates through `[Repository!]!` and **nulls the entire response**; it belongs in its own query. Found when a source-built harness could not reach the Forge and one field took the whole report down with it.
- `resetWorkItem` returns a bare `ID!` and takes no selection set; `retryWorkItem`, `pauseWorkItem`, `startWorkItem`, and `interruptWorkItem` return `WorkItem!` and do. A malformed mutation fails validation before executing, so a bad Reset destroys nothing.

## Contents

- `SKILL.md` — mental model, reporting, operating, and a triage playbook mapping reason codes to actions.
- `references/lifecycle.md` — states, statuses, lane rules, all 32 Step Run reason codes, failure codes, and operator-action reversibility.
- `references/graphql-api.md` — GraphQL surface, input shapes, recipes, and introspection for when fields drift between releases.
- `scripts/rfa_report.py` — lane occupancy, per-step timing, stall detection, blocked reasons, throughput. Probes the Repository merge field so one script serves both `mergePolicy` and older `autoMerge` schemas.

Follows the `AGENTS.md` convention: content under `.agents/skills/`, symlinked from `.claude/skills/`, with an `agents/openai.yaml` interface file.

## Testing

Verified against two running harnesses: a source build of current `main` (`mergePolicy`, three-state) and a published `v0.24.0` binary (legacy `autoMerge`). Checked on both: report rendering, `--issue` lookup of an item hidden from repo-wide listings, `--throughput`, partial-failure handling, and unreachable-endpoint handling. All enum vocabularies (`WorkItemState`, `WorkItemStatus`, `LifecyclePhase`, `KanbanLaneId`, `MergePolicy`) and all 32 ontology reason codes were diffed against the live schema.

Earlier drafts were benchmarked with and without the skill across three reporting tasks; same correctness at ~60% of the wall time and 72% of the tokens. That comparison ran inside this repo, where a baseline agent can read `kanban-projection.ts` and the SQLite DB directly — a much stronger baseline than an operator working from their own project gets.

Docs and one script only; no runtime code paths touched. Scope is GitHub and GitLab.

Local `bunx nx run ready-for-agent:test` fails on this arm64 machine at `compiled host binary ambient-auth smoke` with a missing `msgpackr-extract` native module. Confirmed pre-existing — identical failure on a clean checkout without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lae1QiZc1enRcd1Q5sW5bS