### PR TITLE
fix(graphql-api): label paused Work Items as Draining while a Step Run is active

### DIFF
--- a/apps/ready-for-agent/src/cli-json.test.ts
+++ b/apps/ready-for-agent/src/cli-json.test.ts
@@ -62,6 +62,7 @@ describe("finite CLI JSON contract", () => {
               issueTitle: "Blocked follow-up",
               state: "CREATE_WORKTREE",
               status: "WAITING_FOR_BLOCKERS",
+              statusLabel: "Waiting for blockers",
               statusMessage: "Waiting for blocking Issues",
               paused: false,
               canRetry: false,
@@ -88,9 +89,61 @@ describe("finite CLI JSON contract", () => {
     expect(doc.lanes[0]?.workItems[0]?.pullRequestNumber).toBeNull()
     expect(doc.lanes[0]?.workItems[0]?.canRetry).toBe(false)
     expect(doc.lanes[0]?.workItems[0]?.latestStepRunReason).toBeNull()
+    expect(doc.lanes[0]?.workItems[0]?.statusLabel).toBe("Waiting for blockers")
     expect(encodeCompactJson(doc)).toContain('"command":"status"')
     expect(encodeCompactJson(doc)).toContain('"pullRequestNumber":null')
     expect(encodeCompactJson(doc)).toContain('"canRetry":false')
+    expect(encodeCompactJson(doc)).toContain(
+      '"statusLabel":"Waiting for blockers"',
+    )
+  })
+
+  test("status rows carry Draining statusLabel while machine status stays Needs human review", () => {
+    const doc = buildStatusSuccessDocument({
+      repository: null,
+      lanes: [
+        {
+          id: "ATTENTION",
+          label: "Attention",
+          count: 1,
+          workItems: [
+            {
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+              id: "wi-draining",
+              issueNumber: 42,
+              issueTitle: "Paused while Build is still running",
+              state: "IMPLEMENT",
+              status: "NEEDS_HUMAN_REVIEW",
+              statusLabel: "Draining",
+              statusMessage: null,
+              paused: true,
+              canRetry: false,
+              latestStepRunReason: null,
+              pullRequestNumber: null,
+              createdAt: "2026-08-12T10:00:00.000Z",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              stateReadyAt: "2026-08-12T10:00:00.000Z",
+              postponedUntil: null,
+            },
+          ],
+        },
+        { id: "QUEUE", label: "Queue", count: 0, workItems: [] },
+        { id: "BUILD", label: "Build", count: 0, workItems: [] },
+        { id: "REVIEW", label: "Review", count: 0, workItems: [] },
+        { id: "PR", label: "PR", count: 0, workItems: [] },
+        { id: "MERGED", label: "Merged", count: 0, workItems: [] },
+      ],
+    })
+    expect(doc.schemaVersion).toBe(1)
+    expect(doc.lanes[0]?.workItems[0]?.status).toBe("NEEDS_HUMAN_REVIEW")
+    expect(doc.lanes[0]?.workItems[0]?.statusLabel).toBe("Draining")
+    expect(encodeCompactJson(doc)).toContain('"statusLabel":"Draining"')
+    expect(encodeCompactJson(doc)).toContain('"status":"NEEDS_HUMAN_REVIEW"')
   })
 
   test("status rows carry canRetry and latest Step Run reason additively on schemaVersion 1", () => {
@@ -114,6 +167,7 @@ describe("finite CLI JSON contract", () => {
               issueTitle: "Retryable implement failure",
               state: "IMPLEMENT",
               status: "FAILED",
+              statusLabel: "Failed",
               statusMessage:
                 "Claude Code failed to implement the Work Item issue",
               paused: false,
@@ -152,6 +206,7 @@ describe("finite CLI JSON contract", () => {
               issueTitle: "Terminal close failure",
               state: "FAILED",
               status: "FAILED",
+              statusLabel: "Failed",
               statusMessage: "Issue is not open",
               paused: false,
               canRetry: false,
@@ -179,6 +234,7 @@ describe("finite CLI JSON contract", () => {
               issueTitle: "Retryable review handoff",
               state: "NEEDS_HUMAN",
               status: "NEEDS_HUMAN",
+              statusLabel: "Needs human",
               statusMessage: "Human must review findings",
               paused: false,
               canRetry: true,
@@ -206,6 +262,7 @@ describe("finite CLI JSON contract", () => {
               issueTitle: "Interrupted without detail",
               state: "IMPLEMENT",
               status: "INTERRUPTED",
+              statusLabel: "Interrupted",
               statusMessage:
                 "Lifecycle Step was interrupted before an outcome could be established",
               paused: false,

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -192,6 +192,7 @@ export type StatusWorkItemRow = {
   readonly issueTitle: string | null
   readonly state: string
   readonly status: string
+  readonly statusLabel: string
   readonly statusMessage: string | null
   readonly paused: boolean
   readonly canRetry: boolean

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -1480,6 +1480,7 @@ describe("operator binary finite-command process contract", () => {
           issueTitle: "Retryable implement failure",
           state: "IMPLEMENT",
           status: "FAILED",
+          statusLabel: "Failed",
           statusMessage: "Claude Code failed to implement the Work Item issue",
           paused: false,
           canRetry: true,
@@ -1513,6 +1514,7 @@ describe("operator binary finite-command process contract", () => {
           issueTitle: "Terminal close failure",
           state: "FAILED",
           status: "FAILED",
+          statusLabel: "Failed",
           statusMessage: "Issue is not open",
           paused: false,
           canRetry: false,
@@ -1537,6 +1539,7 @@ describe("operator binary finite-command process contract", () => {
           issueTitle: "Retryable review handoff",
           state: "NEEDS_HUMAN",
           status: "NEEDS_HUMAN",
+          statusLabel: "Needs human",
           statusMessage: "Human must review findings",
           paused: false,
           canRetry: true,
@@ -1561,6 +1564,7 @@ describe("operator binary finite-command process contract", () => {
           issueTitle: "Interrupted without detail",
           state: "IMPLEMENT",
           status: "INTERRUPTED",
+          statusLabel: "Interrupted",
           statusMessage:
             "Lifecycle Step was interrupted before an outcome could be established",
           paused: false,
@@ -1572,6 +1576,26 @@ describe("operator binary finite-command process contract", () => {
             detail: null,
             retryAt: null,
           },
+          pullRequestNumber: null,
+          createdAt: "2026-08-12T10:00:00.000Z",
+          updatedAt: "2026-08-12T10:00:00.000Z",
+          stateReadyAt: "2026-08-12T10:00:00.000Z",
+          postponedUntil: null,
+        },
+      },
+      {
+        repository,
+        workItem: {
+          id: "wi-draining",
+          issueNumber: 14,
+          issueTitle: "Paused while Build is still running",
+          state: "IMPLEMENT",
+          status: "NEEDS_HUMAN_REVIEW",
+          statusLabel: "Draining",
+          statusMessage: null,
+          paused: true,
+          canRetry: false,
+          latestStepRunReason: null,
           pullRequestNumber: null,
           createdAt: "2026-08-12T10:00:00.000Z",
           updatedAt: "2026-08-12T10:00:00.000Z",
@@ -1640,6 +1664,7 @@ describe("operator binary finite-command process contract", () => {
       expect(
         seenBodies.some((body) => body.includes("latestStepRunReason")),
       ).toBe(true)
+      expect(seenBodies.some((body) => body.includes("statusLabel"))).toBe(true)
       const document = parseExactlyOneJsonDocument(result.stdout)
       expect(document).toEqual(
         buildStatusSuccessDocument({

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -1608,6 +1608,7 @@ describe("operator binary CLI seam", () => {
             issueTitle: "Retryable implement failure",
             state: "IMPLEMENT",
             status: "FAILED",
+            statusLabel: "Failed",
             statusMessage:
               "Claude Code failed to implement the Work Item issue",
             paused: false,
@@ -1640,6 +1641,7 @@ describe("operator binary CLI seam", () => {
             issueTitle: "Terminal close failure",
             state: "FAILED",
             status: "FAILED",
+            statusLabel: "Failed",
             statusMessage: "Issue is not open",
             paused: false,
             canRetry: false,
@@ -1662,6 +1664,7 @@ describe("operator binary CLI seam", () => {
             issueTitle: "Retryable review handoff",
             state: "NEEDS_HUMAN",
             status: "NEEDS_HUMAN",
+            statusLabel: "Needs human",
             statusMessage: "Human must review findings",
             paused: false,
             canRetry: true,
@@ -1684,6 +1687,7 @@ describe("operator binary CLI seam", () => {
             issueTitle: "Interrupted without detail",
             state: "IMPLEMENT",
             status: "INTERRUPTED",
+            statusLabel: "Interrupted",
             statusMessage:
               "Lifecycle Step was interrupted before an outcome could be established",
             paused: false,

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -159,6 +159,7 @@ type GraphqlStatusWorkItem = {
   readonly issueTitle: string | null
   readonly state: string
   readonly status: string
+  readonly statusLabel: string
   readonly statusMessage: string | null
   readonly paused: boolean
   readonly canRetry: boolean
@@ -212,6 +213,7 @@ const toStatusWorkItemRow = (row: {
   issueTitle: row.workItem.issueTitle,
   state: row.workItem.state,
   status: row.workItem.status,
+  statusLabel: row.workItem.statusLabel,
   statusMessage: row.workItem.statusMessage,
   paused: row.workItem.paused,
   canRetry: row.workItem.canRetry,
@@ -863,6 +865,7 @@ export class GraphqlApi extends Context.Service<
                         issueTitle: true,
                         state: true,
                         status: true,
+                        statusLabel: true,
                         statusMessage: true,
                         paused: true,
                         canRetry: true,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -84,7 +84,6 @@ import { toGraphQLError } from "./to-graphql-error.js"
 import { validateAgentModelsAgainstCatalog } from "./validate-agent-models.js"
 import {
   lifecycleLabels,
-  statusLabel,
   workIssueProjection,
   workItemCanRetry,
   workItemHasActiveStepRun,
@@ -94,6 +93,7 @@ import {
   workItemPostponedUntil,
   workItemStateLabel,
   workItemStatus,
+  workItemStatusLabel,
   workItemStatusMessage,
 } from "./work-item-projection.js"
 
@@ -1329,7 +1329,7 @@ export const createGraphqlApi = <R>(
           status: (workItem: WorkItemRecord) =>
             workItemStatus(workItem).toUpperCase(),
           statusLabel: (workItem: WorkItemRecord) =>
-            statusLabel(workItemStatus(workItem)),
+            workItemStatusLabel(workItem),
           statusMessage: async (
             workItem: WorkItemRecord,
             _args: unknown,

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -234,6 +234,18 @@ export const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
   return stepRunDisplayStatus(latest)
 }
 
+/**
+ * Operator-visible status badge. Drain is Pause plus an active Step Run, not
+ * a lifecycle state: machine status stays Needs human review.
+ */
+export const workItemStatusLabel = (workItem: WorkItemRecord): string => {
+  const status = workItemStatus(workItem)
+  if (status === "needs_human_review" && workItemHasActiveStepRun(workItem)) {
+    return "Draining"
+  }
+  return statusLabel(status)
+}
+
 const REVIEW_IN_PROGRESS_CHIP_MESSAGES = new Set<string>([
   REVIEW_REVIEWING_MESSAGE,
   REVIEW_APPLYING_FINDINGS_MESSAGE,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -5830,6 +5830,208 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("projects paused unfinished work item with a running Step Run as Draining", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const draining = {
+      ...workItem,
+      state: "implement",
+      paused: true,
+      pauseBeforeStep: null,
+      stepRuns: [
+        { ...baseRun, step: "create_worktree", status: "succeeded" },
+        { ...baseRun, step: "install_dependencies", status: "succeeded" },
+        {
+          ...baseRun,
+          step: "implement",
+          status: "running",
+          finishedAt: null,
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([draining]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $issueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+            state status statusLabel paused isTerminal canRetry hasActiveStepRun
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            state: "IMPLEMENT",
+            status: "NEEDS_HUMAN_REVIEW",
+            statusLabel: "Draining",
+            paused: true,
+            isTerminal: false,
+            canRetry: false,
+            hasActiveStepRun: true,
+            lifecycleLabels: [
+              {
+                phase: "CREATE_WORKTREE",
+                label: "Create worktree: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "INSTALL_DEPENDENCIES",
+                label: "Install dependencies: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "IMPLEMENT",
+                label: "Build: Running",
+                status: "RUNNING",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("projects paused Implement Locally work item with a running Step Run as Draining", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const drainingLocally = {
+      ...workItem,
+      state: "review",
+      paused: true,
+      pauseBeforeStep: "commit",
+      stepRuns: [
+        { ...baseRun, step: "create_worktree", status: "succeeded" },
+        { ...baseRun, step: "install_dependencies", status: "succeeded" },
+        { ...baseRun, step: "implement", status: "succeeded" },
+        { ...baseRun, step: "pre_commit", status: "succeeded" },
+        {
+          ...baseRun,
+          step: "review",
+          status: "running",
+          finishedAt: null,
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([drainingLocally]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $issueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+            state status statusLabel paused isTerminal
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            state: "REVIEW",
+            status: "NEEDS_HUMAN_REVIEW",
+            statusLabel: "Draining",
+            paused: true,
+            isTerminal: false,
+          },
+        ],
+      },
+    })
+  })
+
+  test("projects paused closed-Issue stop with a running Step Run as Draining", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const reason =
+      "Issue #42 is closed or no longer present while pull request #101 is still open. Reopen the issue if you want to continue, then Start job."
+    const drainingClosedIssue = {
+      ...workItem,
+      state: "watch_pr_status_checks",
+      paused: true,
+      pauseBeforeStep: null,
+      pullRequestNumber: 101,
+      failureCode: null,
+      failureMessage: reason,
+      holdsWorkerSlot: true,
+      stepRuns: [
+        { ...baseRun, step: "create_worktree", status: "succeeded" },
+        {
+          ...baseRun,
+          step: "watch_pr_status_checks",
+          status: "running",
+          finishedAt: null,
+          reasonCode: "issue_closed_while_pr_open",
+          reasonMessage: reason,
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([drainingClosedIssue]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $issueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+            state status statusLabel statusMessage paused isTerminal canRetry
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            state: "WATCH_PR_STATUS_CHECKS",
+            status: "NEEDS_HUMAN_REVIEW",
+            statusLabel: "Draining",
+            statusMessage: reason,
+            paused: true,
+            isTerminal: false,
+            canRetry: false,
+          },
+        ],
+      },
+    })
+  })
+
   test("projects paused closed-Issue + open-PR stop as Needs human review with reason, not Succeeded", async () => {
     const baseRun = workItem.stepRuns[0]!
     const reason =

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -12,6 +12,7 @@ import {
   workItemPostponedUntil,
   workItemStateLabel,
   workItemStatus,
+  workItemStatusLabel,
   workItemStatusMessage,
 } from "../src/lib/work-item-projection.js"
 import { describe, expect, test } from "bun:test"
@@ -202,6 +203,14 @@ describe("Postponed Step Run projection", () => {
       ),
     ).toBe("needs_human_review")
     expect(
+      workItemStatusLabel(
+        workItemWith({
+          paused: true,
+          stepRuns: [{ ...baseStepRun, status: "running", finishedAt: null }],
+        }),
+      ),
+    ).toBe("Draining")
+    expect(
       workItemCanRetry(
         workItemWith({ waitingSince: new Date("2026-07-14T08:05:00.000Z") }),
       ),
@@ -293,6 +302,94 @@ describe("Postponed Step Run projection", () => {
         durationMs: 2_315_000,
       },
     ])
+  })
+})
+
+describe("paused Work Item statusLabel drain", () => {
+  test("labels a paused Work Item with a running Step Run as Draining", () => {
+    const draining = workItemWith({
+      paused: true,
+      stepRuns: [{ ...baseStepRun, status: "running", finishedAt: null }],
+    })
+    expect(workItemStatus(draining)).toBe("needs_human_review")
+    expect(workItemStatusLabel(draining)).toBe("Draining")
+    expect(lifecycleLabels(draining)).toEqual([
+      {
+        phase: "REVIEW",
+        label: "Review: reviewing",
+        status: "RUNNING",
+        durationMs: 2_315_000,
+      },
+    ])
+  })
+
+  test("labels a paused Work Item with a queued Step Run as Draining", () => {
+    const draining = workItemWith({
+      paused: true,
+      stepRuns: [
+        {
+          ...baseStepRun,
+          status: "queued",
+          startedAt: null,
+          finishedAt: null,
+          executionDurationMs: null,
+        },
+      ],
+    })
+    expect(workItemStatus(draining)).toBe("needs_human_review")
+    expect(workItemStatusLabel(draining)).toBe("Draining")
+  })
+
+  test("keeps idle paused Work Items as Needs human review", () => {
+    const idlePaused = workItemWith({
+      paused: true,
+      stepRuns: [{ ...baseStepRun, status: "succeeded" }],
+    })
+    expect(workItemStatus(idlePaused)).toBe("needs_human_review")
+    expect(workItemStatusLabel(idlePaused)).toBe("Needs human review")
+  })
+
+  test("restores the live Step Run label after Start during drain", () => {
+    const startedDuringDrain = workItemWith({
+      paused: false,
+      stepRuns: [{ ...baseStepRun, status: "running", finishedAt: null }],
+    })
+    expect(workItemStatus(startedDuringDrain)).toBe("running")
+    expect(workItemStatusLabel(startedDuringDrain)).toBe("Running")
+  })
+
+  test("does not relabel waiting-for-blockers or waiting-for-worker-slot over Pause", () => {
+    const pausedWaitingForBlockers = workItemWith({
+      paused: true,
+      waitingForBlockers: true,
+      stepRuns: [{ ...baseStepRun, status: "running", finishedAt: null }],
+    })
+    expect(workItemStatus(pausedWaitingForBlockers)).toBe(
+      "waiting_for_blockers",
+    )
+    expect(workItemStatusLabel(pausedWaitingForBlockers)).toBe(
+      "Waiting for blockers",
+    )
+
+    const pausedWaitingForSlot = workItemWith({
+      paused: true,
+      waitingSince: new Date("2026-07-14T08:05:00.000Z"),
+      stepRuns: [{ ...baseStepRun, status: "running", finishedAt: null }],
+    })
+    expect(workItemStatus(pausedWaitingForSlot)).toBe("waiting_for_worker_slot")
+    expect(workItemStatusLabel(pausedWaitingForSlot)).toBe(
+      "Waiting for worker slot",
+    )
+  })
+
+  test("keeps terminal Needs human distinct from drain", () => {
+    const needsHuman = workItemWith({
+      state: "needs_human",
+      paused: false,
+      stepRuns: [{ ...baseStepRun, status: "succeeded" }],
+    })
+    expect(workItemStatus(needsHuman)).toBe("needs_human")
+    expect(workItemStatusLabel(needsHuman)).toBe("Needs human")
   })
 })
 


### PR DESCRIPTION
## Why

Pause is a hold, not a stop: the current Step Run keeps running. During
that drain the board still showed **Needs human review**, which reads as
if a handoff is already waiting even though no human action is needed yet.

## What changed

The projected operator-visible `statusLabel` is now **Draining** when a
Work Item is paused and a Step Run is still queued or running. Machine
`status` stays Needs human review, so the card remains in Attention with
the existing alarm treatment.

When that Step Run finishes, the label becomes **Needs human review**
with no extra action. Clearing Pause during drain restores the live step
label. Interrupt stays available while draining; Start appears only once
idle; Retry stays unavailable for the whole Pause.

`ready-for-agent status` now carries `statusLabel`, so CLI output matches
the board and GraphQL. Journey chips still show the real Step Run outcome
(for example **Build: Running**).

This is a display overlay on `paused` plus an active Step Run. It does
not add a lifecycle state, GraphQL status enum, or persisted draining
flag.

## Verification

GraphQL API tests cover operator Pause, Implement Locally auto-pause, and
closed-Issue pause: draining while a Step Run is active, **Needs human
review** once idle, and terminal **Needs human** unchanged. Projection
tests cover queued drain, Start during drain, and waiting-for-blockers /
waiting-for-worker-slot still beating Pause. CLI status tests assert
`statusLabel` is queried and passed through, including **Draining** with
machine status Needs human review.

No visual attachments. Badge color, chip styling, and
Pause/Start/Interrupt/Retry behavior were left unchanged.

Related to #1201.

Closes #1201