### PR TITLE
fix(harness): show OpenCode model display names in Settings

### DIFF
--- a/apps/harness/src/agent-model-settings.ts
+++ b/apps/harness/src/agent-model-settings.ts
@@ -76,21 +76,24 @@ export const formatAgentModelKindLabel = (
  * Examples:
  * - `US Anthropic Claude Sonnet 4.6 · System · us.anthropic.claude-sonnet-4-6`
  * - `My Org Sonnet · Application · arn:aws:bedrock:…:application-inference-profile/…`
+ * - `opencode/x-preview-f-free (Ox Alpha Free (Unlimited))` — a name without
+ *   kind metadata keeps the id first and appends the name in parentheses
  * - plain `haiku` when no name/kind metadata is present
  */
 export const formatAgentModelLabel = (model: AgentModelOption): string => {
   const name = model.name?.trim() ?? ""
   const kindLabel = formatAgentModelKindLabel(model.kind)
+  if (kindLabel === null) {
+    if (name.length > 0 && name !== model.id) {
+      return `${model.id} (${name})`
+    }
+    return model.id
+  }
   const parts: string[] = []
   if (name.length > 0 && name !== model.id) {
     parts.push(name)
   }
-  if (kindLabel !== null) {
-    parts.push(kindLabel)
-  }
-  if (parts.length === 0) {
-    return model.id
-  }
+  parts.push(kindLabel)
   return `${parts.join(" · ")} · ${model.id}`
 }
 

--- a/apps/harness/test/agent-model-settings.test.ts
+++ b/apps/harness/test/agent-model-settings.test.ts
@@ -430,6 +430,24 @@ describe("Agent Model presentation (issue #821)", () => {
     ).toBe("sonnet")
   })
 
+  test("formatAgentModelLabel appends a kind-less name after the id in parentheses", () => {
+    expect(
+      formatAgentModelLabel({
+        id: "opencode/x-preview-f-free",
+        thinkingLevels: ["high", "max"],
+        name: "Ox Alpha Free (Unlimited)",
+      }),
+    ).toBe("opencode/x-preview-f-free (Ox Alpha Free (Unlimited))")
+    // A name equal to the id adds no information.
+    expect(
+      formatAgentModelLabel({
+        id: "opencode/gpt-5",
+        thinkingLevels: [],
+        name: "opencode/gpt-5",
+      }),
+    ).toBe("opencode/gpt-5")
+  })
+
   test("findCatalogModel matches by executable id only", () => {
     const catalog = [systemModel, applicationModel]
     expect(findCatalogModel(catalog, systemModel.id)).toEqual(systemModel)

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -86,6 +86,7 @@ export const Opencode = {
             backend: OPENCODE_BACKEND,
             models: parsed.models.map((model) => ({
               id: model.id,
+              ...(model.name !== undefined ? { name: model.name } : {}),
               thinkingLevels: model.variants,
             })),
           }

--- a/packages/opencode/src/lib/parse-verbose-models.ts
+++ b/packages/opencode/src/lib/parse-verbose-models.ts
@@ -70,7 +70,14 @@ export const parseVerboseModelsOutputDetailed = (
       const parsed: unknown = JSON.parse(jsonLines.join("\n"))
       const variantsValue = isRecord(parsed) ? parsed.variants : undefined
       const variants = isRecord(variantsValue) ? Object.keys(variantsValue) : []
-      models.push({ id, variants })
+      const rawName = isRecord(parsed) ? parsed.name : undefined
+      const name =
+        typeof rawName === "string" && rawName.trim().length > 0
+          ? rawName.trim()
+          : undefined
+      models.push(
+        name === undefined ? { id, variants } : { id, name, variants },
+      )
     } catch {
       complete = false
       models.push({ id, variants: [] })

--- a/packages/opencode/src/lib/types.ts
+++ b/packages/opencode/src/lib/types.ts
@@ -3,6 +3,8 @@ import type { Duration } from "effect"
 /** One OpenCode model id with its supported thinking-level (variant) keys. */
 export interface OpencodeModel {
   readonly id: string
+  /** Operator-facing display name from `opencode models --verbose`, when present. */
+  readonly name?: string
   readonly variants: ReadonlyArray<string>
 }
 

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -813,6 +813,7 @@ describe("Opencode AgentBackend adapter", () => {
         'if [ "$1" = "models" ] && [ "$2" = "--verbose" ]; then',
         `  printf '%s\\n' 'xai/grok-4.5'`,
         `  printf '%s\\n' '{'`,
+        `  printf '%s\\n' '  "name": "Grok 4.5",'`,
         `  printf '%s\\n' '  "variants": {'`,
         `  printf '%s\\n' '    "low": {},'`,
         `  printf '%s\\n' '    "medium": {},'`,
@@ -852,6 +853,7 @@ describe("Opencode AgentBackend adapter", () => {
         expect(result.models).toEqual([
           {
             id: "xai/grok-4.5",
+            name: "Grok 4.5",
             thinkingLevels: ["low", "medium", "high"],
           },
           {

--- a/packages/opencode/test/parse-verbose-models.spec.ts
+++ b/packages/opencode/test/parse-verbose-models.spec.ts
@@ -62,6 +62,34 @@ describe("parseVerboseModelsOutput", () => {
     ])
   })
 
+  it("extracts the operator-facing name when the JSON blob carries one", () => {
+    const stdout = [
+      "opencode/x-preview-f-free",
+      "{",
+      '  "id": "x-preview-f-free",',
+      '  "providerID": "opencode",',
+      '  "name": "Ox Alpha Free (Unlimited)",',
+      '  "variants": {',
+      '    "high": {},',
+      '    "max": {}',
+      "  }",
+      "}",
+      "opencode/unnamed",
+      "{",
+      '  "variants": {}',
+      "}",
+    ].join("\n")
+
+    expect(parseVerboseModelsOutput(stdout)).toEqual([
+      {
+        id: "opencode/x-preview-f-free",
+        name: "Ox Alpha Free (Unlimited)",
+        variants: ["high", "max"],
+      },
+      { id: "opencode/unnamed", variants: [] },
+    ])
+  })
+
   it("skips blank lines and treats missing variants as empty", () => {
     const stdout = [
       "",


### PR DESCRIPTION
## Problem

OpenCode model catalogs in Settings rendered as raw provider-prefixed ids (e.g. `opencode/x-preview-f-free`) with no friendly display name. `opencode models --verbose` emits a JSON blob per model that includes an operator-facing `name` (e.g. "Ox Alpha Free (Unlimited)"), but the harness parser discarded it.

## Change

- parse the optional `name` from the verbose models JSON (`packages/opencode`)
- carry it through `Opencode.inspect` into `AgentModel.name`
- format kind-less named catalog entries as `id (Name)` in Settings; Bedrock entries with kind metadata keep their existing `Name · Kind · id` format

## Testing

- new parser test for name extraction (present / absent)
- inspect test asserting `name` reaches the catalog
- label-formatting tests for the `id (Name)` form
- `bunx nx affected -t lint,typecheck,test` green