### PR TITLE
fix(lifecycle): associate Azure Boards Issues with draft PRs so merge can close them

### DIFF
--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -197,6 +197,7 @@ const defaultAzureDevOpsShape = {
   getOpenPullRequestNumber: () => Effect.succeed(1),
   findOpenPullRequestNumber: () => Effect.succeed(null),
   createDraftPullRequest: () => Effect.succeed(1),
+  ensurePullRequestLinkedToIssue: () => Effect.void,
   updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
   countOpenNonDraftPullRequests: () => Effect.succeed(0),
   getPullRequestCheckStatus: () =>

--- a/docs/adr/0061-azure-devops-merge-and-status-mapping.md
+++ b/docs/adr/0061-azure-devops-merge-and-status-mapping.md
@@ -40,7 +40,12 @@ request. `mergePullRequest` completes via `PATCH .../pullrequests/{id}` with
 `lastMergeSourceCommit: {commitId: <expected head>}`, and
 `completionOptions: {transitionWorkItems: true}`. The completion option asks
 Azure DevOps to transition linked work items to their next logical state; the
-PR description remains the published implementation summary. Azure DevOps
+PR description remains the published implementation summary. Create PR
+associates the Forge Issue with that pull request as a Boards ArtifactLink
+(`ensurePullRequestLinkedToIssue`) so the option has a link to act on —
+Azure DevOps does not treat `Closes #N` in the description as a Boards
+association. The link is idempotent: reuse of an already-open Work Item PR
+adds it only when missing. Azure DevOps
 rejects a stale `lastMergeSourceCommit` the same way GitLab's `sha` merge
 parameter guards against a concurrent push, so `400`/`409`/`422` are treated
 as "handled, re-classify" (mirroring GitLab's `405`/`406`/`409`/`422`), and any

--- a/packages/azure-devops-service/src/lib/azure-devops-helper-process.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-helper-process.ts
@@ -12,8 +12,8 @@ export const INTERNAL_AZURE_DEVOPS_HELPER_ARG =
 /**
  * CLI-backed operations. `hasCredentials`/`hasAmbientCredentials` are
  * synchronous local checks (no vault secret needed) and never need a
- * subprocess, matching GitLab's helper operation set. Of the 18-method
- * surface that leaves 14 future helper candidates: 13 are already
+ * subprocess, matching GitLab's helper operation set. Of the 19-method
+ * surface that leaves 15 future helper candidates: 14 are already
  * implemented against the live REST API in-process, while
  * `countOpenNonDraftPullRequests` still fails with
  * `AzureDevOpsNotImplementedError`. Each gains a helper operation (and

--- a/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
@@ -115,6 +115,7 @@ const ProjectRefSchema = Schema.Struct({
 })
 
 const RepositoryRefSchema = Schema.Struct({
+  id: Schema.optional(Schema.NullOr(Schema.String)),
   project: Schema.optional(Schema.NullOr(ProjectRefSchema)),
 })
 
@@ -130,6 +131,13 @@ const PullRequestSchema = Schema.Struct({
   mergeStatus: Schema.optional(Schema.NullOr(Schema.String)),
   lastMergeSourceCommit: Schema.optional(Schema.NullOr(CommitRefSchema)),
   creationDate: Schema.optional(Schema.NullOr(Schema.String)),
+  /**
+   * Canonical ArtifactLink URI for this pull request
+   * (`vstfs:///Git/PullRequestId/{projectId}%2f{repositoryId}%2f{pullRequestId}`).
+   * Used to associate Boards work items; prefer this over constructing the
+   * URI from GUIDs.
+   */
+  artifactId: Schema.optional(Schema.NullOr(Schema.String)),
   /** Present on the full PR resource; used to build the policy artifact id. */
   repository: Schema.optional(Schema.NullOr(RepositoryRefSchema)),
 })
