### PR TITLE
fix(lifecycle): include Forge HTTP status in board failure messages

### DIFF
--- a/packages/azure-devops-service/test/azure-devops-service.spec.ts
+++ b/packages/azure-devops-service/test/azure-devops-service.spec.ts
@@ -1,6 +1,10 @@
 import { Effect, Fiber, Result } from "effect"
 import { TestClock } from "effect/testing"
 import {
+  buildReasonDetail,
+  formatUserFacingError,
+} from "@ready-for-agent/github-service"
+import {
   AzureDevOpsNotImplementedError,
   AzureDevOpsProjectUnavailableError,
   AzureDevOpsRequestError,
@@ -1262,6 +1266,15 @@ describe("Azure DevOps mergePullRequest", () => {
     if (Result.isFailure(result)) {
       expect(result.failure).toBeInstanceOf(AzureDevOpsRequestError)
       expect(result.failure.statusCode).toBe(401)
+      const flattened = formatUserFacingError(result.failure)
+      expect(flattened).toContain("Failed to merge pull request 42")
+      expect(flattened).toContain("HTTP 401")
+      const detail = buildReasonDetail(result.failure)
+      expect(detail).not.toBeNull()
+      expect(detail?.causeChain.length).toBeGreaterThan(1)
+      expect(
+        detail?.causeChain.some((link) => link.message?.includes("HTTP 401")),
+      ).toBe(true)
     }
   })
 

--- a/packages/github-service/src/lib/user-facing-error.ts
+++ b/packages/github-service/src/lib/user-facing-error.ts
@@ -45,36 +45,136 @@ export const sanitizeUserFacingText = (
   return cleaned
 }
 
+/** Operator-facing labels for statuses the board must distinguish. */
+const HTTP_SHORT_CAUSE: Readonly<Record<number, string>> = {
+  401: "Unauthorized",
+  403: "Forbidden",
+  409: "Conflict",
+  422: "Unprocessable Entity",
+  429: "Too Many Requests",
+}
+
+const readProp = (value: unknown, key: string): unknown =>
+  typeof value === "object" && value !== null
+    ? Reflect.get(value, key)
+    : undefined
+
+const readHttpStatusCode = (value: unknown): number | undefined => {
+  const status = readProp(value, "statusCode")
+  if (
+    typeof status === "number" &&
+    Number.isInteger(status) &&
+    status >= 100 &&
+    status <= 599
+  ) {
+    return status
+  }
+  return undefined
+}
+
+const httpStatusFromText = (text: string): number | undefined => {
+  let fallback: number | undefined
+  for (const match of text.matchAll(/\bHTTP\s+(\d{3})\b/gi)) {
+    const status = Number(match[1])
+    if (status >= 400 && status <= 599) {
+      return status
+    }
+    if (fallback === undefined && status >= 100 && status <= 599) {
+      fallback = status
+    }
+  }
+  return fallback
+}
+
+const nextCause = (value: unknown): unknown => {
+  const cause = readProp(value, "cause")
+  if (cause !== undefined) {
+    return cause
+  }
+  const errors = readProp(value, "errors")
+  if (Array.isArray(errors) && errors.length > 0) {
+    return errors[0]
+  }
+  return undefined
+}
+
+/**
+ * Prefer the typed `statusCode` field, then `HTTP NNN` in messages or
+ * postcondition `diagnostics`. Never copies nested response bodies.
+ */
+const extractHttpStatus = (error: unknown): number | undefined => {
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  let fromText: number | undefined
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current)
+    const fromField = readHttpStatusCode(current)
+    if (fromField !== undefined) {
+      return fromField
+    }
+    if (fromText === undefined) {
+      const message = readProp(current, "message")
+      if (typeof message === "string") {
+        fromText = httpStatusFromText(message)
+      }
+    }
+    if (fromText === undefined) {
+      const diagnostics = readProp(current, "diagnostics")
+      if (typeof diagnostics === "string") {
+        fromText = httpStatusFromText(diagnostics)
+      }
+    }
+    current = nextCause(current)
+  }
+  return fromText
+}
+
+const httpSuffix = (status: number, message: string): string => {
+  const label = `HTTP ${status}`
+  if (message.includes(label)) {
+    return ""
+  }
+  const cause = HTTP_SHORT_CAUSE[status]
+  if (
+    cause !== undefined &&
+    !message.toLowerCase().includes(cause.toLowerCase())
+  ) {
+    return `: ${label} ${cause}`
+  }
+  return `: ${label}`
+}
+
 export const formatUserFacingError = (
   error: unknown,
   fallback = "Unknown error",
   maxLength?: number,
 ): string => {
   const finish = (value: string): string => {
-    const cleaned = sanitizeUserFacingText(value, maxLength)
-    return cleaned.length > 0 ? cleaned : fallback
+    const base = sanitizeUserFacingText(value)
+    const usable = base.length > 0 ? base : fallback
+    const status = extractHttpStatus(error)
+    const suffix = status === undefined ? "" : httpSuffix(status, usable)
+    const combined = `${usable}${suffix}`
+    if (maxLength === undefined || combined.length <= maxLength) {
+      return combined
+    }
+    if (suffix.length === 0) {
+      return combined.slice(0, maxLength)
+    }
+    const budget = Math.max(0, maxLength - suffix.length)
+    return `${usable.slice(0, budget)}${suffix}`
   }
 
   if (typeof error === "string") {
     return finish(error)
   }
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof (error as { message: unknown }).message === "string" &&
-    (error as { message: string }).message.trim().length > 0
-  ) {
-    return finish((error as { message: string }).message)
+  const message = readProp(error, "message")
+  if (typeof message === "string" && message.trim().length > 0) {
+    return finish(message)
   }
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "_tag" in error &&
-    typeof (error as { _tag: unknown })._tag === "string" &&
-    (error as { _tag: string })._tag.trim().length > 0
-  ) {
-    return finish((error as { _tag: string })._tag)
+  const tag = readProp(error, "_tag")
+  if (typeof tag === "string" && tag.trim().length > 0) {
+    return finish(tag)
   }
   if (typeof error === "number" || typeof error === "boolean") {
     return finish(String(error))

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -239,6 +239,63 @@ describe("GitHubService live implementation", () => {
     }),
   )
 
+  it("surfaces HTTP 401 on merge in the flattened failure message", async () => {
+    const secret = "ghp_this_must_never_appear_in_user_facing_text"
+    const service = makeGitHubServiceFromToken(
+      "expired-token",
+      async (_input, init) => {
+        const query = graphqlQueryText(init)
+        if (query.includes("mergePullRequest")) {
+          return new Response(`Bad credentials ${secret}`, {
+            status: 401,
+            statusText: "Unauthorized",
+          })
+        }
+        return jsonGraphqlResponse({
+          data: {
+            repository: {
+              pullRequests: {
+                nodes: [
+                  {
+                    id: "PR_kwDOOpen",
+                    state: "OPEN",
+                    merged: false,
+                    headRefOid: "abc123",
+                    mergeable: "MERGEABLE",
+                    statusCheckRollup: { state: "SUCCESS" },
+                  },
+                ],
+              },
+            },
+          },
+        })
+      },
+    )
+
+    const error = await Effect.runPromise(
+      service.mergePullRequest(repository, "branch").pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect((error as GitHubRequestError).statusCode).toBe(401)
+    const flattened = formatUserFacingError(error)
+    expect(flattened).toContain("Failed to merge pull request")
+    expect(flattened).toContain("HTTP 401")
+    expect(flattened).not.toContain(secret)
+    const detail = buildReasonDetail(error)
+    expect(detail).not.toBeNull()
+    expect(detail?.causeChain.length).toBeGreaterThan(1)
+    expect(
+      detail?.causeChain.some((link) =>
+        link.message?.includes("Failed to merge pull request"),
+      ),
+    ).toBe(true)
+    expect(
+      detail?.causeChain.some((link) => link.message?.includes("Unauthorized")),
+    ).toBe(true)
+    expect(JSON.stringify(detail)).not.toContain(secret)
+  })
+
   it.effect(
     "classifies GraphQL repository NOT_FOUND as unavailable and names the token identity",
     () =>
@@ -4478,6 +4535,79 @@ describe("user-facing error formatting", () => {
     expect(formatUserFacingError(error, "fallback")).toBe(
       "Failed to get pull request check status for acme/widgets",
     )
+  })
+
+  it("includes HTTP status and a short cause from a Forge HTTP error", () => {
+    const secret = "ghp_this_must_never_appear_in_user_facing_text"
+    const httpCause = Object.assign(
+      new Error(`Unauthorized: Bad credentials ${secret}`),
+      { statusCode: 401 },
+    )
+    const error = new GitHubRequestError({
+      message: "Failed to merge pull request for acme/widgets:branch",
+      cause: httpCause,
+      statusCode: 401,
+    })
+
+    const flattened = formatUserFacingError(error)
+    expect(flattened).toContain(
+      "Failed to merge pull request for acme/widgets:branch",
+    )
+    expect(flattened).toContain("HTTP 401")
+    expect(flattened).toContain("Unauthorized")
+    expect(flattened).not.toContain(secret)
+    expect(flattened).not.toContain("Bad credentials")
+  })
+
+  it("lets the operator tell auth, permission, conflict, and transport apart", () => {
+    const mergeMessage = "Failed to merge pull request for acme/widgets:branch"
+    expect(
+      formatUserFacingError(
+        new GitHubRequestError({ message: mergeMessage, statusCode: 401 }),
+      ),
+    ).toContain("HTTP 401")
+    expect(
+      formatUserFacingError(
+        new GitHubRequestError({ message: mergeMessage, statusCode: 403 }),
+      ),
+    ).toContain("HTTP 403")
+    expect(
+      formatUserFacingError(
+        new GitHubRequestError({ message: mergeMessage, statusCode: 409 }),
+      ),
+    ).toContain("HTTP 409")
+
+    const transport = new GitHubRequestError({
+      message: mergeMessage,
+      code: "ENOTFOUND",
+      cause: Object.assign(new Error("getaddrinfo ENOTFOUND api.github.com"), {
+        code: "ENOTFOUND",
+      }),
+    })
+    expect(formatUserFacingError(transport)).toBe(mergeMessage)
+    expect(formatUserFacingError(transport)).not.toMatch(/HTTP \d{3}/)
+  })
+
+  it("lifts HTTP status out of postcondition diagnostics", () => {
+    const flattened = formatUserFacingError({
+      _tag: "CreatePrPostconditionError",
+      message:
+        "No open pull request found for acme/widgets:branch after native attempt and agent fallback",
+      diagnostics:
+        "createDraftPullRequest failed: Failed to create draft pull request for acme/widgets:branch: HTTP 401 Unauthorized",
+    })
+    expect(flattened).toContain("HTTP 401")
+    expect(flattened).toContain("No open pull request found")
+  })
+
+  it("does not duplicate an HTTP status already in the message", () => {
+    const error = new GitHubRequestError({
+      message:
+        "Failed to merge pull request 42 for acme/widgets: Azure DevOps returned HTTP 401",
+      statusCode: 401,
+    })
+    const flattened = formatUserFacingError(error)
+    expect(flattened.match(/HTTP 401/g)).toEqual(["HTTP 401"])
   })
 })
 

--- a/packages/gitlab-service/test/gitlab-service.spec.ts
+++ b/packages/gitlab-service/test/gitlab-service.spec.ts
@@ -1,5 +1,9 @@
 import { Effect, Result } from "effect"
 import {
+  buildReasonDetail,
+  formatUserFacingError,
+} from "@ready-for-agent/github-service"
+import {
   GitLabProjectUnavailableError,
   GitLabRequestError,
   makeGitLabServiceFromToken,
@@ -2644,6 +2648,12 @@ describe("GitLab PR status checks and ready-for-review", () => {
     expect(Result.isFailure(result)).toBe(true)
     if (Result.isFailure(result)) {
       expect(result.failure).toBeInstanceOf(GitLabRequestError)
+      expect(result.failure.statusCode).toBe(403)
+      const flattened = formatUserFacingError(result.failure)
+      expect(flattened).toContain("HTTP 403")
+      const detail = buildReasonDetail(result.failure)
+      expect(detail).not.toBeNull()
+      expect(detail?.causeChain.length).toBeGreaterThan(1)
     }
   })
 

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -17,6 +17,7 @@ import { DbService, type RepositoryRecord } from "@ready-for-agent/db-service"
 import {
   GitHubService,
   type GitHubThrottledError,
+  formatUserFacingError,
   isGitHubThrottledError,
   logErrorAnnotations,
 } from "@ready-for-agent/github-service"
@@ -163,12 +164,7 @@ const boundDiagnostics = (text: string): string => {
 }
 
 const errorMessage = (cause: unknown): string =>
-  cause &&
-  typeof cause === "object" &&
-  "message" in cause &&
-  typeof cause.message === "string"
-    ? cause.message
-    : String(cause)
+  formatUserFacingError(cause, "Unknown error")
 
 const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
   Effect.gen(function* () {

--- a/packages/work-item-lifecycle/src/lib/mark-pr-ready-for-review.ts
+++ b/packages/work-item-lifecycle/src/lib/mark-pr-ready-for-review.ts
@@ -5,6 +5,7 @@ import { DbService, type RepositoryRecord } from "@ready-for-agent/db-service"
 import {
   GitHubService,
   type GitHubThrottledError,
+  formatUserFacingError,
   isGitHubThrottledError,
   logErrorAnnotations,
 } from "@ready-for-agent/github-service"
@@ -38,12 +39,7 @@ export type MarkPrReadyForReviewResult = {
 }
 
 const errorMessage = (cause: unknown): string =>
-  cause &&
-  typeof cause === "object" &&
-  "message" in cause &&
-  typeof cause.message === "string"
-    ? cause.message
-    : String(cause)
+  formatUserFacingError(cause, "Unknown error")
 
 const boundDiagnostics = (text: string): string => {
   const trimmed = text.trim()

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer } from "effect"
 import {
+  AzureDevOpsRequestError,
   AzureDevOpsService,
   type AzureDevOpsServiceShape,
 } from "@ready-for-agent/azure-devops-service"
@@ -10,6 +11,7 @@ import {
 import {
   GitHubService,
   type GitHubServiceShape,
+  formatUserFacingError,
 } from "@ready-for-agent/github-service"
 import {
   GitLabService,
@@ -280,6 +282,58 @@ describe("closeIssue", () => {
         projectPath: "acme/widgets",
       },
     ])
+  })
+
+  it("surfaces HTTP 401 from Azure close-out in the flattened failure message", async () => {
+    const azureDevOpsRepository = makeRepositoryRecord({
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/acme-widgets",
+    })
+    const db = stubDbServiceLayer({
+      listRepositories: Effect.succeed([azureDevOpsRepository]),
+      listIssues: () =>
+        Effect.succeed([
+          {
+            ...openLeaf,
+            repositoryId: azureDevOpsRepository.id,
+            url: "https://dev.azure.com/acme/widgets/_workitems/edit/42",
+          },
+        ]),
+    })
+    const github = Layer.succeed(GitHubService, unusedGithub)
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      ensureIssueCompletedWithSummary: () =>
+        Effect.fail(
+          new AzureDevOpsRequestError({
+            message:
+              "Failed to complete Azure Boards Issue #42 for acme/widgets",
+            statusCode: 401,
+            cause: Object.assign(
+              new Error(
+                "Failed to complete Azure Boards Issue #42 for acme/widgets: Azure DevOps returned HTTP 401",
+              ),
+              { statusCode: 401 },
+            ),
+          }),
+        ),
+    } as AzureDevOpsServiceShape)
+
+    const error = await Effect.runPromise(
+      closeIssue({
+        ...context,
+        repositoryId: azureDevOpsRepository.id,
+      }).pipe(
+        Effect.provide(Layer.mergeAll(db, github, azureDevOps)),
+        Effect.flip,
+      ),
+    )
+
+    expect(error).toBeInstanceOf(AzureDevOpsRequestError)
+    const flattened = formatUserFacingError(error)
+    expect(flattened).toContain("HTTP 401")
+    expect(flattened).not.toMatch(/ghp_|glpat-|Bearer /)
   })
 
   it("rejects an open parent Issue before mutation", async () => {

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -22,6 +22,7 @@ import {
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
+  formatUserFacingError,
 } from "@ready-for-agent/github-service"
 import {
   GitLabService,
@@ -1431,7 +1432,16 @@ describe("createPr", () => {
           findOpenPullRequestNumber: () => Effect.succeed(null),
           createDraftPullRequest: () =>
             Effect.fail(
-              new GitHubRequestError({ message: "create unavailable" }),
+              new GitHubRequestError({
+                message: "Failed to create draft pull request for acme/widgets",
+                statusCode: 401,
+                cause: Object.assign(
+                  new Error(
+                    "Failed to create draft pull request for acme/widgets: Unauthorized: Bad credentials",
+                  ),
+                  { statusCode: 401 },
+                ),
+              }),
             ),
           getOpenPullRequestNumber: () =>
             Effect.fail(
@@ -1447,6 +1457,9 @@ describe("createPr", () => {
         }),
       })
       expect(error).toBeInstanceOf(CreatePrPostconditionError)
+      const flattened = formatUserFacingError(error)
+      expect(flattened).toContain("HTTP 401")
+      expect(error.diagnostics).toContain("HTTP 401")
     }))
 
   it("requires Session context only for agent fallback", () =>

--- a/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
+++ b/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
@@ -13,6 +13,7 @@ import {
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
+  formatUserFacingError,
 } from "@ready-for-agent/github-service"
 import {
   GitLabRequestError,
@@ -256,7 +257,14 @@ describe("markPrReadyForReview", () => {
     const github = Layer.succeed(GitHubService, {
       markPullRequestReadyForReview: () =>
         Effect.fail(
-          new GitHubRequestError({ message: "mark ready unavailable" }),
+          new GitHubRequestError({
+            message:
+              "Failed to mark pull request ready for review for acme/widgets:branch",
+            statusCode: 401,
+            cause: Object.assign(new Error("Unauthorized: Bad credentials"), {
+              statusCode: 401,
+            }),
+          }),
         ),
       getPullRequestCheckStatus: () => Effect.succeed(stillDraftStatus),
     } as GitHubServiceShape)
@@ -272,6 +280,9 @@ describe("markPrReadyForReview", () => {
     )
 
     expect(error).toBeInstanceOf(MarkPrReadyForReviewPostconditionError)
+    const flattened = formatUserFacingError(error)
+    expect(flattened).toContain("HTTP 401")
+    expect(error.diagnostics).toContain("HTTP 401")
   })
 
   it("never trusts the native call's own report: a native success that leaves the PR draft still falls back to the agent", async () => {


### PR DESCRIPTION
## Why

A stale Azure PAT could still push and open PRs, then return HTTP 401
on complete. The board card only showed a flat "Failed to merge pull
request N". The typed error and cause chain already had the 401;
`statusMessage` did not. The same gap exists for GitHub and GitLab
401/403/429.

## What changed

Flattened Forge failure messages now include the HTTP status and a
short cause (`HTTP 401 Unauthorized`, `HTTP 403 Forbidden`,
`HTTP 409 Conflict`). Transport failures still have no `HTTP NNN`, so
auth, permission, conflict, and transport are distinguishable without
opening GraphQL.

Nested HTTP response bodies are not copied into the card text, so
token-shaped secrets in a 401 body stay out of `statusMessage`.
`latestStepRunReason.detail` still keeps the full cause chain.

Create PR and Mark PR Ready for Review now format native Forge errors
the same way, so a postcondition failure that wraps an HTTP error also
shows the status on the card.

## Verification

- Azure merge 401: flattened message includes `HTTP 401`; cause chain
  still has the nested HTTP error
- GitHub merge 401: flattened message includes `HTTP 401`; a `ghp_`
  token in the response body is absent from the card text and persisted
  detail
- GitLab merge 403: flattened message includes `HTTP 403`
- Create PR, Mark PR Ready, and Azure close-out 401 paths include
  `HTTP 401`

Uncommitted-change review found no blocking issues.

## Limits

This does not classify 401/403 as non-retryable. Create PR / Mark PR
Ready still persist a postcondition wrapper as the Step Run error; the
HTTP status is lifted into `statusMessage` from diagnostics.

Closes #1211