### PR TITLE
fix(harness): soft-disable Keymaxxer when no vault exists

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -142,6 +142,10 @@ jobs:
       - name: Harness dev smoke
         run: bunx nx run harness:smoke
 
+      - name: Live Harness e2e (uninitialized Keymaxxer)
+        id: live-e2e-no-vault
+        run: bunx nx run harness:e2e-no-vault
+
       # Chromium once for both live suites.
       - name: Install Playwright Chromium
         working-directory: apps/harness

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -209,6 +209,10 @@ jobs:
       - name: Harness dev smoke
         run: bunx nx run harness:smoke
 
+      - name: Live Harness e2e (uninitialized Keymaxxer)
+        id: live-e2e-no-vault
+        run: bunx nx run harness:e2e-no-vault
+
       - name: Restore/install Playwright Chromium
         uses: ./.github/actions/playwright-chromium
         with:

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -93,6 +93,16 @@
         }
       ]
     },
+    "e2e-no-vault": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions @ready-for-agent/source test test/keymaxxer-uninitialized-e2e.test.ts"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    },
     "e2e-no-backend": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -97,7 +97,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --conditions @ready-for-agent/source test test/keymaxxer-uninitialized-e2e.test.ts"
+        "command": "bun --conditions=@ready-for-agent/source test test/keymaxxer-uninitialized-e2e.test.ts"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/apps/harness/scripts/run-unit-tests.sh
+++ b/apps/harness/scripts/run-unit-tests.sh
@@ -23,9 +23,12 @@ effect_ignore=(
   "**/application-runtime-disposal.test.ts"
   "**/production-sse-idle-timeout.test.ts"
 )
