### PR TITLE
fix(lifecycle): omit shipped Issues from candidates when close-out misses

### DIFF
--- a/docs/prd/repository-intake-cli.md
+++ b/docs/prd/repository-intake-cli.md
@@ -30,7 +30,7 @@ An Intake Candidate is a Relevant, open Leaf Issue with no unfinished Work Item 
 - `IMPLEMENT_NOW`: the Issue is Actionable.
 - `QUEUE`: the Issue is blocked and otherwise eligible for Queue.
 
-Parent Issues, closed or irrelevant Issues, and Issues with unfinished Work Items are absent. Callers never need to inspect hierarchy, blockers, or Work Item state to decide what Intake would attempt.
+Parent Issues, closed or irrelevant Issues, Issues with unfinished Work Items, and Issues with a completed Work Item are absent — including when the forge Issue is still open and ready-labeled because close-out missed. Callers never need to inspect hierarchy, blockers, or Work Item state to decide what Intake would attempt.
 
 When classification returns no candidates, `candidates` succeeds with an empty list and does not run backend/model preflight. When candidates exist, the query applies the same Repository-scoped effective Agent Backend and resolved build/review Agent Model preflight as Intake before returning them. A caller therefore knows that every listed candidate passed shared Repository-level admission checks at query time, while ordinary per-Issue revalidation still occurs during a later Intake.
 
@@ -54,7 +54,7 @@ Repository Intake is a synchronous best-effort operation, not an entity:
 - Repository disappearance, database/lifecycle storage failures, enqueue failures, invalid queue configuration, and unexpected defects are operation-level failures. They stop processing and surface as GraphQL errors. Work Items already committed by earlier candidates remain.
 - A concurrent Issue or Work Item change is revalidated and, when it matches a candidate-local case, reported as that candidate's failure.
 - The GraphQL HTTP request's abort signal must interrupt the Intake Effect. Processing then stops; already-created Work Items remain. This requires extending the current GraphQL Effect runner, which does not yet propagate request cancellation.
-- Re-running the command is safe enough for this workflow because Issues with unfinished Work Items are no longer candidates.
+- Re-running the command is safe enough for this workflow because Issues with unfinished Work Items or a completed Work Item are no longer candidates.
 - Zero candidates is a successful no-op and bypasses backend/model preflight.
 - When candidates exist, one Repository-scoped preflight runs before any candidate is attempted. It applies the ordinary creation requirements to the effective Agent Backend and current resolved build and review Agent Model selections, including catalog membership when the backend reports a catalog. A failed preflight is a command-level failure and creates no Work Items.
 - Repository Paused is not changed and does not block this explicit operator request, matching Implement Now and Queue.

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -8282,6 +8282,223 @@ describe("GraphQL API", () => {
     expect(requireAgentTurnsCalls).toBe(1)
   })
 
