### PR TITLE
docs(forge): publish minimum token scopes per lifecycle step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ When adding a new skill under `.agents/skills/`, add the matching symlink:
 
 Issues live in GitHub Issues for berenddeboer/ready-for-agent (via `gh`). See `docs/agents/issue-tracker.md`.
 
+### Forge token scopes
+
+Minimum token scopes per Forge and lifecycle step (poll, push, Create
+PR, Mark PR Ready for Review, Watch, Merge PR, close-out) live in
+[docs/forge-token-scopes.md](docs/forge-token-scopes.md).
+
 ### GitHub API notes
 
 Fine-grained GitHub PATs cannot call the Checks API (including GraphQL

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ action.
 
 - [Quick start](#quick-start)
 - [Requirements](#requirements)
+- [Forge token scopes](docs/forge-token-scopes.md)
 - [Features](#features)
 - [How it works](#how-it-works)
 - [Configuration](#configuration)
@@ -101,6 +102,12 @@ uses that Forge):
 - [GitHub CLI (`gh`)](https://cli.github.com/) for GitHub repositories
 - [GitLab CLI (`glab`)](https://docs.gitlab.com/cli/) for GitLab repositories.
   Authenticate `glab` for each repository's Forge Host.
+
+Forge tokens need specific scopes for poll, push, Create PR, Watch,
+Merge PR, and close-out. Azure DevOps in particular: git push and
+Create PR can succeed with a narrower PAT than Merge PR — that split
+is how a “working” token still fails every ticket at merge. See
+[Forge token scopes](docs/forge-token-scopes.md).
 
 **Coding agents** are soft prerequisites: they are inspected after
 the harness starts and never block the process or UI from starting. A
@@ -740,6 +747,12 @@ export NODE_EXTRA_CA_CERTS=/path/to/corp-root-ca.pem
 Set the variable in your shell profile (or the service unit that
 starts the harness) so it applies on every launch, then restart
 `ready-for-agent`.
+
+### Merge PR fails on Azure DevOps with 401/403
+
+Git fetch/push and Create PR can succeed with a narrower PAT than
+complete. See [Forge token scopes](docs/forge-token-scopes.md) for
+the extra scopes Merge PR needs.
 
 ### What if an item fails with an error message?
 

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -137,6 +137,9 @@ import { WorkItemResetButton } from "./work-item-reset-button.js"
 export type { Repository } from "./repositories-query.js"
 export { repositoriesQuery } from "./repositories-query.js"
 
+const FORGE_TOKEN_SCOPES_DOC_URL =
+  "https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md"
+
 const graphql = createHarnessGraphqlClient({ batch: true })
 // Long-lived host folder dialog must not pin co-batched GraphQL operations.
 
@@ -2662,7 +2665,16 @@ function RepositoryCard({
                       <code className={ui.guidanceCode}>
                         .github/workflows/**
                       </code>
-                      ). Already-created tokens are not upgraded automatically —
+                      ). See{" "}
+                      <a
+                        href={FORGE_TOKEN_SCOPES_DOC_URL}
+                        className="text-ink underline underline-offset-2 hover:decoration-signal hover:decoration-2"
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        required scopes
+                      </a>
+                      . Already-created tokens are not upgraded automatically —
                       edit or recreate them if Workflows is missing, then
                       replace the secret in Keymaxxer.
                     </p>
@@ -2731,6 +2743,20 @@ function RepositoryCard({
                         <code className={ui.guidanceCode}>
                           {repository.projectPath}
                         </code>
+                        . Prefills <code className={ui.guidanceCode}>api</code>{" "}
+                        and{" "}
+                        <code className={ui.guidanceCode}>
+                          write_repository
+                        </code>
+                        ; see{" "}
+                        <a
+                          href={FORGE_TOKEN_SCOPES_DOC_URL}
+                          className="text-ink underline underline-offset-2 hover:decoration-signal hover:decoration-2"
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          required scopes
+                        </a>
                         . Store it in Keymaxxer when available, or set ambient
                         auth:{" "}
                       </>

--- a/apps/harness/test/forge-token-scopes-doc.test.ts
+++ b/apps/harness/test/forge-token-scopes-doc.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const workspaceRoot = join(import.meta.dir, "../../..")
+
+const publishedDocUrl =
+  "https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md"
+
+const readWorkspace = (relativePath: string) =>
+  readFileSync(join(workspaceRoot, relativePath), "utf8")
+
+describe("published Forge token scopes doc", () => {
+  test("lists minimum scopes per Forge for every required lifecycle step", () => {
+    const doc = readWorkspace("docs/forge-token-scopes.md")
+    for (const forge of ["GitHub", "GitLab", "Azure DevOps"]) {
+      expect(doc).toContain(forge)
+    }
+    for (const step of [
+      "poll Ready Issues",
+      "push",
+      "Create PR",
+      "Mark PR Ready for Review",
+      "Watch",
+      "Merge PR",
+      "close-out",
+    ]) {
+      expect(doc).toContain(step)
+    }
+    expect(doc).toContain("Contents")
+    expect(doc).toContain("Issues")
+    expect(doc).toContain("Pull requests")
+    expect(doc).toContain("Actions")
+    expect(doc).toContain("Workflows")
+    expect(doc).toContain("`api`")
+    expect(doc).toContain("`write_repository`")
+    expect(doc).toContain("Code: Read & write")
+    expect(doc).toContain("Work Items: Read & write")
+    expect(doc).toContain("Build: Read")
+    expect(doc).toContain("Policy: Read")
+  })
+
+  test("calls out that Azure complete/merge needs more than git and Create PR", () => {
+    const doc = readWorkspace("docs/forge-token-scopes.md")
+    expect(doc).toContain("Merge PR needs more than git + Create PR")
+    expect(doc).toContain("transitionWorkItems")
+    expect(doc).toContain("Work Items (Read & write)")
+    expect(doc).toContain(
+      "Do not mint **Code (Read, write, & manage)** for Merge PR",
+    )
+  })
+
+  test("README and add-repository docs link to the published list", () => {
+    const readme = readWorkspace("README.md")
+    expect(readme).toContain("docs/forge-token-scopes.md")
+    const addRepo = readWorkspace("apps/ready-for-agent/README.md")
+    expect(addRepo).toContain("docs/forge-token-scopes.md")
+  })
+
+  test("repo-card token banners point at the same published list", () => {
+    const home = readWorkspace("apps/harness/src/home-page-content.tsx")
+    expect(home).toContain(publishedDocUrl)
+    expect(home).toContain("GitHub token required")
+    expect(home).toContain("GitLab authentication required")
+  })
+})

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -135,6 +135,8 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(body).toContain("Store in Keymaxxer")
     expect(body).toContain("Actions: Read and write")
     expect(body).toContain("Workflows: Read and write")
+    expect(body).toContain("href={FORGE_TOKEN_SCOPES_DOC_URL}")
+    expect(body).toContain("required scopes")
     expect(body).toContain(
       "Already-created tokens are not upgraded automatically",
     )

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -107,6 +107,14 @@ Stop the harness completely before opening that database with external write
 tooling (CLI, GUI, or a second process). The harness uses single-process default
 WAL; concurrent writers are not supported.
 
+### Forge token scopes
+
+Minimum GitHub, GitLab, and Azure DevOps token scopes per lifecycle
+step (poll, push, Create PR, Mark PR Ready for Review, Watch, Merge
+PR, close-out):
+[docs/forge-token-scopes.md](../../docs/forge-token-scopes.md). Azure
+complete/merge needs more than git + Create PR.
+
 ### Add a repository
 
 For interactive first-run setup, prefer the blank-slate UI after `start`
@@ -151,13 +159,14 @@ offers the existing Create GitHub token / Store in Keymaxxer flow.
 
 ### Upgrade an existing GitHub token
 
-New repository token links preselect **Actions: Read and write** (workflow
-reruns and CI job logs) and **Workflows: Read and write** (push or update
-`.github/workflows/**`), plus Issues, Contents, Pull requests (write), and
-Commit statuses (read). Already-created tokens are **not** upgraded
-automatically when the harness changes its requested permissions. Edit the
-fine-grained token on GitHub (or recreate it), then replace the secret in
-Keymaxxer — or remove the secret and use Create GitHub token again.
+New repository token links preselect the GitHub column of
+[docs/forge-token-scopes.md](../../docs/forge-token-scopes.md)
+(**Actions** and **Workflows** Read and write, plus Issues, Contents,
+Pull requests write, and Commit statuses read). Already-created tokens
+are **not** upgraded automatically when the harness changes its
+requested permissions. Edit the fine-grained token on GitHub (or
+recreate it), then replace the secret in Keymaxxer — or remove the
+secret and use Create GitHub token again.
 
 ### Help
 

--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -107,6 +107,7 @@ describe("host tools preflight", () => {
       "AZURE_DEVOPS_EXT_PAT",
     ])
     expect(withoutPat.message).toContain("AZURE_DEVOPS_EXT_PAT")
+    expect(withoutPat.message).toContain("docs/forge-token-scopes.md")
     expect(withoutPat.message).not.toContain("gh:")
     expect(withoutPat.message).not.toContain("glab:")
   })

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -32,7 +32,7 @@ const AZURE_DEVOPS_PAT_ENV_VAR = "AZURE_DEVOPS_EXT_PAT"
 const AZURE_DEVOPS_ENV_REQUIREMENT: HostTool = {
   name: AZURE_DEVOPS_PAT_ENV_VAR,
   installHint:
-    "Set the AZURE_DEVOPS_EXT_PAT environment variable to an Azure DevOps Personal Access Token: https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate",
+    "Set the AZURE_DEVOPS_EXT_PAT environment variable to an Azure DevOps Personal Access Token: https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate — required scopes (Merge PR needs more than git + Create PR): https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md",
 }
 
 type RepositoryForge = "github" | "gitlab" | "azure-devops"

--- a/docs/forge-token-scopes.md
+++ b/docs/forge-token-scopes.md
@@ -1,0 +1,79 @@
+# Forge token scopes
+
+Minimum token scopes the harness needs on each Forge, per lifecycle
+step. Mint one token that covers the **full lifecycle** row for that
+Forge; a narrower token will look “working” until it hits the first
+step it cannot perform.
+
+Repository-card **Create token** actions (GitHub and GitLab today;
+Azure DevOps once the card can store a PAT) open the Forge’s token
+page with these scopes selected or described. This file is the list
+those actions point at.
+
+Git over SSH does not consume the PAT for **push**; HTTPS git does.
+API steps always use the token.
+
+## Full lifecycle (mint this)
+
+| Forge | Token | Minimum scopes |
+| --- | --- | --- |
+| **GitHub** | Fine-grained PAT, **Only select repositories**, this Repository | **Contents**, **Issues**, **Pull requests**, **Actions**, **Workflows**: Read and write. **Commit statuses**: Read-only. **Metadata**: Read-only (automatic). |
+| **GitLab** | Personal access token on the Forge Host | `api` and `write_repository` |
+| **Azure DevOps** | Organization PAT (`AZURE_DEVOPS_EXT_PAT` or the vault secret) | **Code: Read & write**. **Work Items: Read & write**. **Build: Read**. **Policy: Read** (under **Show all scopes**). |
+
+GitHub’s Repository-card link preselects those fine-grained permissions.
+GitLab’s link prefills `api,write_repository`. Azure’s token page
+does not prefill scopes — select the Azure row by hand.
+
+Classic GitHub PATs (`repo` + `workflow`) also work. Fine-grained
+tokens cannot call the Checks API; the harness falls back to Actions
+jobs and that 403 is expected.
+
+## Per step
+
+Each cell is the **minimum for that step alone**. Union the cells for
+the steps you actually run; the table above is that union for the
+full loop.
+
+| Step | GitHub (fine-grained) | GitLab | Azure DevOps |
+| --- | --- | --- | --- |
+| poll Ready Issues | **Issues:** Read-only | `read_api` | **Work Items:** Read |
+| push | **Contents:** Read and write. **Workflows:** Read and write if the branch includes `.github/workflows/**` | `write_repository` | **Code:** Read & write |
+| Create PR | **Pull requests:** Read and write | `api` | **Code:** Read & write. **Work Items:** Read & write (Boards ArtifactLink) |
+| Mark PR Ready for Review | **Pull requests:** Read and write | `api` | **Code:** Read & write |
+| Watch / status checks | **Actions:** Read and write (job logs and workflow reruns). **Commit statuses:** Read-only | `read_api` | **Code:** Read. **Build:** Read (logs). **Policy:** Read (branch policy evaluations) |
+| Merge PR | **Pull requests:** Read and write | `api` | **Code:** Read & write (same REST floor as Create PR). **Work Items:** Read & write (`transitionWorkItems` on complete — extra versus git + Create PR) |
+| close-out | **Issues:** Read and write | `api` | **Work Items:** Read & write (comment + Completed-category state) |
+
+### Azure DevOps: Merge PR needs more than git + Create PR
+
+Git fetch/push and Create PR succeed with **Code (Read & write)**
+alone. Completing the pull request does not: MERGE_PR PATCHes the PR
+to `completed` with `transitionWorkItems: true`, and close-out writes
+a Boards comment and Completed-category state. Those need
+**Work Items (Read & write)** as well.
+
+Azure REST documents both create and complete as **Code (Read & write)**.
+Do not mint **Code (Read, write, & manage)** for Merge PR — that
+scope is repository administration, not the complete floor.
+
+A PAT that can clone, push, and open a PR will still fail at Merge PR
+or close-out until Work Items write is present. Recreate the token;
+existing PATs are not upgraded in place.
+
+If complete still 403s after Code write + Work Items write, it is
+Azure Repos **Contribute** / complete-PR permission (or a branch
+policy), not a missing Code-manage PAT scope.
+
+Create the token at
+`https://dev.azure.com/<organization>/_usersSettings/tokens` (New
+Token → custom scopes). The Repository-card Create action will use
+that same org-scoped page.
+
+## Repository permissions are not PAT scopes
+
+The PAT is necessary but not sufficient. The identity behind the
+token still needs Forge-side permission to complete a PR on a
+protected branch (GitHub branch protection; GitLab Maintainer/merge
+rights; Azure Repos **Contribute** / complete pull requests). Those
+are Repository or project permissions, not token scopes.

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -33,6 +33,10 @@ export class RepositoryCredentialError extends Data.TaggedError(
   "RepositoryCredentialError",
 )<{ readonly message: string }> {}
 
+/** Published operator list of minimum Forge token scopes per lifecycle step. */
+const FORGE_TOKEN_SCOPES_DOC_URL =
+  "https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md"
+
 export const githubTokenSecretName = (repository: Repository) =>
   `GITHUB_TOKEN_${repository.projectPath}`
     .replace(/[^A-Za-z0-9_]/g, "_")
@@ -71,7 +75,7 @@ const githubTokenCreationUrl = (repository: Repository) => {
   url.searchParams.set("name", `rfa - ${name}`)
   url.searchParams.set(
     "description",
-    `Ready For Agent token for ${repository.projectPath}`,
+    `Ready For Agent token for ${repository.projectPath}. Minimum scopes: ${FORGE_TOKEN_SCOPES_DOC_URL}`,
   )
   url.searchParams.set("target_name", owner)
   url.searchParams.set("expires_in", "90")
@@ -89,8 +93,18 @@ const githubTokenCreationUrl = (repository: Repository) => {
 }
 
 /** Instance-correct GitLab personal access token creation page. */
-const gitlabTokenCreationUrl = (repository: Repository) =>
-  `https://${repository.forgeHost}/-/user_settings/personal_access_tokens`
+const gitlabTokenCreationUrl = (repository: Repository) => {
+  const url = new URL(
+    `https://${repository.forgeHost}/-/user_settings/personal_access_tokens`,
+  )
+  url.searchParams.set("name", `rfa - ${repository.projectPath}`)
+  url.searchParams.set(
+    "description",
+    `Ready For Agent token for ${repository.forgeHost}/${repository.projectPath}. Minimum scopes: ${FORGE_TOKEN_SCOPES_DOC_URL}`,
+  )
+  url.searchParams.set("scopes", "api,write_repository")
+  return url.toString()
+}
 
 /** Organization-scoped Azure DevOps personal access token creation page. */
 const azureDevOpsTokenCreationUrl = (repository: Repository) => {

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1390,6 +1390,9 @@ describe("GraphQL API", () => {
     expect(creationUrl.searchParams.get("workflows")).toBe("write")
     expect(creationUrl.searchParams.get("statuses")).toBe("read")
     expect(creationUrl.searchParams.get("checks")).toBeNull()
+    expect(creationUrl.searchParams.get("description")).toContain(
+      "docs/forge-token-scopes.md",
+    )
   })
 
   test("reports ambient GitHub authentication as configured", async () => {
@@ -3516,8 +3519,9 @@ describe("GraphQL API", () => {
         configured: true,
         githubTokenSecretName:
           "GITLAB_TOKEN_GIT_DRUPALCODE_ORG_PROJECT_OAUTH_CLIENT",
-        githubTokenCreationUrl:
+        githubTokenCreationUrl: expect.stringContaining(
           "https://git.drupalcode.org/-/user_settings/personal_access_tokens",
+        ),
       },
     ])
   })
@@ -3575,8 +3579,9 @@ describe("GraphQL API", () => {
             repositoryId: repository.id,
             configured: true,
             githubTokenSecretName: "GITLAB_TOKEN_CUSTOM",
-            githubTokenCreationUrl:
+            githubTokenCreationUrl: expect.stringContaining(
               "https://git.drupalcode.org/-/user_settings/personal_access_tokens",
+            ),
           },
         ],
       },

--- a/packages/graphql-api/test/repository-credentials.test.ts
+++ b/packages/graphql-api/test/repository-credentials.test.ts
@@ -49,6 +49,10 @@ describe("repositoryCredential", () => {
       githubTokenSecretName(githubRepo),
     )
     expect(credential.githubTokenCreationUrl).toContain("github.com")
+    const creationUrl = new URL(credential.githubTokenCreationUrl)
+    expect(creationUrl.searchParams.get("description")).toContain(
+      "docs/forge-token-scopes.md",
+    )
   })
 
   test("suggests a GitLab token secret name and instance-scoped creation URL", () => {
@@ -56,8 +60,13 @@ describe("repositoryCredential", () => {
     expect(credential.githubTokenSecretName).toBe(
       gitlabTokenSecretName(gitlabRepo),
     )
-    expect(credential.githubTokenCreationUrl).toBe(
+    const creationUrl = new URL(credential.githubTokenCreationUrl)
+    expect(`${creationUrl.origin}${creationUrl.pathname}`).toBe(
       "https://git.example.com/-/user_settings/personal_access_tokens",
+    )
+    expect(creationUrl.searchParams.get("scopes")).toBe("api,write_repository")
+    expect(creationUrl.searchParams.get("description")).toContain(
+      "docs/forge-token-scopes.md",
     )
   })
 


### PR DESCRIPTION
A Code-only Azure PAT can clone, push, and open a PR, then fail every
ticket at Merge PR. #1213 asked for an operator list of minimum scopes
per Forge and lifecycle step so that split is visible before minting.

Adds a published scopes list covering GitHub, GitLab, and Azure DevOps
for poll Ready Issues, push, Create PR, Mark PR Ready for Review, Watch,
Merge PR, and close-out. README, add-repository docs, GitHub/GitLab
repo-card banners, GitHub token descriptions, and GitLab create-token
prefills (`api`, `write_repository`) point at that list.

Azure complete uses the same Code (Read & write) REST floor as Create
PR. The extra versus git + Create PR is Work Items (Read & write) for
`transitionWorkItems` and close-out — not Code (Read, write, & manage).
Remaining 403s after that are Contribute / branch policy.

Verification: `nx test graphql-api`, `nx test harness`, and
`nx test ready-for-agent`, including the published-doc contract tests.

Azure still has no Create-token card (sibling credential UX). The org
token page already exists; that card can link the same list.

Closes #1213