### PR TITLE
ci: avoid Claude fetch colliding with local main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,14 +34,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Check out pull request head
+      # The action fetches `pull/$n/head:<head.ref>`. Fork PRs whose head
+      # branch is also `main` collide with the local base branch.
+      - name: Drop local branch colliding with the PR head
         env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "pull/${PR_NUMBER}/head"
-          git checkout --detach "${HEAD_SHA}"
+          git checkout --detach
+          if git show-ref --verify --quiet "refs/heads/${HEAD_REF}"; then
+            git branch -D "${HEAD_REF}"
+          fi
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
## Why

After #1196, Claude Code Review got past OIDC on #1193 and then died on:

```
git fetch origin --depth=20 pull/1193/head:main
! [rejected] refs/pull/1193/head -> main  (non-fast-forward)
```

#1193's fork head branch is also named `main`. The action always fetches `pull/$n/head:<head.ref>`, which tries to update the local base branch. That is not a fast-forward.

## What Changed

Stop checking out the PR head ourselves (the action does that). After the base checkout, detach HEAD and delete a local branch that matches `head.ref` so the action can create it.