@@ -140,8 +148,23 @@ const PullRequestListSchema = Schema.Struct({
 })
 
 const RepositoryMetaSchema = Schema.Struct({
+  id: Schema.optional(RequiredString),
   defaultBranch: Schema.optional(Schema.NullOr(Schema.String)),
+  project: Schema.optional(Schema.NullOr(ProjectRefSchema)),
 })
+
+const PullRequestWorkItemRefSchema = Schema.Struct({
+  id: Schema.optional(Schema.Union([Schema.String, Schema.Int])),
+  url: Schema.optional(Schema.NullOr(Schema.String)),
+})
+const PullRequestWorkItemListSchema = Schema.Struct({
+  value: Schema.optional(Schema.Array(PullRequestWorkItemRefSchema)),
+})
+
+/** ArtifactLink relation type Boards uses for Development / PR links. */
+const ARTIFACT_LINK_REL = "ArtifactLink"
+/** Case-sensitive Boards display name for a pull-request ArtifactLink. */
+const PULL_REQUEST_LINK_NAME = "Pull Request"
 
 /** One `GET .../policy/evaluations` entry (branch policy, including build validation). */
 const PolicyEvaluationSchema = Schema.Struct({
@@ -429,6 +452,11 @@ const WorkItemRelationSchema = Schema.Struct({
   url: RequiredString,
 })
 
+const WorkItemWithRelationsSchema = Schema.Struct({
+  id: Schema.Int,
+  relations: Schema.optional(Schema.Array(WorkItemRelationSchema)),
+})
+
 const WorkItemFieldsSchema = Schema.Struct({
   "System.Title": Schema.optional(Schema.String),
   "System.Description": Schema.optional(Schema.NullOr(Schema.String)),
@@ -602,6 +630,40 @@ const codeReviewArtifactId = (
   projectId: string,
   pullRequestId: number,
 ): string => `vstfs:///CodeReview/CodeReviewId/${projectId}/${pullRequestId}`
+
+/**
+ * Boards ArtifactLink URI for a Git pull request. `%2f` between GUIDs is
+ * required for the link to show on both the PR work-item list and the
+ * Boards item's Development links (a literal `/` creates a one-way link).
+ */
+const gitPullRequestArtifactId = (
+  projectId: string,
+  repositoryId: string,
+  pullRequestId: number,
+): string =>
+  `vstfs:///Git/PullRequestId/${projectId}%2f${repositoryId}%2f${pullRequestId}`
+
+const normalizeArtifactUrl = (url: string): string =>
+  decodeURIComponent(url.trim()).toLowerCase()
+
+const parseWorkItemRefId = (ref: {
+  readonly id?: string | number | undefined
+  readonly url?: string | null | undefined
+}): number | null => {
+  if (
+    typeof ref.id === "number" &&
+    Number.isSafeInteger(ref.id) &&
+    ref.id > 0
+  ) {
+    return ref.id
+  }
+  if (typeof ref.id === "string") {
+    const parsed = Number(ref.id.trim())
+    if (Number.isSafeInteger(parsed) && parsed > 0) return parsed
+  }
+  if (typeof ref.url === "string") return workItemIdFromRelationUrl(ref.url)
+  return null
+}
 
 const policyEvaluationsPath = (
   identity: AzureDevOpsProjectIdentity,
@@ -1303,6 +1365,165 @@ export const makeAzureDevOpsService = (options: {
         })
       }
       return created.pullRequestId
+    }),
+    ensurePullRequestLinkedToIssue: Effect.fn(
+      "AzureDevOpsService.ensurePullRequestLinkedToIssue",
+    )(function* (repository, pullRequestNumber, issueNumber) {
+      if (!Number.isSafeInteger(pullRequestNumber) || pullRequestNumber <= 0) {
+        return yield* new AzureDevOpsRequestError({
+          message: `Invalid pull request number for ${repository.projectPath}: ${String(pullRequestNumber)}`,
+        })
+      }
+      if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+        return yield* new AzureDevOpsRequestError({
+          message: `Invalid Issue number for ${repository.projectPath}: ${String(issueNumber)}`,
+        })
+      }
+      const identity = splitAzureDevOpsProjectPath(repository.projectPath)
+      if (identity === null) {
+        return yield* invalidProjectPath(repository)
+      }
+      const issueRef = `${repository.projectPath}#${issueNumber}`
+      const prRef = `${repository.projectPath} PR ${pullRequestNumber}`
+
+      const listLinkedIssueIds = (): Effect.Effect<
+        readonly number[],
+        AzureDevOpsRequestError
+      > =>
+        requestUnknown(
+          identity.organization,
+          pullRequestsPath(identity, `/${pullRequestNumber}/workitems`),
+          `Failed to list work items linked to ${prRef}`,
+        ).pipe(
+          Effect.flatMap((value) =>
+            decodeOrRequestError(
+              PullRequestWorkItemListSchema,
+              `Azure DevOps returned invalid linked work items for ${prRef}`,
+              value,
+            ),
+          ),
+          Effect.map((listed) =>
+            (listed.value ?? [])
+              .map(parseWorkItemRefId)
+              .filter((id): id is number => id !== null),
+          ),
+          Effect.catch((error) =>
+            error instanceof AzureDevOpsRequestError && error.statusCode === 404
+              ? Effect.succeed([] as const)
+              : Effect.fail(error),
+          ),
+        )
+
+      const alreadyLinked = (ids: readonly number[]): boolean =>
+        ids.includes(issueNumber)
+
+      const initial = yield* listLinkedIssueIds()
+      if (alreadyLinked(initial)) {
+        return
+      }
+
+      const pr = yield* requestUnknown(
+        identity.organization,
+        pullRequestsPath(identity, `/${pullRequestNumber}`),
+        `Failed to load ${prRef}`,
+      ).pipe(
+        Effect.flatMap((value) =>
+          decodePullRequest(value, `Azure DevOps returned an invalid ${prRef}`),
+        ),
+      )
+
+      const artifactIdFromPr = pr.artifactId?.trim() ?? ""
+      let artifactId = artifactIdFromPr
+      if (artifactId === "") {
+        const repositoryId = pr.repository?.id?.trim() ?? ""
+        const projectId = pr.repository?.project?.id?.trim() ?? ""
+        if (repositoryId !== "" && projectId !== "") {
+          artifactId = gitPullRequestArtifactId(
+            projectId,
+            repositoryId,
+            pullRequestNumber,
+          )
+        }
+      }
+      if (artifactId === "") {
+        const meta = yield* requestUnknown(
+          identity.organization,
+          repositoryMetaPath(identity),
+          `Failed to resolve repository identity for ${prRef}`,
+        ).pipe(
+          Effect.flatMap((value) =>
+            decodeOrRequestError(
+              RepositoryMetaSchema,
+              `Azure DevOps returned invalid repository metadata for ${repository.projectPath}`,
+              value,
+            ),
+          ),
+        )
+        const repositoryId = meta.id?.trim() ?? ""
+        const projectId = meta.project?.id?.trim() ?? ""
+        if (repositoryId === "" || projectId === "") {
+          return yield* new AzureDevOpsRequestError({
+            message: `Azure DevOps did not identify the pull request artifact for ${prRef}`,
+          })
+        }
+        artifactId = gitPullRequestArtifactId(
+          projectId,
+          repositoryId,
+          pullRequestNumber,
+        )
+      }
+
+      const patched = yield* requestUnknown(
+        identity.organization,
+        `${workItemPath(identity, issueNumber)}?$expand=relations`,
+        `Failed to associate ${issueRef} with ${prRef}`,
+        {
+          method: "PATCH",
+          contentType: "application/json-patch+json",
+          body: [
+            {
+              op: "add",
+              path: "/relations/-",
+              value: {
+                rel: ARTIFACT_LINK_REL,
+                url: artifactId,
+                attributes: { name: PULL_REQUEST_LINK_NAME },
+              },
+            },
+          ],
+        },
+      ).pipe(
+        Effect.flatMap((value) =>
+          decodeOrRequestError(
+            WorkItemWithRelationsSchema,
+            `Azure DevOps returned an invalid Work Item after linking ${issueRef} to ${prRef}`,
+            value,
+          ),
+        ),
+        Effect.result,
+      )
+
+      if (Result.isSuccess(patched)) {
+        const linked = (patched.success.relations ?? []).some(
+          (relation) =>
+            relation.rel === ARTIFACT_LINK_REL &&
+            normalizeArtifactUrl(relation.url) ===
+              normalizeArtifactUrl(artifactId),
+        )
+        if (linked) {
+          return
+        }
+      } else if (patched.failure.statusCode !== 400) {
+        return yield* patched.failure
+      }
+
+      const after = yield* listLinkedIssueIds()
+      if (alreadyLinked(after)) {
+        return
+      }
+      return yield* new AzureDevOpsRequestError({
+        message: `Azure DevOps did not associate ${issueRef} with ${prRef}`,
+      })
     }),
     updateOpenDraftPullRequestCopy: Effect.fn(
       "AzureDevOpsService.updateOpenDraftPullRequestCopy",

--- a/packages/azure-devops-service/src/lib/azure-devops-service-test.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-test.ts
@@ -16,7 +16,7 @@ import type {
 } from "./types.js"
 
 /**
- * Hand-written fake for the Azure DevOps service surface: the 15 REST-backed
+ * Hand-written fake for the Azure DevOps service surface: the 16 REST-backed
  * methods plus the two local credential checks (`hasCredentials`/
  * `hasAmbientCredentials`). Mirrors
  * `gitlab-service-test.ts`'s in-memory `Map`-keyed `Layer.succeed` pattern:
@@ -147,6 +147,8 @@ export const makeAzureDevOpsServiceTest = (
         state.openPullRequestByBranch[input.headRefName] = pullRequestNumber
         return Effect.succeed(pullRequestNumber)
       }),
+    ensurePullRequestLinkedToIssue: (repository) =>
+      failOr(repository, () => Effect.void),
     updateOpenDraftPullRequestCopy: (repository, headRefName) =>
       failOr(repository, (state) =>
         Effect.succeed(state.openPullRequestByBranch[headRefName] ?? null),

--- a/packages/azure-devops-service/src/lib/azure-devops-service.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service.ts
@@ -24,10 +24,11 @@ export type AzureDevOpsServiceError =
   | AzureDevOpsNotImplementedError
 
 /**
- * Same 18-method surface as {@link @ready-for-agent/gitlab-service#GitLabServiceShape}.
- * 15 methods perform live Azure DevOps REST requests,
- * `hasCredentials`/`hasAmbientCredentials` are local credential checks, and
- * only `countOpenNonDraftPullRequests` still fails with
+ * GitLab's 18-method surface plus {@link AzureDevOpsServiceShape.ensurePullRequestLinkedToIssue}:
+ * Azure Boards does not honor `Closes #N` as a PR association, so Create PR
+ * must write an ArtifactLink. 16 methods perform live Azure DevOps REST
+ * requests, `hasCredentials`/`hasAmbientCredentials` are local credential
+ * checks, and only `countOpenNonDraftPullRequests` still fails with
  * `AzureDevOpsNotImplementedError` (see method-level docs).
  */
 export interface AzureDevOpsServiceShape {
@@ -105,6 +106,18 @@ export interface AzureDevOpsServiceShape {
       readonly baseRefName?: string
     },
   ) => Effect.Effect<number, AzureDevOpsServiceError>
+  /**
+   * Associate the Forge Issue (Azure Boards work item) with an existing
+   * pull request as an ArtifactLink, so Azure's "transition linked work
+   * items" option on merge has something to act on. Idempotent: a missing
+   * link is added; an already-present link is left unchanged. `Closes #N`
+   * in publication copy is not this association.
+   */
+  readonly ensurePullRequestLinkedToIssue: (
+    repository: AzureDevOpsRepository,
+    pullRequestNumber: number,
+    issueNumber: number,
+  ) => Effect.Effect<void, AzureDevOpsServiceError>
   /**
    * When an open draft pull request exists for the exact source branch, set
    * its title and description to the provided values. Non-draft open pull

--- a/packages/azure-devops-service/test/azure-devops-service.spec.ts
+++ b/packages/azure-devops-service/test/azure-devops-service.spec.ts
@@ -1479,6 +1479,161 @@ describe("Azure DevOps createDraftPullRequest", () => {
   })
 })
 
+describe("Azure DevOps ensurePullRequestLinkedToIssue", () => {
+  const artifactId =
+    "vstfs:///Git/PullRequestId/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa%2fbbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb%2f7"
+
+  test("associates the Boards Issue with the pull request when missing", async () => {
+    let patch: {
+      readonly contentType: string | null
+      readonly body: unknown
+      readonly path: string
+    } | null = null
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        const headers = (init?.headers ?? {}) as Record<string, string>
+        patch = {
+          contentType: headers["Content-Type"] ?? null,
+          body: JSON.parse(String(init?.body)),
+          path: url.pathname,
+        }
+        return json({
+          id: 1,
+          relations: [
+            {
+              rel: "ArtifactLink",
+              url: artifactId,
+            },
+          ],
+        })
+      }
+      if (url.pathname.endsWith("/workitems")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.endsWith("/pullrequests/7")) {
+        return json({
+          pullRequestId: 7,
+          status: "active",
+          isDraft: true,
+          artifactId,
+        })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as unknown as typeof fetch)
+
+    await Effect.runPromise(
+      service.ensurePullRequestLinkedToIssue(repository, 7, 1),
+    )
+    expect(patch).toEqual({
+      contentType: "application/json-patch+json",
+      path: "/acme/widgets/_apis/wit/workitems/1",
+      body: [
+        {
+          op: "add",
+          path: "/relations/-",
+          value: {
+            rel: "ArtifactLink",
+            url: artifactId,
+            attributes: { name: "Pull Request" },
+          },
+        },
+      ],
+    })
+  })
+
+  test("does not add a duplicate relation when the Issue is already linked", async () => {
+    let patchCalled = false
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        patchCalled = true
+        return json({ id: 1, relations: [] })
+      }
+      if (url.pathname.endsWith("/workitems")) {
+        return json({
+          value: [
+            {
+              id: "1",
+              url: "https://dev.azure.com/acme/_apis/wit/workItems/1",
+            },
+          ],
+        })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as unknown as typeof fetch)
+
+    await Effect.runPromise(
+      service.ensurePullRequestLinkedToIssue(repository, 7, 1),
+    )
+    expect(patchCalled).toBe(false)
+  })
+
+  test("constructs the ArtifactLink from repository metadata when the pull request omits artifactId", async () => {
+    let patchBody: unknown = null
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        patchBody = JSON.parse(String(init?.body))
+        return json({
+          id: 42,
+          relations: [
+            {
+              rel: "ArtifactLink",
+              url: "vstfs:///Git/PullRequestId/proj-guid%2frepo-guid%2f9",
+            },
+          ],
+        })
+      }
+      if (url.pathname.endsWith("/workitems")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.endsWith("/pullrequests/9")) {
+        return json({
+          pullRequestId: 9,
+          status: "active",
+          isDraft: true,
+        })
+      }
+      if (url.pathname.endsWith("/repositories/widgets")) {
+        return json({
+          id: "repo-guid",
+          project: { id: "proj-guid" },
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as unknown as typeof fetch)
+
+    await Effect.runPromise(
+      service.ensurePullRequestLinkedToIssue(repository, 9, 42),
+    )
+    expect(patchBody).toEqual([
+      {
+        op: "add",
+        path: "/relations/-",
+        value: {
+          rel: "ArtifactLink",
+          url: "vstfs:///Git/PullRequestId/proj-guid%2frepo-guid%2f9",
+          attributes: { name: "Pull Request" },
+        },
+      },
+    ])
+  })
+})
+
 describe("Azure DevOps updateOpenDraftPullRequestCopy", () => {
   test("updates title and description of an open draft pull request", async () => {
     let updateBody: unknown = null

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -263,6 +263,7 @@ const defaultAzureDevOpsShape = {
   getOpenPullRequestNumber: () => Effect.succeed(1),
   findOpenPullRequestNumber: () => Effect.succeed(null),
   createDraftPullRequest: () => Effect.succeed(1),
+  ensurePullRequestLinkedToIssue: () => Effect.void,
   updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
   countOpenNonDraftPullRequests: () => Effect.succeed(0),
   getPullRequestCheckStatus: () =>

--- a/packages/work-item-lifecycle/src/lib/azure-devops-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/azure-devops-service-test.ts
@@ -24,6 +24,7 @@ export const stubAzureDevOpsServiceLayer = (
       getOpenPullRequestNumber: () => Effect.succeed(1),
       findOpenPullRequestNumber: () => Effect.succeed(1),
       createDraftPullRequest: () => Effect.succeed(1),
+      ensurePullRequestLinkedToIssue: () => Effect.void,
       updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
       countOpenNonDraftPullRequests: () => Effect.succeed(0),
       getPullRequestCheckStatus: () =>

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -1277,5 +1277,25 @@ export const createPr = (context: LifecycleStepContext) =>
         }),
     })
 
+    if (repository.forge === "azure-devops") {
+      const azureDevOps = yield* AzureDevOpsService
+      yield* azureDevOps
+        .ensurePullRequestLinkedToIssue(
+          toAzureDevOpsRepository(repository),
+          outcome.value,
+          context.issueNumber,
+        )
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new CreatePrPostconditionError({
+                repositoryId: context.repositoryId,
+                message: `Failed to associate Azure Boards Issue #${context.issueNumber} with pull request ${outcome.value}`,
+                diagnostics: boundDiagnostics(errorMessage(cause)),
+              }),
+          ),
+        )
+    }
+
     return toCreatePrResult(outcome.value, outcome.completion, copy)
   })

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -188,6 +188,10 @@ const stubAzureDevOps = (
     getOpenPullRequestNumber: () => Effect.succeed(321),
     findOpenPullRequestNumber: () => Effect.succeed(null),
     createDraftPullRequest: () => Effect.succeed(321),
+    ensurePullRequestLinkedToIssue: () =>
+      Effect.die(
+        "Azure Boards Issue association is Azure DevOps Create PR only",
+      ),
     updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
     countOpenNonDraftPullRequests: () => Effect.succeed(0),
     getPullRequestCheckStatus: () =>
@@ -496,6 +500,10 @@ describe("createPr", () => {
         title: string
         body: string
       } | null = null
+      const linked: Array<{
+        pullRequestNumber: number
+        issueNumber: number
+      }> = []
       const pushCommands: string[] = []
       let agentCalls = 0
       const azureDevOpsDb = stubDbServiceLayer({
@@ -537,6 +545,14 @@ describe("createPr", () => {
             created = input
             return Effect.succeed(91)
           },
+          ensurePullRequestLinkedToIssue: (
+            _repository,
+            pullRequestNumber,
+            issueNumber,
+          ) =>
+            Effect.sync(() => {
+              linked.push({ pullRequestNumber, issueNumber })
+            }),
           updateOpenDraftPullRequestCopy: () => Effect.succeed(91),
         }),
         keymaxxer: stubKeymaxxer({
@@ -575,6 +591,7 @@ describe("createPr", () => {
         title: "feat: refresh tokens",
         body: "Implements refresh.\n\nCloses #3601642",
       })
+      expect(linked).toEqual([{ pullRequestNumber: 91, issueNumber: 3601642 }])
       expect(githubCalls).toBe(0)
       expect(agentCalls).toBe(0)
       expect(pushCommands).toHaveLength(1)
@@ -595,6 +612,10 @@ describe("createPr", () => {
       let createCalls = 0
       let githubCalls = 0
       let reconciled: { title: string; body: string } | null = null
+      const linked: Array<{
+        pullRequestNumber: number
+        issueNumber: number
+      }> = []
       const azureDevOpsDb = stubDbServiceLayer({
         listRepositories: Effect.succeed([
           makeRepositoryRecord({
@@ -625,6 +646,14 @@ describe("createPr", () => {
             createCalls += 1
             return Effect.succeed(91)
           },
+          ensurePullRequestLinkedToIssue: (
+            _repository,
+            pullRequestNumber,
+            issueNumber,
+          ) =>
+            Effect.sync(() => {
+              linked.push({ pullRequestNumber, issueNumber })
+            }),
           updateOpenDraftPullRequestCopy: (_repository, _branch, input) => {
             reconciled = input
             return Effect.succeed(77)
@@ -650,6 +679,7 @@ describe("createPr", () => {
       })
       expect(createCalls).toBe(0)
       expect(githubCalls).toBe(0)
+      expect(linked).toEqual([{ pullRequestNumber: 77, issueNumber: 3601642 }])
       expect(reconciled).toEqual({
         title: "feat: refresh tokens",
         body: "Implements refresh.\n\nCloses #3601642",
@@ -686,6 +716,7 @@ describe("createPr", () => {
         azureDevOps: stubAzureDevOps({
           findOpenPullRequestNumber: () =>
             Effect.succeed(agentRan ? 654 : null),
+          ensurePullRequestLinkedToIssue: () => Effect.void,
         }),
         keymaxxer: stubKeymaxxer({
           enabled: false,
@@ -871,6 +902,7 @@ describe("createPr", () => {
               createCalls += 1
               return Effect.succeed(999)
             },
+            ensurePullRequestLinkedToIssue: () => Effect.void,
           }),
         },
       )

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -248,6 +248,7 @@ const azureDevOpsWith = (
     getOpenPullRequestNumber: () => Effect.succeed(1),
     findOpenPullRequestNumber: () => Effect.succeed(1),
     createDraftPullRequest: () => Effect.succeed(1),
+    ensurePullRequestLinkedToIssue: () => Effect.void,
     updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
     countOpenNonDraftPullRequests: () => Effect.succeed(0),
     getPullRequestCheckStatus: () => Effect.succeed(status),

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -108,6 +108,7 @@ const stubAzureDevOps = (
     getOpenPullRequestNumber: () => Effect.succeed(1),
     findOpenPullRequestNumber: () => Effect.succeed(null),
     createDraftPullRequest: () => Effect.succeed(1),
+    ensurePullRequestLinkedToIssue: () => Effect.void,
     updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
     countOpenNonDraftPullRequests: () => Effect.succeed(0),
     getPullRequestCheckStatus: () =>


### PR DESCRIPTION
## Why

Azure merge already asks to transition linked work items. Create PR never
created that link — only a GitHub-shaped `Closes #N` line in the
description, which Azure Boards ignores. Dogfood against
`berend-test/test-ready-for-agent` completed a PR with zero linked items;
Boards Issue #1 stayed To Do and still tagged `ready-for-agent`. A control
PR with an explicit Boards link moved Issue #2 to Done.

## What changed

On Azure DevOps, Create PR now associates the Forge Issue with the Work
Item PR as a Boards ArtifactLink. That is the association Azure shows on
the PR work-item list and the Boards item's Development links, and the
one a later merge with transition-linked-items enabled can see. `Closes
#N` stays in publication copy for GitHub/GitLab parity and is not the
Azure mechanism.

Reusing an already-open Work Item PR is idempotent: the Issue is linked
if missing and is not duplicated. GitHub and GitLab Create PR behaviour
is unchanged.

## Verification

Azure service tests cover PR created then Issue linked, and already
linked then no duplicate. Create PR tests assert a new Azure draft and
reuse of an existing exact-branch Azure PR both associate the Issue;
GitHub and GitLab paths still do not. Review found no required findings.

No live Azure e2e in this change; verification is against the REST
contract for bidirectional PR and Boards links. No visual attachments.

Closes #1208