+  test("intakeCandidates omits Complete-and-still-tagged Issues and keeps no-Work-Item and Failed", async () => {
+    const completeIssue = {
+      ...issue,
+      id: "issue-complete",
+      issueNumber: 8,
+      title: "Shipped but still tagged",
+      url: "https://github.com/acme/widgets/issues/8",
+      blockedBy: [],
+    }
+    const noWorkItemIssue = {
+      ...issue,
+      id: "issue-fresh",
+      issueNumber: 9,
+      title: "No Work Item yet",
+      url: "https://github.com/acme/widgets/issues/9",
+      blockedBy: [],
+    }
+    const failedIssue = {
+      ...issue,
+      id: "issue-failed",
+      issueNumber: 10,
+      title: "Failed with Issue still Ready",
+      url: "https://gitlab.example.com/acme/widgets/-/issues/10",
+      blockedBy: [],
+    }
+    const abandonedIssue = {
+      ...issue,
+      id: "issue-abandoned",
+      issueNumber: 15,
+      title: "Abandoned with Issue still Ready",
+      url: "https://github.com/acme/widgets/issues/15",
+      blockedBy: [],
+    }
+    const needsHumanIssue = {
+      ...issue,
+      id: "issue-needs-human",
+      issueNumber: 11,
+      title: "Needs Human",
+      url: "https://github.com/acme/widgets/issues/11",
+      blockedBy: [],
+    }
+    const gitlabCompleteIssue = {
+      ...issue,
+      id: "issue-gitlab-complete",
+      issueNumber: 12,
+      title: "GitLab shipped but still tagged",
+      url: "https://gitlab.example.com/acme/widgets/-/issues/12",
+      blockedBy: [],
+    }
+    const terminal = (
+      issueNumber: number,
+      state: WorkItemRecord["state"],
+    ): WorkItemRecord =>
+      ({
+        ...workItem,
+        id: `wi-${state}-${String(issueNumber)}`,
+        issueNumber,
+        issueTitle: `Issue ${String(issueNumber)}`,
+        state,
+        holdsWorkerSlot: false,
+        waitingForBlockers: false,
+        waitingSince: null,
+        stepRuns: [],
+      }) as WorkItemRecord
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () =>
+          Effect.succeed([
+            completeIssue,
+            noWorkItemIssue,
+            failedIssue,
+            abandonedIssue,
+            needsHumanIssue,
+            gitlabCompleteIssue,
+          ]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed([
+            terminal(completeIssue.issueNumber, "complete"),
+            terminal(failedIssue.issueNumber, "failed"),
+            terminal(abandonedIssue.issueNumber, "abandoned"),
+            terminal(needsHumanIssue.issueNumber, "needs_human"),
+            terminal(gitlabCompleteIssue.issueNumber, "complete"),
+          ]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            candidates {
+              issueNumber
+              title
+              url
+              action
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        intakeCandidates: {
+          candidates: [
+            {
+              issueNumber: 9,
+              title: "No Work Item yet",
+              url: "https://github.com/acme/widgets/issues/9",
+              action: "IMPLEMENT_NOW",
+            },
+            {
+              issueNumber: 10,
+              title: "Failed with Issue still Ready",
+              url: "https://gitlab.example.com/acme/widgets/-/issues/10",
+              action: "IMPLEMENT_NOW",
+            },
+            {
+              issueNumber: 15,
+              title: "Abandoned with Issue still Ready",
+              url: "https://github.com/acme/widgets/issues/15",
+              action: "IMPLEMENT_NOW",
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("intakeCandidates restores IMPLEMENT_NOW after the Complete Work Item is erased", async () => {
+    const stillReady = {
+      ...issue,
+      issueNumber: 14,
+      title: "Ready after Reset",
+      url: "https://github.com/acme/widgets/issues/14",
+      blockedBy: [],
+    }
+    const complete = {
+      ...workItem,
+      id: "wi-complete-14",
+      issueNumber: 14,
+      issueTitle: stillReady.title,
+      state: "complete",
+      holdsWorkerSlot: false,
+      waitingForBlockers: false,
+      waitingSince: null,
+      stepRuns: [],
+    } as WorkItemRecord
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([stillReady]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([complete]),
+      },
+    )
+
+    const beforeReset = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            candidates { issueNumber action }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+    expect(await beforeReset.json()).toEqual({
+      data: {
+        intakeCandidates: {
+          candidates: [],
+        },
+      },
+    })
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([stillReady]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+      },
+    )
+
+    const afterReset = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            candidates { issueNumber action }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+    expect(await afterReset.json()).toEqual({
+      data: {
+        intakeCandidates: {
+          candidates: [{ issueNumber: 14, action: "IMPLEMENT_NOW" }],
+        },
+      },
+    })
+  })
+
   test("empty Intake Candidates skip Agent Backend preflight", async () => {
     let requireAgentTurnsCalls = 0
     await runtime.dispose()
@@ -8525,6 +8742,95 @@ describe("GraphQL API", () => {
     })
     expect(requireAgentTurnsCalls).toBe(0)
     expect(implementCalls).toBe(0)
+  })
+
+  test("startRepositoryIntake does not Implement Now a Complete-and-still-tagged Issue", async () => {
+    const shipped = {
+      ...issue,
+      id: "issue-shipped",
+      issueNumber: 8,
+      title: "Shipped but still tagged",
+      url: "https://github.com/acme/widgets/issues/8",
+      blockedBy: [],
+    }
+    const fresh = {
+      ...issue,
+      id: "issue-fresh-intake",
+      issueNumber: 9,
+      title: "No Work Item yet",
+      url: "https://gitlab.example.com/acme/widgets/-/issues/9",
+      blockedBy: [],
+    }
+    const createdFresh = {
+      ...workItem,
+      id: "wi-fresh-9",
+      issueNumber: 9,
+      issueTitle: fresh.title,
+    } as WorkItemRecord
+    const complete = {
+      ...workItem,
+      id: "wi-complete-8",
+      issueNumber: 8,
+      issueTitle: shipped.title,
+      state: "complete",
+      holdsWorkerSlot: false,
+      waitingForBlockers: false,
+      waitingSince: null,
+      stepRuns: [],
+    } as WorkItemRecord
+    const implementCalls: number[] = []
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([shipped, fresh]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([complete]),
+        implementNow: (_repositoryId, issueNumber) =>
+          Effect.sync(() => {
+            implementCalls.push(issueNumber)
+            return createdFresh
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            results {
+              __typename
+              ... on RepositoryIntakeCreated {
+                issueNumber
+                action
+                workItem { id }
+              }
+              ... on RepositoryIntakeFailed { issueNumber }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(implementCalls).toEqual([9])
+    expect(await response.json()).toEqual({
+      data: {
+        startRepositoryIntake: {
+          results: [
+            {
+              __typename: "RepositoryIntakeCreated",
+              issueNumber: 9,
+              action: "IMPLEMENT_NOW",
+              workItem: { id: createdFresh.id },
+            },
+          ],
+        },
+      },
+    })
   })
 
   test("startRepositoryIntake processes candidates sequentially and routes Queue", async () => {

--- a/packages/lifecycle-model/src/intake-candidates.ts
+++ b/packages/lifecycle-model/src/intake-candidates.ts
@@ -50,7 +50,10 @@ export type IntakeCandidateWorkItemInput = WorkItemPredicateShape & {
  * outright and never offered, independent of what the Issue's own forge
  * state currently reports. This is a defense-in-depth guard: it must hold
  * even when the forge Issue looks open and startable because its close
- * never landed (see `shippedWorkItems`).
+ * never landed (see `shippedWorkItems`). Failed and Abandoned history does
+ * not trigger this veto; Needs Human remains unfinished and is omitted by
+ * the ordinary unfinished-Work-Item rule. The same guard applies for every
+ * Forge (GitHub, GitLab, and Azure DevOps).
  */
 export const classifyIntakeCandidates = (
   issues: readonly IntakeCandidateIssueInput[],

--- a/packages/lifecycle-model/test/intake-candidates.test.ts
+++ b/packages/lifecycle-model/test/intake-candidates.test.ts
@@ -119,29 +119,95 @@ describe("classifyIntakeCandidates", () => {
     expect(candidates.map((c) => c.issueNumber)).toEqual([8, 9])
   })
 
-  it("never offers an Issue with a completed Work Item, even when the forge Issue still looks open and ready-labeled", () => {
-    // Regression for #42: the forge issue close can silently fail, leaving
-    // the Issue open (and still ready-for-agent labeled) even though its
-    // Work Item already reached `complete`. Candidate evaluation must
-    // exclude it regardless of that stale forge state.
-    const candidates = classifyIntakeCandidates(
-      [issue({ issueNumber: 8, state: "OPEN" })],
-      [workItem({ issueNumber: 8, state: "complete" })],
-    )
-    expect(candidates).toEqual([])
-  })
+  describe("terminal Complete Work Item recandidate guard (#1210)", () => {
+    it("omits a still-open ready-labeled Issue that already has a Complete Work Item", () => {
+      // Defense in depth for a missed forge close-out: the Issue can stay
+      // OPEN and ready-labeled after the Work Item already shipped.
+      const candidates = classifyIntakeCandidates(
+        [issue({ issueNumber: 8, state: "OPEN" })],
+        [workItem({ issueNumber: 8, state: "complete" })],
+      )
+      expect(candidates).toEqual([])
+    })
 
-  it("never offers a blocked Issue with a completed Work Item as QUEUE", () => {
-    const candidates = classifyIntakeCandidates(
-      [
-        issue({
-          issueNumber: 8,
-          blockedBy: [{ issueNumber: 1, issueUrl: "https://example/1" }],
-        }),
-      ],
-      [workItem({ issueNumber: 8, state: "complete" })],
-    )
-    expect(candidates).toEqual([])
+    it("omits a blocked Issue with a Complete Work Item as QUEUE", () => {
+      const candidates = classifyIntakeCandidates(
+        [
+          issue({
+            issueNumber: 8,
+            blockedBy: [{ issueNumber: 1, issueUrl: "https://example/1" }],
+          }),
+        ],
+        [workItem({ issueNumber: 8, state: "complete" })],
+      )
+      expect(candidates).toEqual([])
+    })
+
+    it("still offers an Issue with no Work Item as IMPLEMENT_NOW", () => {
+      const candidates = classifyIntakeCandidates(
+        [issue({ issueNumber: 11, state: "OPEN" })],
+        [],
+      )
+      expect(candidates.map((c) => [c.issueNumber, c.action])).toEqual([
+        [11, "IMPLEMENT_NOW"],
+      ])
+    })
+
+    it("still offers Failed-with-Issue-still-Ready as IMPLEMENT_NOW", () => {
+      const candidates = classifyIntakeCandidates(
+        [issue({ issueNumber: 12, state: "OPEN" })],
+        [workItem({ issueNumber: 12, state: "failed" })],
+      )
+      expect(candidates.map((c) => [c.issueNumber, c.action])).toEqual([
+        [12, "IMPLEMENT_NOW"],
+      ])
+    })
+
+    it("does not treat Needs Human as Complete — unfinished still blocks candidacy", () => {
+      const candidates = classifyIntakeCandidates(
+        [issue({ issueNumber: 13, state: "OPEN" })],
+        [workItem({ issueNumber: 13, state: "needs_human" })],
+      )
+      expect(candidates).toEqual([])
+    })
+
+    it("offers the still-Ready Issue again after the Complete Work Item is erased", () => {
+      const stillReady = issue({ issueNumber: 14, state: "OPEN" })
+      expect(
+        classifyIntakeCandidates(
+          [stillReady],
+          [workItem({ issueNumber: 14, state: "complete" })],
+        ),
+      ).toEqual([])
+      expect(classifyIntakeCandidates([stillReady], [])).toEqual([
+        {
+          issueNumber: 14,
+          title: "Issue 14",
+          url: "https://github.com/acme/widgets/issues/14",
+          action: "IMPLEMENT_NOW",
+        },
+      ])
+    })
+
+    it("applies the same Complete veto for GitHub and GitLab Issue URLs", () => {
+      const githubIssue = issue({
+        issueNumber: 21,
+        url: "https://github.com/acme/widgets/issues/21",
+      })
+      const gitlabIssue = issue({
+        issueNumber: 22,
+        url: "https://gitlab.example.com/acme/widgets/-/issues/22",
+      })
+      expect(
+        classifyIntakeCandidates(
+          [githubIssue, gitlabIssue],
+          [
+            workItem({ issueNumber: 21, state: "complete" }),
+            workItem({ issueNumber: 22, state: "complete" }),
+          ],
+        ),
+      ).toEqual([])
+    })
   })
 
   it("returns empty for an empty Issue projection", () => {


### PR DESCRIPTION
Azure close-out can leave a Boards item To Do and still tagged after the
harness Work Item is already Complete and the PR is merged. `candidates`
then listed that Issue as fresh work, and intake would start a second
attempt.

This is defense in depth for #1210 and does not wait on close-out.
`candidates` and intake omit an Issue that already has a terminal Complete
Work Item for that Repository, even when the Forge Issue is still open and
Ready-labeled. Failed or Abandoned history still yields a candidate while
the Issue is Ready. Needs Human stays off the list (Retry/Reset). Reset
that erases the Complete Work Item makes a still-Ready Issue a candidate
again. GitHub and GitLab get the same guard.

The classifier already vetoed shipped work; this change locks that
contract at the GraphQL `candidates` and intake seams, and records it in
the intake design notes.

**Verification.** Classifier coverage for Complete / no Work Item / Failed /
Abandoned / Needs Human / Reset / GitHub+GitLab. GraphQL tests:
`candidates` omit Complete-and-still-tagged Issues; intake does not
Implement Now for them; candidacy returns after the Complete Work Item is
gone.

**Limitation.** Explicit Implement now on the Repos page still treats
Complete like other finished history. Intake will not recandidate it.
Forge close-out itself is a separate ticket.

Closes #1210