-# Also exclude the slow SSE suite from the default bun path (historical).
+# Also exclude the slow SSE suite from the default bun path (historical)
+# and the Keymaxxer uninitialized live e2e (must not inherit this runner's
+# KEYMAXXER_ENABLED=false; run via harness:e2e-no-vault).
 bun_ignore=(
   "**/production-sse-idle-timeout.test.ts"
+  "**/keymaxxer-uninitialized-e2e.test.ts"
   "${effect_ignore[@]}"
 )
 

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -29,6 +29,7 @@ import {
   POLLING_AUTO_HEAL_BACKOFF,
   POLLING_AUTO_HEAL_KEY,
   enqueuePollingAutoHealJob,
+  githubRepositoryHasCredential,
   issuePollFailureBackoff,
   repairPollingSchedules,
   sampleIssuePollingDelay,
@@ -128,11 +129,7 @@ const repositoryHasGitHubCredential = Effect.fn(
 )(function* (projectPath: string) {
   const keymaxxer = yield* KeymaxxerService
   if (keymaxxer.enabled === false) return true
-  const credential = yield* keymaxxer.findSecret({
-    provider: "github",
-    account: projectPath,
-  })
-  return credential !== null
+  return yield* githubRepositoryHasCredential(keymaxxer, projectPath)
 })
 
 const repositoryHasCredential = Effect.fn("JobWorker.repositoryHasCredential")(

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -2984,136 +2984,132 @@ describe("Job worker", () => {
       }),
   )
 
-  it.live("auto-heal retries with backoff until Keymaxxer succeeds", () =>
-    Effect.gen(function* () {
-      const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-      const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-      let findSecretCalls = 0
-      const keymaxxer = Layer.succeed(KeymaxxerService, {
-        initialize: Effect.void,
-        findSecret: ({ account, provider }) =>
-          Effect.gen(function* () {
-            findSecretCalls += 1
-            if (findSecretCalls < 3) {
+  it.live(
+    "auto-heal treats KeymaxxerError as ambient and does not ERROR-loop",
+    () =>
+      Effect.gen(function* () {
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        let findSecretCalls = 0
+        const keymaxxer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () =>
+            Effect.gen(function* () {
+              findSecretCalls += 1
               return yield* new KeymaxxerError({
                 operation: "findSecret",
-                message: "Keymaxxer unavailable",
+                message: "Keymaxxer list failed",
               })
-            }
-            return provider === "github" &&
-              account === `${repository.projectPath}`
-              ? `GITHUB_TOKEN`
-              : null
-          }),
-        findSecrets: () => Effect.die("not used"),
-        hasSecret: () => Effect.die("not used"),
-        addSecret: () => Effect.die("not used"),
-        runWithSecrets: () => Effect.die("not used"),
-      })
-      const lifecycle = Layer.succeed(WorkItemLifecycle, {
-        maxDurations: {
-          create_worktree: Duration.minutes(5),
-          install_dependencies: Duration.minutes(15),
-          implement: Duration.hours(2),
-          assess_changes: Duration.minutes(5),
-          pre_commit: Duration.hours(2),
-          review: Duration.hours(1),
-          commit: Duration.minutes(5),
-          create_pr: Duration.minutes(10),
-          watch_pr_status_checks: Duration.minutes(5),
-          resolve_pr_merge_conflict: Duration.hours(2),
-          investigate_pr_status_checks: Duration.hours(2),
-          mark_pr_ready_for_review: Duration.minutes(5),
-          decide_pr_merge: Duration.minutes(15),
-          merge_pr: Duration.minutes(5),
-          close_issue: Duration.minutes(5),
-          local_cleanup: Duration.minutes(5),
-        },
-        implementNow: unused,
-        implementWith: unused,
-        implementLocally: unused,
-        implementAllWithAutoMerge: unused,
-        queue: unused,
-        recoverOrphanedStepRuns: Effect.succeed(0),
-        interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
-        runStep: () => Effect.succeed({ _tag: "noop" as const }),
-        wakePostponedStep: () => Effect.succeed({ _tag: "stale" as const }),
-        retry: unused,
-        pause: unused,
-        interrupt: unused,
-        start: unused,
-        abandon: unused,
-        reset: unused,
-        getWorkItem: unused,
-        listWorkItemsForIssue: unused,
-        listWorkItemsForRepository: () => Effect.succeed([]),
-        listCompletedWorkItems: () =>
-          Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-        ownsSessionId: () => Effect.succeed(false),
-        findWorkItemBySessionId: unused,
-        countCommittedPullRequests: () => Effect.succeed(0),
-        continueAfterHumanPrOutcome: unused,
-        stopForCompetingIssueClosingPullRequests: () => Effect.succeed(0),
-        admitWaitingWorkItems: Effect.succeed(0),
-        releaseWaitingForBlockers: () => Effect.succeed(0),
-      })
-
-      yield* Effect.gen(function* () {
-        const db = yield* DbService
-        const service = yield* QueueService
-        const added = yield* db.addRepository({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-          localPath: repository.localPath,
-          isBare: true,
+            }),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => Effect.die("not used"),
+        })
+        const lifecycle = Layer.succeed(WorkItemLifecycle, {
+          maxDurations: {
+            create_worktree: Duration.minutes(5),
+            install_dependencies: Duration.minutes(15),
+            implement: Duration.hours(2),
+            assess_changes: Duration.minutes(5),
+            pre_commit: Duration.hours(2),
+            review: Duration.hours(1),
+            commit: Duration.minutes(5),
+            create_pr: Duration.minutes(10),
+            watch_pr_status_checks: Duration.minutes(5),
+            resolve_pr_merge_conflict: Duration.hours(2),
+            investigate_pr_status_checks: Duration.hours(2),
+            mark_pr_ready_for_review: Duration.minutes(5),
+            decide_pr_merge: Duration.minutes(15),
+            merge_pr: Duration.minutes(5),
+            close_issue: Duration.minutes(5),
+            local_cleanup: Duration.minutes(5),
+          },
+          implementNow: unused,
+          implementWith: unused,
+          implementLocally: unused,
+          implementAllWithAutoMerge: unused,
+          queue: unused,
+          recoverOrphanedStepRuns: Effect.succeed(0),
+          interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
+          runStep: () => Effect.succeed({ _tag: "noop" as const }),
+          wakePostponedStep: () => Effect.succeed({ _tag: "stale" as const }),
+          retry: unused,
+          pause: unused,
+          interrupt: unused,
+          start: unused,
+          abandon: unused,
+          reset: unused,
+          getWorkItem: unused,
+          listWorkItemsForIssue: unused,
+          listWorkItemsForRepository: () => Effect.succeed([]),
+          listCompletedWorkItems: () =>
+            Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+          ownsSessionId: () => Effect.succeed(false),
+          findWorkItemBySessionId: unused,
+          countCommittedPullRequests: () => Effect.succeed(0),
+          continueAfterHumanPrOutcome: unused,
+          stopForCompetingIssueClosingPullRequests: () => Effect.succeed(0),
+          admitWaitingWorkItems: Effect.succeed(0),
+          releaseWaitingForBlockers: () => Effect.succeed(0),
         })
 
-        yield* Effect.scoped(
-          Effect.gen(function* () {
-            yield* startJobWorker({
-              idlePollInterval: Duration.zero,
-              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-              sampleAutoHealBackoff: Effect.succeed(Duration.zero),
-            })
-            while ((yield* service.listKeyed(ISSUE_POLL_QUEUE)).length < 1) {
-              yield* Effect.sleep("5 millis")
-            }
-          }),
-        )
+        yield* Effect.gen(function* () {
+          const db = yield* DbService
+          const service = yield* QueueService
+          const added = yield* db.addRepository({
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: repository.localPath,
+            isBare: true,
+          })
 
-        const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
-        expect(schedules).toHaveLength(1)
-        expect(schedules[0]?.key).toBe(added.id)
-        expect(findSecretCalls).toBeGreaterThanOrEqual(3)
-        const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
-        expect(
-          autoHeal.filter((entry) => entry.key === POLLING_AUTO_HEAL_KEY),
-        ).toHaveLength(0)
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            defaultGithubLayer,
-            database,
-            queue,
-            Layer.succeed(IssueReconciler, {
-              reconcile: () =>
-                Effect.succeed({
-                  fetched: 0,
-                  inserted: 0,
-                  updated: 0,
-                  deleted: 0,
-                  unchanged: 0,
-                  competingObservations: [],
-                }),
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* startJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+                sampleAutoHealBackoff: Effect.succeed(Duration.zero),
+              })
+              while ((yield* service.listKeyed(ISSUE_POLL_QUEUE)).length < 1) {
+                yield* Effect.sleep("5 millis")
+              }
             }),
-            keymaxxer,
-            lifecycle,
+          )
+
+          const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+          expect(schedules).toHaveLength(1)
+          expect(schedules[0]?.key).toBe(added.id)
+          expect(findSecretCalls).toBe(1)
+          const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+          expect(
+            autoHeal.filter((entry) => entry.key === POLLING_AUTO_HEAL_KEY),
+          ).toHaveLength(0)
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              defaultGithubLayer,
+              database,
+              queue,
+              Layer.succeed(IssueReconciler, {
+                reconcile: () =>
+                  Effect.succeed({
+                    fetched: 0,
+                    inserted: 0,
+                    updated: 0,
+                    deleted: 0,
+                    unchanged: 0,
+                    competingObservations: [],
+                  }),
+              }),
+              keymaxxer,
+              lifecycle,
+            ),
           ),
-        ),
-        Effect.orDie,
-      )
-    }),
+          Effect.orDie,
+        )
+      }),
   )
 
   it.live(

--- a/apps/harness/test/keymaxxer-uninitialized-e2e.test.ts
+++ b/apps/harness/test/keymaxxer-uninitialized-e2e.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Live e2e for Keymaxxer soft-disable when the operator never initialized a
+ * vault (issue #1195). Does **not** set KEYMAXXER_ENABLED=false — that is the
+ * current hole this suite exists to close. Workspace/stub `keymaxxer` stays
+ * on PATH; HOME has no vault; at least one Repository is seeded so Auto-heal
+ * would call list if Keymaxxer were wrongly enabled.
+ */
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import { Effect, Layer } from "effect"
+import { DatabaseLive, runConfiguredMigrations } from "@ready-for-agent/db"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import { isKeymaxxerAvailable } from "@ready-for-agent/keymaxxer-service"
+import { pathWithoutBinaries } from "../e2e/support/agent-backend-path.ts"
+import { createApplication } from "../src/server/application.server.ts"
+import { environmentConfigLayer } from "../src/server/application-config.ts"
+import {
+  type Application,
+  type ProductionLifecycleEvent,
+  resolveKeymaxxerMode,
+  startProductionLifecycle,
+} from "../src/server/production-lifecycle.ts"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const AUTO_HEAL_FAILURE = "Polling Auto-heal Job failed"
+const LIST_FAILURE = "Keymaxxer list failed"
+
+const graphqlHealth = async (application: Application): Promise<boolean> => {
+  const response = await application.context.graphqlApi.fetch(
+    new Request("http://127.0.0.1/graphql", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "query { health }" }),
+    }),
+  )
+  if (!response.ok) {
+    return false
+  }
+  const payload = (await response.json()) as {
+    data?: { health?: boolean }
+  }
+  return payload.data?.health === true
+}
+
+describe("Keymaxxer uninitialized operator path", () => {
+  let runDir: string | undefined
+
+  afterEach(async () => {
+    if (runDir !== undefined) {
+      await rm(runDir, { recursive: true, force: true })
+      runDir = undefined
+    }
+  })
+
+  test("workspace keymaxxer without a vault soft-disables and Auto-heal stays silent", async () => {
+    runDir = mkdtempSync(join(tmpdir(), "rfa-keymaxxer-uninitialized-"))
+    const home = join(runDir, "home")
+    const binDir = join(runDir, "bin")
+    const dbPath = join(runDir, "harness.db")
+    mkdirSync(home, { recursive: true })
+    mkdirSync(binDir, { recursive: true })
+    writeFileSync(
+      join(binDir, "keymaxxer"),
+      `#!/bin/sh
+echo "keymaxxer: no vault found. Run \`keymaxxer init\` first." >&2
+exit 1
+`,
+    )
+    chmodSync(join(binDir, "keymaxxer"), 0o755)
+
+    const productPath = `${binDir}${delimiter}${pathWithoutBinaries(process.env.PATH ?? "", ["keymaxxer"])}`
+    const environment: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: home,
+      PATH: productPath,
+      SQLITE_DATABASE_PATH: dbPath,
+      NO_BROWSER: "1",
+    }
+    for (const key of [
+      "KEYMAXXER_ENABLED",
+      "KEYMAXXER_SIDECAR_URL",
+      "KEYMAXXER_ENTRYPOINT",
+      "KEYMAXXER_DB_DIR",
+      "XDG_CONFIG_HOME",
+      "KEYMAXXER_MASTER_KEY",
+      "E2E_KEYMAXXER_MASTER_KEY",
+    ]) {
+      delete environment[key]
+    }
+
+    expect(Bun.which("keymaxxer", { PATH: productPath })).toBe(
+      join(binDir, "keymaxxer"),
+    )
+    expect(isKeymaxxerAvailable(environment)).toBe(false)
+    expect(resolveKeymaxxerMode(environment)).toEqual({ kind: "disabled" })
+
+    const events: ProductionLifecycleEvent[] = []
+    const logs: string[] = []
+    let application: Application | undefined
+    let applicationEnv: NodeJS.ProcessEnv | undefined
+
+    const pushLog = (value: unknown) => {
+      logs.push(typeof value === "string" ? value : String(value))
+    }
+    const original = {
+      log: console.log,
+      info: console.info,
+      warn: console.warn,
+      error: console.error,
+    }
+    console.log = (...args: unknown[]) => {
+      args.forEach(pushLog)
+      original.log.apply(console, args)
+    }
+    console.info = (...args: unknown[]) => {
+      args.forEach(pushLog)
+      original.info.apply(console, args)
+    }
+    console.warn = (...args: unknown[]) => {
+      args.forEach(pushLog)
+      original.warn.apply(console, args)
+    }
+    console.error = (...args: unknown[]) => {
+      args.forEach(pushLog)
+      original.error.apply(console, args)
+    }
+
+    const configLayer = environmentConfigLayer(environment)
+    try {
+      const handle = await startProductionLifecycle({
+        waitForShutdown: false,
+        environment,
+        argv: ["bun", "server.ts", "--no-open"],
+        applyMigrations: async () => {
+          await Effect.runPromise(
+            runConfiguredMigrations().pipe(
+              Effect.provide(DatabaseLive.pipe(Layer.provide(configLayer))),
+            ),
+          )
+          const databaseLayer = DbServiceLive.pipe(
+            Layer.provideMerge(DatabaseLive),
+            Layer.provide(configLayer),
+          )
+          await Effect.runPromise(
+            Effect.gen(function* () {
+              const db = yield* DbService
+              yield* db.addRepository({
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "acme/widgets",
+                localPath: join(home, "widgets.git"),
+                isBare: true,
+              })
+            }).pipe(Effect.provide(databaseLayer)),
+          )
+        },
+        createApplication: async (applicationEnvironment) => {
+          applicationEnv = { ...applicationEnvironment }
+          application = await createApplication(applicationEnvironment)
+          return application
+        },
+        loadStartHandler: async () => ({
+          fetch: async () => new Response("handler"),
+        }),
+        serveHttp: async () => ({
+          port: 4242,
+          stop: async () => {},
+        }),
+        openBrowser: () => {},
+        onEvent: (event) => {
+          events.push(event)
+        },
+        logInfo: pushLog,
+        logError: pushLog,
+      })
+
+      expect(applicationEnv?.KEYMAXXER_ENABLED).toBe("false")
+      expect(applicationEnv?.KEYMAXXER_SIDECAR_URL).toBeUndefined()
+      expect(events).not.toContain("sidecar-ready")
+      expect(events).toContain("application-ready")
+      if (application === undefined) {
+        throw new Error("createApplication did not return an Application")
+      }
+      const started = application
+
+      const healthDeadline = Date.now() + 15_000
+      let healthy = false
+      while (Date.now() < healthDeadline) {
+        healthy = await graphqlHealth(started)
+        if (healthy) {
+          break
+        }
+        await Bun.sleep(200)
+      }
+      expect(healthy).toBe(true)
+
+      // Auto-heal is forked at application start; give it a beat to fail
+      // closed if Keymaxxer were still wrongly enabled.
+      await Bun.sleep(1_500)
+      const combined = logs.join("\n")
+      expect(combined).not.toContain(AUTO_HEAL_FAILURE)
+      expect(combined).not.toContain(LIST_FAILURE)
+
+      await handle.dispose()
+    } finally {
+      console.log = original.log
+      console.info = original.info
+      console.warn = original.warn
+      console.error = original.error
+    }
+  }, 120_000)
+})

