### PR TITLE
fix(azure-devops): treat queued PR completion as in-flight merge

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -392,7 +392,8 @@ The Lifecycle Step that changes a Work Item PR from draft to ready for review af
 The Lifecycle Step that decides whether a settled Work Item PR may be merged by the harness or requires a human.
 
 **Merge PR**:
-The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge.
+The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge. On Azure DevOps, a complete request that is still queued is in-flight merge work, not a Merge Revalidation Outcome or a rejected merge.
+
 
 **local cleanup**:
 The Lifecycle Step that removes the Work Item's local worktree and branch after its remote outcome is finished.

--- a/docs/adr/0061-azure-devops-merge-and-status-mapping.md
+++ b/docs/adr/0061-azure-devops-merge-and-status-mapping.md
@@ -44,7 +44,10 @@ PR description remains the published implementation summary. Azure DevOps
 rejects a stale `lastMergeSourceCommit` the same way GitLab's `sha` merge
 parameter guards against a concurrent push, so `400`/`409`/`422` are treated
 as "handled, re-classify" (mirroring GitLab's `405`/`406`/`409`/`422`), and any
-other status code is a hard failure.
+other status code is a hard failure. A successful complete body that is still
+`active` with `mergeStatus: queued` is in-flight completion, not unknown
+mergeability or a rejected mergeable PR (ADR 0066): Merge PR re-fetches until
+the PR is `completed` or a bounded wait elapses.
 
 **Work item close-out is a `System.State` transition plus a marked comment.**
 `ensureIssueCompletedWithSummary` posts a hidden-marker comment via the

--- a/docs/adr/0066-azure-devops-queued-pr-completion.md
+++ b/docs/adr/0066-azure-devops-queued-pr-completion.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+amends:
+  - 0061
+---
+
+# Azure DevOps queued PR completion is in-flight merge work
+
+Azure DevOps commonly answers a complete request with the pull request still
+`active` and `mergeStatus: queued`, then flips to `completed` a moment later.
+Treating that body as unknown mergeability or as a rejected mergeable PR made
+MERGE_PR fail or revalidate while Azure was actually merging — the same
+operator symptom as a bad PAT, with a different cause.
+
+After a complete request, `active` + `queued` is in-flight completion: Merge PR
+re-fetches the pull request and waits a bounded interval for `completed`. A
+PR that becomes `completed` during that wait is merged and continues to local
+cleanup. A PR that stays queued past the wait fails as a retryable Merge PR
+Step Run whose message says completion is still queued. `conflicts` still
+maps to Merge Conflict Handoff; `rejectedByPolicy` and hard HTTP failures are
+unchanged. Watch-time `queued` (merge not yet computed) remains unknown
+mergeability.
+
+**Considered options:** returning a Merge Revalidation Outcome immediately so
+Watch/Refresh could finish the merge — rejected because it consumes the
+three-cycle revalidation budget on in-flight Azure work and still tells the
+operator the mergeability changed. Failing as `merge_rejected` — rejected
+because the complete request was accepted.

--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -609,7 +609,7 @@ rfa:MergePr
   rfa:retryable true ;
   skos:prefLabel "Merge PR"@en ;
   skos:definition
-    "The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge."@en .
+    "The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge. On Azure DevOps, a complete request that is still queued is in-flight merge work, not a Merge Revalidation Outcome or a rejected merge."@en .
 
 rfa:CloseIssue
   a owl:Class, owl:NamedIndividual, skos:Concept,

--- a/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import {
+  Clock,
   Config,
   Duration,
   Effect,
@@ -39,6 +40,13 @@ import {
 } from "./types.js"
 
 const REQUEST_TIMEOUT = Duration.seconds(30)
+/**
+ * Azure's complete call commonly returns the PR still `active` with
+ * `mergeStatus: queued`, then flips to `completed` a moment later. Merge PR
+ * waits this long for that flip before failing retryably.
+ */
+const QUEUED_COMPLETION_WAIT = Duration.seconds(15)
+const QUEUED_COMPLETION_POLL_INTERVAL = Duration.seconds(1)
 /** Azure DevOps REST API version pinned for stable response shapes. */
 const API_VERSION = "7.1"
 /**
@@ -321,6 +329,19 @@ const mapAzureDevOpsMergeability = (
   if (normalized === "conflicts") return "conflicting"
   return "unknown"
 }
+
+const isActivePullRequest = (pr: AzureDevOpsPullRequest): boolean =>
+  pr.status === "active" || pr.status === undefined
+
+/**
+ * After a complete request, `active` + `queued` means Azure accepted the
+ * merge and is finishing it — not unknown Watch mergeability, and not a
+ * rejected mergeable PR. Watch-time `queued` (merge not yet computed) still
+ * maps to `unknown` via {@link mapAzureDevOpsMergeability}.
+ */
+const isQueuedCompletionInFlight = (pr: AzureDevOpsPullRequest): boolean =>
+  isActivePullRequest(pr) &&
+  (pr.mergeStatus ?? "").trim().toLowerCase() === "queued"
 
 const policyEvaluationTerminalChecks = (
   evaluations: readonly AzureDevOpsPolicyEvaluation[],
@@ -1813,6 +1834,49 @@ export const makeAzureDevOpsService = (options: {
           Effect.result,
         )
 
+        const loadPullRequestById = (
+          pullRequestId: number,
+        ): Effect.Effect<AzureDevOpsPullRequest, AzureDevOpsRequestError> =>
+          requestUnknown(
+            identity.organization,
+            pullRequestsPath(identity, `/${pullRequestId}`),
+            `Failed to re-fetch pull request ${pullRequestId} after merge for ${repository.projectPath}`,
+          ).pipe(
+            Effect.flatMap((value) =>
+              decodePullRequest(
+                value,
+                `Azure DevOps returned an invalid pull request after merge for ${repository.projectPath}:${headRefName}`,
+              ),
+            ),
+          )
+
+        /**
+         * Azure accepted the complete request but has not finished it.
+         * Poll the pull request until it leaves `queued`, or fail retryably
+         * once the wait bound elapses — never `merge_rejected`.
+         */
+        const waitForQueuedCompletion = (
+          pullRequestId: number,
+        ): Effect.Effect<AzureDevOpsPullRequest, AzureDevOpsServiceError> =>
+          Effect.gen(function* () {
+            const deadline =
+              (yield* Clock.currentTimeMillis) +
+              Duration.toMillis(QUEUED_COMPLETION_WAIT)
+            for (;;) {
+              const current = yield* loadPullRequestById(pullRequestId)
+              if (!isQueuedCompletionInFlight(current)) {
+                return current
+              }
+              if ((yield* Clock.currentTimeMillis) >= deadline) {
+                return yield* new AzureDevOpsRequestError({
+                  message: `Azure DevOps completion is still queued for ${repository.projectPath}:${headRefName}`,
+                })
+              }
+              yield* Effect.sleep(QUEUED_COMPLETION_POLL_INTERVAL)
+            }
+          })
+
+        let queuedObservation: AzureDevOpsPullRequest | null = null
         if (Result.isSuccess(mergeResult)) {
           const merged = mergeResult.success
           if (merged.status === "completed") {
@@ -1823,6 +1887,21 @@ export const makeAzureDevOpsService = (options: {
               _tag: "needs_human" as const,
               reason: "closed_unmerged" as const,
               message: `Pull request for ${repository.projectPath}:${headRefName} was concurrently closed without merging`,
+            }
+          }
+          if (isQueuedCompletionInFlight(merged)) {
+            queuedObservation = yield* waitForQueuedCompletion(
+              merged.pullRequestId,
+            )
+            if (queuedObservation.status === "completed") {
+              return { _tag: "merged" } as const
+            }
+            if (queuedObservation.status === "abandoned") {
+              return {
+                _tag: "needs_human" as const,
+                reason: "closed_unmerged" as const,
+                message: `Pull request for ${repository.projectPath}:${headRefName} was concurrently closed without merging`,
+              }
             }
           }
           // Unexpected non-completed success body (e.g. still active after a
@@ -1843,11 +1922,13 @@ export const makeAzureDevOpsService = (options: {
           }
         }
 
-        const refreshed = yield* resolvePullRequestForBranch(
-          repository,
-          identity,
-          headRefName,
-        )
+        const refreshed =
+          queuedObservation ??
+          (yield* resolvePullRequestForBranch(
+            repository,
+            identity,
+            headRefName,
+          ))
         if (refreshed === null) {
           return yield* new AzureDevOpsRequestError({
             message: `Azure DevOps did not return a pull request after merge for ${repository.projectPath}:${headRefName}`,

--- a/packages/azure-devops-service/src/lib/azure-devops-service.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service.ts
@@ -161,7 +161,9 @@ export interface AzureDevOpsServiceShape {
   ) => Effect.Effect<PullRequestLifecycleStatus, AzureDevOpsServiceError>
   /**
    * Merge the open pull request on the exact source branch
-   * (`PATCH .../pullrequests/{id}` with `status: "completed"`). Implemented.
+   * (`PATCH .../pullrequests/{id}` with `status: "completed"`). A complete
+   * response that is still `active` with `mergeStatus: queued` is in-flight
+   * completion (ADR 0066), not a rejected merge. Implemented.
    */
   readonly mergePullRequest: (
     repository: AzureDevOpsRepository,

--- a/packages/azure-devops-service/test/azure-devops-service.spec.ts
+++ b/packages/azure-devops-service/test/azure-devops-service.spec.ts
@@ -1,4 +1,5 @@
-import { Effect, Result } from "effect"
+import { Effect, Fiber, Result } from "effect"
+import { TestClock } from "effect/testing"
 import {
   AzureDevOpsNotImplementedError,
   AzureDevOpsProjectUnavailableError,
@@ -892,6 +893,376 @@ describe("Azure DevOps mergePullRequest", () => {
       lastMergeSourceCommit: { commitId: "sha-1" },
       completionOptions: { transitionWorkItems: true },
     })
+  })
+
+  test("treats a complete response of active+queued as in-flight and merges once a later GET is completed", async () => {
+    let patchBody: unknown = null
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        patchBody = JSON.parse(String(init?.body))
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "queued",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (method === "GET" && /\/pullrequests\/42$/.test(url.pathname)) {
+        return json({
+          pullRequestId: 42,
+          status: "completed",
+          isDraft: false,
+          mergeStatus: "succeeded",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (url.pathname.endsWith("/statuses")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.includes("/policy/evaluations")) {
+        return json({ value: [{ evaluationId: "e1", status: "approved" }] })
+      }
+      return json({
+        value: [
+          {
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "succeeded",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          },
+        ],
+      })
+    }) as unknown as typeof fetch)
+
+    const result = await Effect.runPromise(
+      service.mergePullRequest(repository, "feature"),
+    )
+    expect(result).toEqual({ _tag: "merged" })
+    expect(patchBody).toEqual({
+      status: "completed",
+      lastMergeSourceCommit: { commitId: "sha-1" },
+      completionOptions: { transitionWorkItems: true },
+    })
+  })
+
+  test("merges when a queued complete later becomes completed on poll", async () => {
+    let getByIdCalls = 0
+    let resolveFirstQueuedGet: () => void = () => undefined
+    const firstQueuedGet = new Promise<void>((resolve) => {
+      resolveFirstQueuedGet = resolve
+    })
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "queued",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (method === "GET" && /\/pullrequests\/42$/.test(url.pathname)) {
+        getByIdCalls += 1
+        if (getByIdCalls === 1) {
+          resolveFirstQueuedGet()
+          return json({
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "queued",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          })
+        }
+        return json({
+          pullRequestId: 42,
+          status: "completed",
+          isDraft: false,
+          mergeStatus: "succeeded",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (url.pathname.endsWith("/statuses")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.includes("/policy/evaluations")) {
+        return json({ value: [{ evaluationId: "e1", status: "approved" }] })
+      }
+      return json({
+        value: [
+          {
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "succeeded",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          },
+        ],
+      })
+    }) as unknown as typeof fetch)
+
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* service
+            .mergePullRequest(repository, "feature")
+            .pipe(Effect.forkChild)
+          yield* Effect.promise(() => firstQueuedGet)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust("1 second")
+          return yield* Fiber.join(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(result).toEqual({ _tag: "merged" })
+    expect(getByIdCalls).toBe(2)
+  })
+
+  test("fails retryably when completion stays queued past the wait bound", async () => {
+    let resolveFirstQueuedGet: () => void = () => undefined
+    const firstQueuedGet = new Promise<void>((resolve) => {
+      resolveFirstQueuedGet = resolve
+    })
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "queued",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (method === "GET" && /\/pullrequests\/42$/.test(url.pathname)) {
+        resolveFirstQueuedGet()
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "queued",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (url.pathname.endsWith("/statuses")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.includes("/policy/evaluations")) {
+        return json({ value: [{ evaluationId: "e1", status: "approved" }] })
+      }
+      return json({
+        value: [
+          {
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "succeeded",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          },
+        ],
+      })
+    }) as unknown as typeof fetch)
+
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* service
+            .mergePullRequest(repository, "feature")
+            .pipe(Effect.result, Effect.forkChild)
+          yield* Effect.promise(() => firstQueuedGet)
+          yield* Effect.yieldNow
+          yield* TestClock.adjust("20 seconds")
+          return yield* Fiber.join(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(AzureDevOpsRequestError)
+      expect(result.failure.message).toContain("completion is still queued")
+      expect(result.failure.message).not.toContain("rejected")
+    }
+  })
+
+  test("routes conflicts after a queued complete to mergeability revalidation", async () => {
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "queued",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (method === "GET" && /\/pullrequests\/42$/.test(url.pathname)) {
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "conflicts",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (url.pathname.endsWith("/statuses")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.includes("/policy/evaluations")) {
+        return json({ value: [{ evaluationId: "e1", status: "approved" }] })
+      }
+      return json({
+        value: [
+          {
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "succeeded",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          },
+        ],
+      })
+    }) as unknown as typeof fetch)
+
+    const result = await Effect.runPromise(
+      service.mergePullRequest(repository, "feature"),
+    )
+    expect(result).toEqual({
+      _tag: "revalidation",
+      reason: "mergeability_changed",
+      message:
+        "Pull request mergeability changed while merging acme/widgets:feature",
+    })
+  })
+
+  test("revalidates rejectedByPolicy after a queued complete instead of merge_rejected", async () => {
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "queued",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (method === "GET" && /\/pullrequests\/42$/.test(url.pathname)) {
+        return json({
+          pullRequestId: 42,
+          status: "active",
+          isDraft: false,
+          mergeStatus: "rejectedByPolicy",
+          lastMergeSourceCommit: { commitId: "sha-1" },
+          repository: { project: { id: "proj-1" } },
+        })
+      }
+      if (url.pathname.endsWith("/statuses")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.includes("/policy/evaluations")) {
+        return json({ value: [{ evaluationId: "e1", status: "approved" }] })
+      }
+      return json({
+        value: [
+          {
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "succeeded",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          },
+        ],
+      })
+    }) as unknown as typeof fetch)
+
+    const result = await Effect.runPromise(
+      service.mergePullRequest(repository, "feature"),
+    )
+    expect(result).toEqual({
+      _tag: "revalidation",
+      reason: "mergeability_changed",
+      message:
+        "Pull request mergeability changed while merging acme/widgets:feature",
+    })
+  })
+
+  test("keeps credential and 5xx failures operational", async () => {
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (method === "PATCH") {
+        return new Response("unauthorized", { status: 401 })
+      }
+      if (url.pathname.endsWith("/statuses")) {
+        return json({ value: [] })
+      }
+      if (url.pathname.includes("/policy/evaluations")) {
+        return json({ value: [{ evaluationId: "e1", status: "approved" }] })
+      }
+      return json({
+        value: [
+          {
+            pullRequestId: 42,
+            status: "active",
+            isDraft: false,
+            mergeStatus: "succeeded",
+            lastMergeSourceCommit: { commitId: "sha-1" },
+            repository: { project: { id: "proj-1" } },
+          },
+        ],
+      })
+    }) as unknown as typeof fetch)
+
+    const result = await Effect.runPromise(
+      Effect.result(service.mergePullRequest(repository, "feature")),
+    )
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(AzureDevOpsRequestError)
+      expect(result.failure.statusCode).toBe(401)
+    }
   })
 
   test("re-fetches and reclassifies after a 422 merge precondition rejection", async () => {


### PR DESCRIPTION
Azure DevOps often answers a complete request with the pull request still
**active** and merge status **queued**, then flips to **completed** a moment
later (#1209). Merge PR treated that as unknown mergeability or a rejected
mergeable PR, so operators saw the step fail or revalidate while Azure was
actually merging — the same symptom as a bad PAT, with a different cause.

After a successful complete call, `active` + `queued` is in-flight completion:

- Re-fetch and wait up to 15 seconds for `completed`.
- If it completes during that wait, Merge PR reports merged and continues to
  local cleanup.
- If it stays queued past the bound, the step fails retryably with a message
  that completion is still queued — not that Azure rejected a mergeable PR.
- Conflicts still go to Merge Conflict Handoff. Policy rejection and hard HTTP
  failures are unchanged. Watch-time `queued` (merge not yet computed) remains
  unknown mergeability.

Glossary and ADR 0066 record this as in-flight merge work, not a Merge
Revalidation Outcome.

Azure merge tests cover the live dogfood shape (PATCH `active`+`queued`, later
GET `completed`), a poll that then completes, timeout still-queued as retryable,
conflicts to mergeability revalidation, `rejectedByPolicy` unchanged, and 401
remaining operational. Pre-commit passed after keeping the Merge PR ontology
definition in parity with CONTEXT.md.

The wait is 15 seconds. A slower Azure complete still fails retryably; Retry or
Refresh will pick the PR up if it has completed by then.

Closes #1209