### PR TITLE
docs: add Azure DevOps to README, add help, and operator docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,9 @@ covers monorepo development of Ready for Agent.
 ## Prerequisites
 
 Product host tools from the product README: `git`, plus `gh` for GitHub
-Repositories and `glab` for GitLab Repositories. Authenticate each Forge CLI
-for the Repository's Forge Host.
+Repositories, `glab` for GitLab Repositories, and `AZURE_DEVOPS_EXT_PAT` for
+Azure DevOps Repositories. Authenticate each Forge CLI for the Repository's
+Forge Host.
 
 Also needed to run or test the harness:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Ready for Agent: Clanker Harness for 150+ PRs a week
 
-Ready for Agent turns GitHub (or GitLab) issues into merged pull
-requests. You create issues and label them `ready-for-agent`; the
-harness hands each one to your preferred coding agent, which
-implements it, reviews the code, opens a PR, and merges when
-allowed. You design, you architect, you verify where needed — the
-harness removes the babysitting between issue and merged PR.
+Ready for Agent turns GitHub, GitLab, or Azure DevOps issues into
+merged pull requests. You mark them `ready-for-agent` (a label on
+GitHub and GitLab, a Boards tag on Azure DevOps). The harness hands
+each one to your preferred coding agent, which implements it, reviews
+the code, opens a PR, and merges when allowed. You design, you
+architect, you verify where needed — the harness removes the
+babysitting between issue and merged PR.
 
 <img src="ready-for-agent.png" alt="Ready for Agent" width="90%" />
 