--- a/apps/harness/test/pr-e2e-jobs.test.ts
+++ b/apps/harness/test/pr-e2e-jobs.test.ts
@@ -177,6 +177,16 @@ describe("PR live e2e jobs (issue #999)", () => {
     expect(uiHistory?.needs ?? []).not.toContain("harness-e2e-live-forge")
   })
 
+  test("the uninitialized-Keymaxxer suite still runs on a fork-safe job", async () => {
+    const workflow = await loadPrWorkflow()
+    const uiHistory = workflow.jobs?.["harness-e2e-ui-history"]
+    expect(
+      uiHistory?.steps?.some((step) =>
+        step.run?.includes("harness:e2e-no-vault"),
+      ),
+    ).toBe(true)
+  })
+
   test("same-repo PRs fail closed when the live-Forge vault secret is missing", async () => {
     const workflow = await loadPrWorkflow()
     const steps = workflow.jobs?.["harness-e2e-live-forge"]?.steps

--- a/apps/harness/test/production-lifecycle.test.ts
+++ b/apps/harness/test/production-lifecycle.test.ts
@@ -1,6 +1,15 @@
 import { spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
 import {
@@ -127,6 +136,28 @@ describe("production lifecycle keymaxxer mode", () => {
     expect(resolveKeymaxxerMode({}, () => true)).toEqual({
       kind: "spawn-sidecar",
     })
+  })
+
+  test("disables when a keymaxxer binary is on PATH but no vault exists", () => {
+    const runDir = mkdtempSync(join(tmpdir(), "rfa-keymaxxer-mode-"))
+    try {
+      const home = join(runDir, "home")
+      const binDir = join(runDir, "bin")
+      mkdirSync(home)
+      mkdirSync(binDir)
+      const binary = join(binDir, "keymaxxer")
+      writeFileSync(binary, "#!/bin/sh\nexit 1\n")
+      chmodSync(binary, 0o755)
+      expect(Bun.which("keymaxxer", { PATH: binDir })).toBe(binary)
+      expect(
+        resolveKeymaxxerMode({
+          HOME: home,
+          PATH: binDir,
+        }),
+      ).toEqual({ kind: "disabled" })
+    } finally {
+      rmSync(runDir, { recursive: true, force: true })
+    }
   })
 })
 

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -131,6 +131,14 @@ describe("single application server topology", () => {
     expect(
       harness.targets["e2e-no-backend"]?.options?.env?.E2E_HARNESS_WORKERS,
     ).toBeUndefined()
+    // Uninitialized-Keymaxxer live e2e must not force KEYMAXXER_ENABLED=false
+    // (that is the hole the suite exists to close; issue #1195).
+    expect(
+      harness.targets["e2e-no-vault"]?.options?.env?.KEYMAXXER_ENABLED,
+    ).toBeUndefined()
+    expect(harness.targets["e2e-no-vault"]?.options?.command).toContain(
+      "keymaxxer-uninitialized-e2e",
+    )
     // Vault-free @no-backend suite: soft-disable Keymaxxer, clear ambient
     // master keys so fixture mode cannot win, and strip OpenCode.
     expect(
@@ -154,6 +162,7 @@ describe("single application server topology", () => {
       "utf8",
     )
     expect(runnerScript).toContain("export KEYMAXXER_ENABLED=false")
+    expect(runnerScript).toContain("keymaxxer-uninitialized-e2e.test.ts")
   })
 
   test("an inherited KEYMAXXER_ENABLED=true cannot override the unit-test runner's export", async () => {

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -137,7 +137,7 @@ describe("single application server topology", () => {
       harness.targets["e2e-no-vault"]?.options?.env?.KEYMAXXER_ENABLED,
     ).toBeUndefined()
     expect(harness.targets["e2e-no-vault"]?.options?.command).toContain(
-      "keymaxxer-uninitialized-e2e",
+      "bun --conditions=@ready-for-agent/source test test/keymaxxer-uninitialized-e2e.test.ts",
     )
     // Vault-free @no-backend suite: soft-disable Keymaxxer, clear ambient
     // master keys so fixture mode cannot win, and strip OpenCode.

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./lib/add-repository-command.js"
 export * from "./lib/graphql-api.js"
 export * from "./lib/issue-polling.js"
+export { githubRepositoryHasCredential } from "./lib/repository-credentials.js"
 export * from "./lib/repository-intake.js"
 export * from "./lib/repository-retry.js"

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -210,6 +210,21 @@ const probeVaultSecret = (
   )
 }
 
+/**
+ * GitHub credential for Issue Polling: a vault secret, or ambient `gh` when
+ * Keymaxxer is unavailable. A clean vault miss is not credentialed.
+ */
+export const githubRepositoryHasCredential = (
+  keymaxxer: KeymaxxerServiceShape,
+  projectPath: string,
+  metadataTimeout?: Duration.Duration,
+): Effect.Effect<boolean> =>
+  probeVaultSecret(
+    keymaxxer,
+    { provider: "github", account: projectPath },
+    metadataTimeout,
+  ).pipe(Effect.map((probe) => probe.kind !== "miss"))
+
 /** Activate durable Issue Polling only when this repository has forge credentials. */
 export const activatePollingIfCredentialed = Effect.fn(
   "graphql-api.activatePollingIfCredentialed",
@@ -288,25 +303,20 @@ export const activatePollingIfCredentialed = Effect.fn(
       }
       return
     }
-    // "github" and any unrecognized/legacy forge value both preserve the
-    // historical GitHub-first fallback (fail-closed vault-first, no ambient
-    // check, matching GitHub's existing posture rather than GitLab's/Azure
-    // DevOps's permissive one).
+    // "github" and any unrecognized/legacy forge value: vault-first when
+    // Keymaxxer can list secrets; a KeymaxxerError is unavailable and falls
+    // back to ambient `gh`, matching GraphQL probeVaultSecret and the
+    // disabled-Keymaxxer path. A clean miss still does not activate.
     default: {
-      const lookup = keymaxxer.findSecret({
-        provider: "github",
-        account: repository.projectPath,
-      })
-      const credential =
-        options?.metadataTimeout === undefined
-          ? yield* lookup
-          : yield* withKeymaxxerMetadataTimeout(
-              lookup,
-              options.metadataTimeout,
-              "findSecret",
-            )
-      if (credential === null) return
-      yield* activateRepositoryPolling(repository.id)
+      if (
+        yield* githubRepositoryHasCredential(
+          keymaxxer,
+          repository.projectPath,
+          options?.metadataTimeout,
+        )
+      ) {
+        yield* activateRepositoryPolling(repository.id)
+      }
       return
     }
   }

--- a/packages/graphql-api/test/repository-credentials.test.ts
+++ b/packages/graphql-api/test/repository-credentials.test.ts
@@ -105,6 +105,138 @@ const ambientOnlyKeymaxxer: KeymaxxerServiceShape = {
   runWithSecrets: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
 }
 
+describe("activatePollingIfCredentialed (GitHub)", () => {
+  test("activates polling when Keymaxxer is disabled", async () => {
+    const activated: string[] = []
+    const runtime = makeRuntime(
+      ambientOnlyKeymaxxer,
+      stubQueueService({
+        enqueue: (queueName, payload) =>
+          Effect.sync(() => {
+            if (queueName === ISSUE_REFRESH_QUEUE) {
+              activated.push((payload as { repositoryId: string }).repositoryId)
+            }
+            return "job-1" as never
+          }),
+        ensureKeyed: () =>
+          Effect.succeed({ jobId: "job-1" as never, created: true }),
+      }),
+    )
+    try {
+      await runtime.runPromise(
+        activatePollingIfCredentialed(githubRepo).pipe(Random.withSeed(1)),
+      )
+      expect(activated).toEqual([githubRepo.id])
+    } finally {
+      await runtime.dispose()
+    }
+  })
+
+  test("activates polling from a vault secret when Keymaxxer is effective", async () => {
+    const findSecretCalls: { provider: string; account: string }[] = []
+    const activated: string[] = []
+    const runtime = makeRuntime(
+      {
+        initialize: Effect.void,
+        hasSecret: () => Effect.succeed(true),
+        findSecret: (input) => {
+          findSecretCalls.push(input)
+          return Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS")
+        },
+        findSecrets: () => Effect.succeed([]),
+        addSecret: () => Effect.succeed(true),
+        runWithSecrets: () =>
+          Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      } satisfies KeymaxxerServiceShape,
+      stubQueueService({
+        enqueue: (_queueName, payload) =>
+          Effect.sync(() => {
+            activated.push((payload as { repositoryId: string }).repositoryId)
+            return "job-1" as never
+          }),
+        ensureKeyed: () =>
+          Effect.succeed({ jobId: "job-1" as never, created: true }),
+      }),
+    )
+    try {
+      await runtime.runPromise(
+        activatePollingIfCredentialed(githubRepo).pipe(Random.withSeed(1)),
+      )
+      expect(findSecretCalls).toEqual([
+        { provider: "github", account: "acme/widgets" },
+      ])
+      expect(activated).toEqual([githubRepo.id])
+    } finally {
+      await runtime.dispose()
+    }
+  })
+
+  test("does not activate polling on a clean vault miss", async () => {
+    const activated: string[] = []
+    const runtime = makeRuntime(
+      {
+        initialize: Effect.void,
+        hasSecret: () => Effect.succeed(false),
+        findSecret: () => Effect.succeed(null),
+        findSecrets: () => Effect.succeed([]),
+        addSecret: () => Effect.succeed(true),
+        runWithSecrets: () =>
+          Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      } satisfies KeymaxxerServiceShape,
+      stubQueueService({
+        enqueue: (_queueName, payload) =>
+          Effect.sync(() => {
+            activated.push((payload as { repositoryId: string }).repositoryId)
+            return "job-1" as never
+          }),
+        ensureKeyed: () =>
+          Effect.succeed({ jobId: "job-1" as never, created: true }),
+      }),
+    )
+    try {
+      await runtime.runPromise(
+        activatePollingIfCredentialed(githubRepo).pipe(Random.withSeed(1)),
+      )
+      expect(activated).toEqual([])
+    } finally {
+      await runtime.dispose()
+    }
+  })
+
+  test("activates polling from ambient credentials when the vault errors", async () => {
+    const activated: string[] = []
+    const runtime = makeRuntime(
+      {
+        initialize: Effect.void,
+        hasSecret: () => Effect.succeed(true),
+        findSecret: () =>
+          Effect.fail(keymaxxerError("findSecret", "Keymaxxer list failed")),
+        findSecrets: () => Effect.succeed([]),
+        addSecret: () => Effect.succeed(true),
+        runWithSecrets: () =>
+          Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      } satisfies KeymaxxerServiceShape,
+      stubQueueService({
+        enqueue: (_queueName, payload) =>
+          Effect.sync(() => {
+            activated.push((payload as { repositoryId: string }).repositoryId)
+            return "job-1" as never
+          }),
+        ensureKeyed: () =>
+          Effect.succeed({ jobId: "job-1" as never, created: true }),
+      }),
+    )
+    try {
+      await runtime.runPromise(
+        activatePollingIfCredentialed(githubRepo).pipe(Random.withSeed(1)),
+      )
+      expect(activated).toEqual([githubRepo.id])
+    } finally {
+      await runtime.dispose()
+    }
+  })
+})
+
 describe("activatePollingIfCredentialed (Azure DevOps)", () => {
   test("activates polling from the ambient AZURE_DEVOPS_EXT_PAT when Keymaxxer is disabled", async () => {
     const previous = process.env.AZURE_DEVOPS_EXT_PAT

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -1,4 +1,6 @@
 import { accessSync, constants, existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { Config, Effect, Layer } from "effect"
@@ -109,13 +111,56 @@ export const keymaxxerMcpCommand = (
   return { command: "keymaxxer", args: ["serve"] }
 }
 
+/** Operator vault directory used by Keymaxxer 0.2.x. */
+const keymaxxerVaultDirectory = (
+  environment: Partial<Record<string, string | undefined>> = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+): string => {
+  const dbDir = environment.KEYMAXXER_DB_DIR?.trim()
+  if (dbDir !== undefined && dbDir !== "") {
+    return dbDir
+  }
+  const xdg = environment.XDG_CONFIG_HOME?.trim()
+  if (xdg !== undefined && xdg !== "") {
+    const xdgDir = join(xdg, "keymaxxer")
+    if (pathExists(xdgDir)) {
+      return xdgDir
+    }
+  }
+  const home = environment.HOME?.trim()
+  return join(
+    home !== undefined && home !== "" ? home : homedir(),
+    ".keymaxxer",
+  )
+}
+
+/**
+ * True when an on-disk vault is present. File presence only — never runs
+ * `keymaxxer list`, which would prompt for a passphrase when a vault exists.
+ */
+const isKeymaxxerVaultPresent = (
+  environment: Partial<Record<string, string | undefined>> = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+): boolean => {
+  const directory = keymaxxerVaultDirectory(environment, pathExists)
+  return (
+    pathExists(join(directory, "vault.db")) ||
+    pathExists(join(directory, "vault.meta.json"))
+  )
+}
+
 export const isKeymaxxerAvailable = (
   environment: Partial<Record<string, string | undefined>> = process.env,
   pathExists: (path: string) => boolean = existsSync,
   commandExists: (command: string) => boolean = (command) =>
-    Bun.which(command) !== null,
+    Bun.which(command, {
+      PATH: environment.PATH ?? process.env.PATH,
+    }) !== null,
   isExecutable: (path: string) => boolean = isExecutableKeymaxxerEntrypoint,
 ) => {
+  if (!isKeymaxxerVaultPresent(environment, pathExists)) {
+    return false
+  }
   const entrypoint = environment.KEYMAXXER_ENTRYPOINT?.trim()
   if (entrypoint && pathExists(entrypoint)) return true
   const command = keymaxxerMcpCommand(environment, pathExists, isExecutable)

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -559,18 +559,91 @@ describe("MCP process configuration", () => {
     ).toBe(false)
   })
 
-  test("reports Keymaxxer available from either source", () => {
+  test("reports Keymaxxer unavailable when a binary is on PATH but no vault exists", () => {
     expect(
       isKeymaxxerAvailable(
-        { KEYMAXXER_ENTRYPOINT: "/custom/keymaxxer/index.ts" },
+        { HOME: "/home/operator" },
+        () => false,
         () => true,
+      ),
+    ).toBe(false)
+  })
+
+  test("reports Keymaxxer unavailable when ENTRYPOINT exists but no vault exists", () => {
+    expect(
+      isKeymaxxerAvailable(
+        {
+          HOME: "/home/operator",
+          KEYMAXXER_ENTRYPOINT: "/custom/keymaxxer/index.ts",
+        },
+        (path) => path === "/custom/keymaxxer/index.ts",
+        () => false,
+      ),
+    ).toBe(false)
+  })
+
+  test("reports Keymaxxer available when a vault and PATH binary exist", () => {
+    expect(
+      isKeymaxxerAvailable(
+        { HOME: "/home/operator" },
+        (path) => path === "/home/operator/.keymaxxer/vault.db",
+        () => true,
+      ),
+    ).toBe(true)
+  })
+
+  test("reports Keymaxxer available when a vault and ENTRYPOINT exist", () => {
+    expect(
+      isKeymaxxerAvailable(
+        {
+          HOME: "/home/operator",
+          KEYMAXXER_ENTRYPOINT: "/custom/keymaxxer/index.ts",
+        },
+        (path) =>
+          path === "/custom/keymaxxer/index.ts" ||
+          path === "/home/operator/.keymaxxer/vault.db",
         () => false,
       ),
     ).toBe(true)
+  })
+
+  test("reports Keymaxxer available when KEYMAXXER_DB_DIR has a vault", () => {
     expect(
       isKeymaxxerAvailable(
-        {},
-        () => false,
+        { KEYMAXXER_DB_DIR: "/var/keymaxxer", HOME: "/home/operator" },
+        (path) => path === "/var/keymaxxer/vault.db",
+        () => true,
+      ),
+    ).toBe(true)
+  })
+
+  test("does not fall back to HOME when KEYMAXXER_DB_DIR is set without a vault", () => {
+    expect(
+      isKeymaxxerAvailable(
+        { KEYMAXXER_DB_DIR: "/var/empty", HOME: "/home/operator" },
+        (path) => path === "/home/operator/.keymaxxer/vault.db",
+        () => true,
+      ),
+    ).toBe(false)
+  })
+
+  test("reports Keymaxxer available from an XDG vault directory", () => {
+    expect(
+      isKeymaxxerAvailable(
+        { XDG_CONFIG_HOME: "/xdg", HOME: "/home/operator" },
+        (path) =>
+          path === "/xdg/keymaxxer" || path === "/xdg/keymaxxer/vault.db",
+        () => true,
+      ),
+    ).toBe(true)
+  })
+
+  test("falls back to a HOME vault when the XDG keymaxxer directory is absent", () => {
+    expect(
+      isKeymaxxerAvailable(
+        { XDG_CONFIG_HOME: "/xdg", HOME: "/home/operator" },
+        (path) =>
+          path === "/xdg" || path === "/home/operator/.keymaxxer/vault.db",
         () => true,
       ),
     ).toBe(true)


### PR DESCRIPTION
Workspace `bun install` puts `keymaxxer` on PATH, so the Harness treated it as installed even with
no vault. Dev and production then started the Sidecar; Polling Auto-heal hit `Keymaxxer list failed`
and retried. Operators who never ran `keymaxxer init` should get the same path as
`KEYMAXXER_ENABLED=false`: ambient Forge auth, no Sidecar, no unlock prompt.

Availability now requires an on-disk vault (`vault.db` / `vault.meta.json`) under Keymaxxer's own
directory rules (`KEYMAXXER_DB_DIR`, then `$XDG_CONFIG_HOME/keymaxxer` only if that directory
exists, else `~/.keymaxxer`), plus a resolvable binary or `KEYMAXXER_ENTRYPOINT`. Mode resolution
still happens before Sidecar spawn. Explicit `KEYMAXXER_SIDECAR_URL` and `KEYMAXXER_ENABLED=false`
are unchanged. GitHub credential checks (GraphQL activation and Auto-heal) treat `KeymaxxerError` as
unavailable/ambient instead of fail-closing.

Verification: keymaxxer-service availability tests (including XDG vs HOME fallback), GraphQL GitHub
`KeymaxxerError` → ambient, job-worker Auto-heal no longer ERROR-loops, production-lifecycle mode
with a real PATH binary and empty HOME, and `harness:e2e-no-vault` (does not set
`KEYMAXXER_ENABLED=false`; stub `keymaxxer` on PATH, temp HOME, seeded Repository). Fork-safe CI
runs that suite.

Limitation: the live e2e infers Auto-heal success from the absence of fail-close logs (plus a
refresh side effect) rather than asserting queue acknowledge; the job-worker unit test covers
acknowledge.

Related: #1195.

Closes #1195