### PR TITLE
ci: skip Claude OIDC exchange on fork reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -48,6 +48,13 @@ jobs:
         uses: anthropics/claude-code-action@9d7150bc8a3dae8149739a88019d192b579ad90c # v1.0.193
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Anthropic's OIDC→app-token exchange rejects pull_request_target
+          # (anthropics/claude-code-action#713). The job token skips that
+          # exchange; reviews post as github-actions[bot], not claude[bot].
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Fork CONTRIBUTORs have no write access. The job if already skips
+          # first-timers; this only lets those remaining authors through.
+          allowed_non_write_users: "*"
           # Automatic PR reviews often run as github-actions[bot] (e.g. after
           # workflow re-runs). Explicit allowlist — not '*' — so only this
           # trusted platform bot can trigger the review action.


### PR DESCRIPTION
## Why

#1194 made Claude Code Review run on contributor fork PRs via `pull_request_target`, but the job still failed on #1193. GitHub issued an OIDC token; Anthropic's GitHub App token exchange rejected it with `401 Unauthorized - Invalid OIDC token` because that endpoint does not accept `pull_request_target` ([anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713)).

## What Changed

Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` so the action skips the OIDC exchange. Reviews post as `github-actions[bot]` instead of `claude[bot]`.

Also set `allowed_non_write_users: "*"` because fork `CONTRIBUTOR`s have no write access and the action would otherwise refuse them once it is using the job token. The job `if` still skips first-timers.