@@ -20,6 +21,7 @@ action.
 - [Features](#features)
 - [How it works](#how-it-works)
 - [Configuration](#configuration)
+- [Azure DevOps](#azure-devops)
 - [Command reference](#command-reference)
 - [Shell completions](#shell-completions)
 - [Troubleshooting](#troubleshooting)
@@ -63,15 +65,19 @@ action.
    <img src="docs/add-repository-blank-slate.png" alt="Blank slate: add a repository from the UI (Browse, path field, or CLI)" width="75%" />
 
    Advanced: once the harness is running, you can also add from a
-   shell:
+   shell. The path must be a git repository with a GitHub, GitLab, or
+   Azure DevOps remote:
 
    ```bash
    ready-for-agent add /path/to/local/repo
    ```
 
-4. Label a GitHub issue with `ready-for-agent`. It shows up in the UI
-   shortly. By default only issues you authored are listed — see
-   [Troubleshooting](#troubleshooting).
+4. Mark a Ready Issue: label a GitHub or GitLab issue
+   `ready-for-agent`, or tag an Azure Boards work item
+   `ready-for-agent`. It shows up in the UI shortly. By default only
+   issues you authored are listed — see
+   [Troubleshooting](#troubleshooting). Azure specifics (PAT, empty
+   repos, Merge Policy) are in [Azure DevOps](#azure-devops).
 
 5. Go to the `/repos` page to see your issues:
 
@@ -101,6 +107,9 @@ uses that Forge):
 - [GitHub CLI (`gh`)](https://cli.github.com/) for GitHub repositories
 - [GitLab CLI (`glab`)](https://docs.gitlab.com/cli/) for GitLab repositories.
   Authenticate `glab` for each repository's Forge Host.
+- Azure DevOps: no CLI. Set `AZURE_DEVOPS_EXT_PAT` to a personal
+  access token. See [Azure DevOps](#azure-devops) and the
+  [token scopes ticket](https://github.com/berenddeboer/ready-for-agent/issues/1213).
 
 **Coding agents** are soft prerequisites: they are inspected after
 the harness starts and never block the process or UI from starting. A
@@ -151,18 +160,18 @@ issues that come with running compute in the cloud.
   spend, no environment drift.
 - Works with your existing Claude (or other) subscription rather than
   metered API billing.
-- GitHub and GitLab support.
+- GitHub, GitLab, and Azure DevOps support.
 - Human in the loop where you want it: you design, you architect, you
   verify.
 
 ## How it works
 
-The harness is a loop around issues labelled `ready-for-agent`: it
-only shows those, you pick the ones to work on, and it autonomously
-completes them using your selected coding agent. For each issue it
-creates a fresh worktree, installs packages, and asks the headless
-agent to implement the issue, review the code, create a PR, and merge
-if allowed.
+The harness is a loop around issues marked `ready-for-agent` (a GitHub
+or GitLab label, or an Azure Boards tag): it only shows those, you
+pick the ones to work on, and it autonomously completes them using
+your selected coding agent. For each issue it creates a fresh
+worktree, installs packages, and asks the headless agent to implement
+the issue, review the code, create a PR, and merge if allowed.
 
 Steps 1 to 3 are you. Steps 4 and 5 are the harness.
 
@@ -181,8 +190,8 @@ tickets (`/to-tickets`). These tickets will be labeled with
 [Skills for Real Engineers](https://github.com/mattpocock/skills) to
 get started with this kind of workflow.
 
-But as long as an issue has the `ready-for-agent` label, this tool
-can work on it.
+But as long as an issue has the `ready-for-agent` label (or Azure
+Boards tag), this tool can work on it.
 
 ### Working on issues
 
@@ -255,7 +264,9 @@ READY_FOR_AGENT_GRAPHQL_URL=http://<reachable-host>:<port>/graphql \
 Each repo can override the harness-wide coding agent and build/review
 models, and set a Merge Policy (Off, Classify, or Always). This allows
 you to configure more expensive models for more complex code, and
-cheaper models for others.
+cheaper models for others. New Repositories default to Off. For a
+no-CI Azure DevOps repo, Always is the unattended merge setting — see
+[Azure DevOps](#azure-devops).
 
 ### KeyMaxxer
 
@@ -270,6 +281,19 @@ Disable with:
 ```bash
 KEYMAXXER_ENABLED=false npx ready-for-agent@latest
 ```
+
+## Azure DevOps
+
+Azure DevOps is a first-class Forge. Ready discovery is a Boards tag
+`ready-for-agent`, not a label. Auth is the ambient
+`AZURE_DEVOPS_EXT_PAT` environment variable until credential UX
+ships. A repo with no default branch is not usable until `main` (or
+equivalent) exists. Default Merge Policy is Off; Always is required to
+auto-merge a no-CI Azure repo. Boards close-out is not yet at parity
+with GitHub and GitLab.
+
+Details: [docs/azure-devops.md](docs/azure-devops.md). Token scopes:
+[issue #1213](https://github.com/berenddeboer/ready-for-agent/issues/1213).
 
 ## Command reference
 
@@ -450,7 +474,7 @@ ready-for-agent start --host
 - **Usage**: `ready-for-agent add [--forge-host <host>] [--project-path <project-path>] <path>`
 - **Effect**: modifies state
 
-Inspect and add a local repository; inferred GitLab identity can be corrected with flags
+Inspect and add a local GitHub, GitLab, or Azure DevOps repository; inferred identity can be corrected with flags
 
 ### Arguments
 
@@ -678,10 +702,11 @@ usage generate completion powershell ready-for-agent \
 
 ### Startup fails with "Required host tools are missing from PATH"
 
-Install the listed tools. Only `git` and the Forge tool for your
-repositories (`gh` for GitHub, `glab` for GitLab) block startup. A
-missing coding agent never does — it shows as Unavailable instead
-(see below).
+Install the listed tools. Only `git` and the Forge requirement for
+your repositories (`gh` for GitHub, `glab` for GitLab,
+`AZURE_DEVOPS_EXT_PAT` for Azure DevOps) block startup. A missing
+coding agent never does — it shows as Unavailable instead (see
+below).
 
 ### Startup fails with SIGILL / "Illegal instruction"
 
@@ -702,8 +727,9 @@ unaffected (`bun run ready-for-agent`).
 
 ### A labelled issue does not show up
 
-- The issue must carry the `ready-for-agent` label — the harness only
-  shows those.
+- GitHub and GitLab: the issue must carry the `ready-for-agent` label.
+  Azure DevOps: the Boards work item must carry the `ready-for-agent`
+  tag — not a GitHub-style label. The harness only shows those.
 - By default only issues **you** authored are listed. If someone else's
   `ready-for-agent` issue is missing, enable **Include all Issue Authors**
   in the repo settings to include issues created by any author.
@@ -768,9 +794,11 @@ backend's current catalog, never typed in.
 
 2. Does the harness support a Forge other than GitHub?
 
-Yes. GitLab repository identity, issue reconciliation, and local
-agent work through review are supported. GitLab pull request
-lifecycle operations are being delivered in later phases.
+Yes. GitLab and Azure DevOps are first-class Forges. Azure Boards
+Ready discovery is a Boards tag `ready-for-agent` (not a label), auth
+is `AZURE_DEVOPS_EXT_PAT`, and Merge Policy Always is the unattended
+setting when the Azure repo has no CI. See
+[Azure DevOps](#azure-devops).
 
 3. Can I use my Claude subscription?
 
@@ -806,8 +834,8 @@ with finding work, they are not explorer work or creating work.
   agent doing the work.
 - **Harness** — this tool: the deterministic loop that steers
   clankers from issue to merged PR.
-- **Forge** — the code-hosting platform for a repository: GitHub or
-  GitLab.
+- **Forge** — the code-hosting platform for a repository: GitHub,
+  GitLab, or Azure DevOps.
 - **Agent Backend** — the coding-agent CLI the harness drives:
   OpenCode, Codex, Grok Build, or Claude Code.
 - **Work Item** — one attempt to complete an issue through the work
@@ -854,5 +882,5 @@ Contributions welcome, see [CONTRIBUTING.md](CONTRIBUTING.md).
   well](https://x.com/victorsavkin/status/2085381771516846093),
   although we disagree on whether the tooling is always personal, or
   can be generalised a bit. Obviously my take is that with regards to
-  GitHub/GitLab systems, and a single programmer a tool like
-  ready-for-agent can give a significant productivity boost.
+  GitHub/GitLab/Azure DevOps systems, and a single programmer a tool
+  like ready-for-agent can give a significant productivity boost.

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -62,7 +62,9 @@ This boots the full Harness (UI + backend) on the existing monorepo dev path
 Before start, the binary checks that required host tools are on `PATH`: `git`,
 plus `gh` when a GitHub Repository exists and
 [`glab`](https://docs.gitlab.com/cli/) when a GitLab Repository exists.
-Install and authenticate `glab` for the Repository's Forge Host. Selected Agent
+Install and authenticate `glab` for the Repository's Forge Host. Azure DevOps
+needs no CLI; set `AZURE_DEVOPS_EXT_PAT` when an Azure DevOps Repository exists.
+See [Azure DevOps](../../docs/azure-devops.md). Selected Agent
 Backend executables are inspected after start; a missing or broken CLI marks
 that backend Unavailable and opens Settings, but never blocks the process or UI
 from starting. The AWS CLI is **not** required for Claude Code Bedrock profile
@@ -120,8 +122,9 @@ bun run ready-for-agent add /path/to/local/repo
 
 The command inspects the local git repository, calls the harness GraphQL
 endpoint at `http://127.0.0.1:6056/graphql`, and prints the persisted Repository
-id, local path, and bare flag. The path must be a git repository with a GitHub
-or GitLab remote. `add` does not start the Harness.
+id, local path, and bare flag. The path must be a git repository with a GitHub,
+GitLab, or Azure DevOps remote. An Azure Repos clone with no default branch is
+not usable until `main` (or equivalent) exists. `add` does not start the Harness.
 
 Override the endpoint when the harness is available elsewhere (non-default port
 or non-loopback bind):

--- a/apps/ready-for-agent/ready-for-agent.usage.kdl
+++ b/apps/ready-for-agent/ready-for-agent.usage.kdl
@@ -53,7 +53,7 @@ cmd "start" help="Start the full Harness (UI + backend); opens the browser unles
   example "ready-for-agent start --host" header="Start on all interfaces" help="Bind 0.0.0.0 instead of loopback"
 }
 
-cmd "add" help="Inspect and add a local repository; inferred GitLab identity can be corrected with flags" effect="write" {
+cmd "add" help="Inspect and add a local GitHub, GitLab, or Azure DevOps repository; inferred identity can be corrected with flags" effect="write" {
   arg "<path>" help="Path to a local git repository"
   complete "path" type="dir"
   flag "--forge-host <host>" help="Correct the forge host inferred from the repository remote"

--- a/apps/ready-for-agent/src/azure-devops-operator-docs.test.ts
+++ b/apps/ready-for-agent/src/azure-devops-operator-docs.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Operator-facing Azure DevOps docs: README Features / Requirements / add,
+ * Boards tags, ambient PAT, empty default branch, Merge Policy Always for
+ * no-CI, and no un-qualified Boards close-out claim.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "bun:test"
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(appRoot, "../..")
+const publicReadmePath = join(workspaceRoot, "README.md")
+const monorepoAddReadmePath = join(appRoot, "README.md")
+const usageSpecPath = join(appRoot, "ready-for-agent.usage.kdl")
+const cliPath = join(appRoot, "src/cli.ts")
+const azureOperatorDocPath = join(workspaceRoot, "docs/azure-devops.md")
+const scopesTicketUrl =
+  "https://github.com/berenddeboer/ready-for-agent/issues/1213"
+
+const markdownSection = (source: string, heading: string): string => {
+  const start = source.indexOf(`${heading}\n`)
+  if (start < 0) return ""
+  const rest = source.slice(start + heading.length + 1)
+  const next = rest.search(/\n## |\n# /)
+  return (next < 0 ? rest : rest.slice(0, next)).trim()
+}
+
+const addCommandHelp = (usageSpec: string): string => {
+  const match = usageSpec.match(/cmd "add" help="([^"]+)"/)
+  return match?.[1] ?? ""
+}
+
+describe("Azure DevOps operator documentation", () => {
+  test("README Features, Requirements, and add path name Azure DevOps alongside GitHub and GitLab", () => {
+    const readme = readFileSync(publicReadmePath, "utf8")
+    const features = markdownSection(readme, "## Features")
+    const requirements = markdownSection(readme, "## Requirements")
+    const quickStart = markdownSection(readme, "## Quick start")
+    const addReference = markdownSection(readme, "## `ready-for-agent add`")
+
+    expect(features).toContain("Azure DevOps")
+    expect(features).toContain("GitHub")
+    expect(features).toContain("GitLab")
+
+    expect(requirements).toContain("Azure DevOps")
+    expect(requirements).toContain("GitHub")
+    expect(requirements).toContain("GitLab")
+    expect(requirements).toContain("AZURE_DEVOPS_EXT_PAT")
+
+    expect(quickStart).toContain("Azure DevOps")
+    expect(quickStart).toContain("ready-for-agent add")
+    expect(addReference).toContain("Azure DevOps")
+
+    const monorepoAdd = readFileSync(monorepoAddReadmePath, "utf8")
+    expect(monorepoAdd).toContain("Azure DevOps")
+    expect(monorepoAdd).not.toMatch(
+      /git repository with a GitHub or GitLab remote/,
+    )
+  })
+
+  test("add help names Azure DevOps as a supported Forge", () => {
+    const usageSpec = readFileSync(usageSpecPath, "utf8")
+    const cli = readFileSync(cliPath, "utf8")
+    const help = addCommandHelp(usageSpec)
+
+    expect(help).toContain("Azure DevOps")
+    expect(help).toContain("GitHub")
+    expect(help).toContain("GitLab")
+    expect(cli).toContain(help)
+  })
+
+  test("operator docs describe Boards tags, the ambient PAT, empty default branch, and Always for no-CI", () => {
+    expect(existsSync(azureOperatorDocPath)).toBe(true)
+    const azureDoc = readFileSync(azureOperatorDocPath, "utf8")
+    const readme = readFileSync(publicReadmePath, "utf8")
+
+    expect(azureDoc).toMatch(/Boards tag/)
+    expect(azureDoc).toContain("`ready-for-agent`")
+    expect(azureDoc).not.toMatch(/Ready[- ]labeled Issues are Azure labels/)
+    expect(azureDoc).toContain("AZURE_DEVOPS_EXT_PAT")
+    expect(azureDoc).toContain(scopesTicketUrl)
+    expect(azureDoc).toMatch(/no default branch/)
+    expect(azureDoc).toMatch(/Merge Policy/)
+    expect(azureDoc).toMatch(/\boff\b/)
+    expect(azureDoc).toMatch(/\bAlways\b/)
+    expect(azureDoc).toMatch(/no-CI|no CI|without CI|absence of CI/)
+
+    expect(readme).toContain("docs/azure-devops.md")
+    expect(readme).toMatch(/Boards tag/)
+  })
+
+  test("operator docs qualify Boards close-out instead of claiming parity", () => {
+    const azureDoc = readFileSync(azureOperatorDocPath, "utf8")
+    expect(azureDoc).toMatch(/close-out/)
+    expect(azureDoc).toMatch(/not yet|not at parity|still being finished/)
+    expect(azureDoc).not.toMatch(
+      /work item close-out with a completion summary are all implemented/,
+    )
+  })
+})

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -514,7 +514,7 @@ const addCommand = Command.make(
     }),
 ).pipe(
   Command.withDescription(
-    "Inspect and add a local repository; inferred GitLab identity can be corrected with flags",
+    "Inspect and add a local GitHub, GitLab, or Azure DevOps repository; inferred identity can be corrected with flags",
   ),
 )
 

--- a/docs/azure-devops.md
+++ b/docs/azure-devops.md
@@ -1,0 +1,56 @@
+# Azure DevOps
+
+Azure DevOps is a first-class Forge: add a local clone the same way as
+GitHub or GitLab. The harness lists Ready Issues, implements in a
+worktree, opens a pull request, watches status checks, and can merge.
+Boards close-out is not yet at parity with GitHub and GitLab.
+
+## Ready discovery is a Boards tag
+
+Azure Boards has no GitHub-style labels. Tag the work item
+`ready-for-agent`. The harness lists open work items that carry that
+Boards tag. A label on another surface is ignored.
+
+Predecessor/Successor links on the work item show up as blockers
+(`blockedBy`).
+
+## Authentication
+
+Until Azure credential UX ships, auth is the ambient PAT environment
+variable:
+
+```bash
+export AZURE_DEVOPS_EXT_PAT=<your-pat>
+```
+
+There is no `az` CLI requirement. Minimum token scopes per lifecycle
+step (poll Ready Issues, push, Create PR, Mark PR Ready for Review,
+Watch/status checks, Merge PR, close-out) are tracked in
+[issue #1213](https://github.com/berenddeboer/ready-for-agent/issues/1213).
+Merge/complete needs more than git + create-PR; a narrower PAT can
+implement and open a PR, then fail at Merge PR.
+
+Create a PAT at
+`https://dev.azure.com/<organization>/_usersSettings/tokens`.
+
+## Empty repositories
+
+An Azure Repos Git repository with no default branch is not usable
+until you push an initial commit so `main` (or equivalent) exists.
+Add may still succeed today; later worktree and Implement steps fail.
+Push `main` first.
+
+## Merge Policy
+
+New Repositories default to Merge Policy `off` — a human must merge.
+Azure orgs often have no pipelines. `off` plus no CI means every PR
+waits for a human. **Always** is the unattended setting for a no-CI
+Azure repo: after the Check-Start Deadline, absence of CI is green.
+Pending, failed, and Expected checks still block Always.
+
+## Boards close-out
+
+Create PR links the Boards work item to the PR so Azure can complete
+it on merge. That is not full close-out parity: a merged PR can leave
+the tagged item in To Do, and it would recandidate. Completing the
+Boards item after merge is still being finished.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "developer-tools",
     "github",
     "gitlab",
+    "azure-devops",
     "issue-tracker",
     "pull-request",
     "worktree"


### PR DESCRIPTION
## Why

Published operator docs still said GitHub or GitLab. Operators following the README and `add` help would not know Azure DevOps is supported, that Ready discovery is a Boards tag, that auth is `AZURE_DEVOPS_EXT_PAT`, or that Always is the unattended setting when an Azure repo has no CI.

That is issue #1215.

## What changed

- README Features, Requirements, and add path name Azure DevOps alongside GitHub and GitLab.
- Ready discovery is documented as a Boards tag `ready-for-agent`, not a label.
- Ambient PAT `AZURE_DEVOPS_EXT_PAT` is documented, with a link to the scopes ticket (#1213).
- Empty Azure Repos with no default branch are documented as unusable until `main` (or equivalent) exists. `add` is not claimed to reject them yet.
- Default Merge Policy is Off; Always is required to auto-merge a no-CI Azure repo.
- Boards close-out is qualified as not yet at parity.
- CLI `add` help and the Usage contract match.

A dedicated Azure DevOps operator page holds the PAT, empty-repo, merge-policy, and close-out caveats; the README carries the same facts in short form.

## Verification

- Operator-docs tests lock Features / Requirements / add, Boards tag, PAT, empty default branch, Always for no-CI, and qualified close-out.
- Usage quality gate: lint, README command-reference check, Effect/Usage inventory parity, completions.
- Uncommitted-change review found no findings.

## Limits

This is documentation only. Credential-card UX (#1212), the full scopes list (#1213), empty-repo add rejection (#1216), and Boards close-out after merge (#1217) remain separate.

Closes #1215