### PR TITLE
fix(azure-devops): reject empty Git repositories before they are added

### DIFF
--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -1069,6 +1069,8 @@ describe("Job worker", () => {
               Layer.succeed(ActiveAgentBackend, stubActiveAgentBackend()),
               sessionStore,
               defaultGithubLayer,
+              defaultGitlabLayer,
+              defaultAzureDevOpsLayer,
               localGit,
               directoryPicker,
             ),

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -10,6 +10,10 @@ import {
   missingSessionTelemetry,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
+import {
+  AzureDevOpsService,
+  type AzureDevOpsServiceShape,
+} from "@ready-for-agent/azure-devops-service"
 import { DbService, RepositoryId } from "@ready-for-agent/db-service"
 import {
   makeRepositoryRecord,
@@ -118,6 +122,39 @@ const defaultGitlab: GitLabServiceShape = {
   getOpenPullRequestNumber: () => Effect.succeed(1),
   findOpenPullRequestNumber: () => Effect.succeed(null),
   createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  getPullRequestCheckStatus: () =>
+    Effect.succeed({
+      _tag: "succeeded",
+      terminalChecks: [],
+      mergeability: "mergeable",
+      baseRefName: "main",
+      headPushedAt: null,
+      headSha: null,
+      createdAt: null,
+      isDraft: null,
+    }),
+  getPrStatusCheckDiagnostics: () => Effect.succeed([]),
+  markPullRequestReadyForReview: () => Effect.void,
+  getPullRequestLifecycleStatus: () =>
+    Effect.succeed({ _tag: "open" as const }),
+  mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
+}
+
+const defaultAzureDevOps: AzureDevOpsServiceShape = {
+  verifyProject: (repository) => Effect.succeed(repository),
+  getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+  listReadyIssues: () => Effect.succeed([]),
+  hasCredentials: () => Effect.succeed(true),
+  hasAmbientCredentials: () => Effect.succeed(true),
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  ensurePullRequestLinkedToIssue: () => Effect.void,
   updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
   countOpenNonDraftPullRequests: () => Effect.succeed(0),
   getPullRequestCheckStatus: () =>
@@ -416,6 +453,7 @@ describe("production GraphQL SSE idle timeout", () => {
           Layer.succeed(WorkItemLifecycle, lifecycle),
           Layer.succeed(GitHubService, defaultGithub),
           Layer.succeed(GitLabService, defaultGitlab),
+          Layer.succeed(AzureDevOpsService, defaultAzureDevOps),
           Layer.succeed(LocalGit, {
             inspect: () => Effect.die("unused"),
           }),

--- a/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
@@ -1108,19 +1108,16 @@ export const makeAzureDevOpsService = (options: {
     })
 
   /**
-   * Resolve the base branch for a new draft pull request: an explicit
-   * `baseRefName` when provided, otherwise the Git repository's default
-   * branch (Azure DevOps project metadata has no default-branch field —
-   * that lives on the repository resource, unlike GitLab's project).
+   * Load the Git repository's default branch. Azure DevOps project metadata
+   * has no default-branch field — that lives on the repository resource
+   * (unlike GitLab's project). Empty / uninitialized repos report
+   * `defaultBranch: null`.
    */
-  const resolveBaseRefName = (
+  const loadDefaultBranch = (
     repository: AzureDevOpsRepository,
     identity: AzureDevOpsProjectIdentity,
-    explicitBaseRefName: string | undefined,
   ): Effect.Effect<string, AzureDevOpsServiceError> =>
     Effect.gen(function* () {
-      const trimmed = explicitBaseRefName?.trim() ?? ""
-      if (trimmed !== "") return trimmed
       const meta = yield* unavailableOn404(
         repository,
         requestUnknown(
@@ -1148,10 +1145,26 @@ export const makeAzureDevOpsService = (options: {
       const defaultBranch = meta.defaultBranch?.trim() ?? ""
       if (defaultBranch === "") {
         return yield* new AzureDevOpsRequestError({
-          message: `Repository ${repository.projectPath} has no default base branch`,
+          message: `Repository ${repository.projectPath} has no default branch; push an initial commit first`,
         })
       }
       return branchFromRefName(defaultBranch)
+    })
+
+  /**
+   * Resolve the base branch for a new draft pull request: an explicit
+   * `baseRefName` when provided, otherwise the Git repository's default
+   * branch.
+   */
+  const resolveBaseRefName = (
+    repository: AzureDevOpsRepository,
+    identity: AzureDevOpsProjectIdentity,
+    explicitBaseRefName: string | undefined,
+  ): Effect.Effect<string, AzureDevOpsServiceError> =>
+    Effect.gen(function* () {
+      const trimmed = explicitBaseRefName?.trim() ?? ""
+      if (trimmed !== "") return trimmed
+      return yield* loadDefaultBranch(repository, identity)
     })
 
   return {
@@ -1174,20 +1187,25 @@ export const makeAzureDevOpsService = (options: {
           catch: (cause) =>
             requestError("Azure DevOps returned an invalid project", cause),
         })
-        // Project verification only canonicalizes the org/project segments
-        // (e.g. case correction); an explicit repository segment (present
-        // when the Git repository name differs from the project name) is
-        // carried through unchanged — this method is intentionally
-        // project-scoped only and never validates the Git repository name.
+        // Canonicalize org/project casing from the project resource; an
+        // explicit repository segment (Git name differs from the project)
+        // is carried through unchanged, then the Git repository itself is
+        // verified so an empty repo cannot persist.
         const projectPath =
           identity.repository === undefined
             ? `${identity.organization}/${project.name}`
             : `${identity.organization}/${project.name}/${identity.repository}`
-        return {
+        const resolved = {
           forge: repository.forge,
           forgeHost: repository.forgeHost,
           projectPath,
         } satisfies AzureDevOpsRepository
+        yield* loadDefaultBranch(resolved, {
+          organization: identity.organization,
+          project: project.name,
+          repository: identity.repository,
+        })
+        return resolved
       },
     ),
     getAuthenticatedUserLogin: Effect.fn(

--- a/packages/azure-devops-service/src/lib/azure-devops-service.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service.ts
@@ -35,7 +35,9 @@ export type AzureDevOpsServiceError =
 export interface AzureDevOpsServiceShape {
   /**
    * Verify Organization + Project against Azure DevOps before persistence
-   * (`GET _apis/projects/{project}`). Implemented.
+   * (`GET _apis/projects/{project}`), then the Git repository itself
+   * (`GET .../git/repositories/{repository}`). Rejects when the Git repo
+   * has no default branch (empty / uninitialized). Implemented.
    */
   readonly verifyProject: (
     repository: AzureDevOpsRepository,

--- a/packages/azure-devops-service/test/azure-devops-service.spec.ts
+++ b/packages/azure-devops-service/test/azure-devops-service.spec.ts
@@ -48,6 +48,9 @@ describe("Azure DevOps verifyProject", () => {
           id: "11111111-1111-1111-1111-111111111111",
           name: "Widgets",
         },
+        "/acme/Widgets/_apis/git/repositories/Widgets?api-version=7.1": {
+          defaultBranch: "refs/heads/main",
+        },
       }),
     )
 
@@ -68,7 +71,7 @@ describe("Azure DevOps verifyProject", () => {
     ) => {
       const headers = (init?.headers ?? {}) as Record<string, string>
       authorization = headers.Authorization ?? null
-      return json({ name: "widgets" })
+      return json({ name: "widgets", defaultBranch: "refs/heads/main" })
     }) as typeof fetch)
     await Effect.runPromise(service.verifyProject(repository))
     expect(authorization).toBe(
@@ -117,6 +120,9 @@ describe("Azure DevOps verifyProject", () => {
           id: "11111111-1111-1111-1111-111111111111",
           name: "Default",
         },
+        "/acme/Default/_apis/git/repositories/gantry?api-version=7.1": {
+          defaultBranch: "refs/heads/main",
+        },
       }),
     )
 
@@ -132,6 +138,83 @@ describe("Azure DevOps verifyProject", () => {
       forgeHost: "dev.azure.com",
       projectPath: "acme/Default/gantry",
     })
+  })
+
+  test("rejects a Git repository with no default branch", async () => {
+    const service = makeAzureDevOpsServiceFromToken(
+      "test-pat",
+      fakeFetch({
+        "/acme/_apis/projects/widgets?api-version=7.1": {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "widgets",
+        },
+        "/acme/widgets/_apis/git/repositories/widgets?api-version=7.1": {
+          defaultBranch: null,
+        },
+      }),
+    )
+    const error = await Effect.runPromise(
+      service.verifyProject(repository).pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(AzureDevOpsRequestError)
+    expect(error.message).toBe(
+      "Repository acme/widgets has no default branch; push an initial commit first",
+    )
+  })
+
+  test("accepts a Git repository whose name differs from the project when it has a default branch", async () => {
+    const service = makeAzureDevOpsServiceFromToken(
+      "test-pat",
+      fakeFetch({
+        "/acme/_apis/projects/Default?api-version=7.1": {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "Default",
+        },
+        "/acme/Default/_apis/git/repositories/gantry?api-version=7.1": {
+          defaultBranch: "refs/heads/main",
+        },
+      }),
+    )
+
+    await expect(
+      Effect.runPromise(
+        service.verifyProject({
+          ...repository,
+          projectPath: "acme/Default/gantry",
+        }),
+      ),
+    ).resolves.toEqual({
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/Default/gantry",
+    })
+  })
+
+  test("rejects a differently-named Git repository with no default branch", async () => {
+    const service = makeAzureDevOpsServiceFromToken(
+      "test-pat",
+      fakeFetch({
+        "/acme/_apis/projects/Default?api-version=7.1": {
+          id: "11111111-1111-1111-1111-111111111111",
+          name: "Default",
+        },
+        "/acme/Default/_apis/git/repositories/gantry?api-version=7.1": {
+          defaultBranch: null,
+        },
+      }),
+    )
+    const error = await Effect.runPromise(
+      service
+        .verifyProject({
+          ...repository,
+          projectPath: "acme/Default/gantry",
+        })
+        .pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(AzureDevOpsRequestError)
+    expect(error.message).toBe(
+      "Repository acme/Default/gantry has no default branch; push an initial commit first",
+    )
   })
 })
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -24,7 +24,10 @@ import {
   listSelectableAgentBackendInfos,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
-import { azureDevOpsVaultAccount } from "@ready-for-agent/azure-devops-service"
+import {
+  AzureDevOpsService,
+  azureDevOpsVaultAccount,
+} from "@ready-for-agent/azure-devops-service"
 import {
   DbService,
   type Forge,
@@ -423,6 +426,7 @@ export type GraphqlServices =
   | DbService
   | GitHubService
   | GitLabService
+  | AzureDevOpsService
   | KeymaxxerService
   | ActiveAgentBackend
   | QueueService
@@ -446,19 +450,10 @@ const isSameOriginRequest = (request: Request): boolean => {
 }
 
 /**
- * Resolution of the "does this file need an Azure DevOps branch?" open
- * question carried over from the Azure DevOps detection/auth ticket: this
- * file's three `forge`-aware call sites (`verifyRepositoryIdentity` below,
- * the `repositoryCredentials` resolver's vault-probe branch, and
- * `Repository.pullRequestCount`) are GraphQL-only internals for project
- * verification, vault-credential display, and PR count — none of them read
- * or relate to `listReadyIssues`. Azure DevOps has no GraphQL API of its
- * own, so its Ready Issue listing and blocking-link reads (ticket: "List
- * and reconcile Azure DevOps work items as the ready-for-agent frontier")
- * are consumed entirely inside `@ready-for-agent/issue-reconciler`, which
- * never routes through this file. No `listReadyIssues`-related branch is
- * needed here; each of the three sites already has its own explicit,
- * deliberate (if temporary) Azure DevOps posture documented inline below.
+ * Forge identity verification at add / identity-change time. GitLab and
+ * Azure DevOps revalidate against their APIs before persistence; GitHub
+ * still passes through like the identity-defaulting posture below.
+ * Ready Issue listing stays in `@ready-for-agent/issue-reconciler`.
  */
 const verifyRepositoryIdentity = Effect.fn(
   "graphql-api.verifyRepositoryIdentity",
@@ -467,17 +462,25 @@ const verifyRepositoryIdentity = Effect.fn(
   readonly forgeHost: string
   readonly projectPath: string
 }) {
-  // Azure DevOps project verification is not wired here yet (out of scope
-  // for the detection/auth ticket that widened this type) — pass through
-  // unverified like GitHub, matching the identity-defaulting posture below.
-  if (identity.forge !== "gitlab") return identity
-  const gitlab = yield* GitLabService
-  const resolved = yield* gitlab.verifyProject(identity)
-  return {
-    forge: identity.forge,
-    forgeHost: resolved.forgeHost,
-    projectPath: resolved.projectPath,
+  if (identity.forge === "gitlab") {
+    const gitlab = yield* GitLabService
+    const resolved = yield* gitlab.verifyProject(identity)
+    return {
+      forge: identity.forge,
+      forgeHost: resolved.forgeHost,
+      projectPath: resolved.projectPath,
+    }
   }
+  if (identity.forge === "azure-devops") {
+    const azureDevOps = yield* AzureDevOpsService
+    const resolved = yield* azureDevOps.verifyProject(identity)
+    return {
+      forge: identity.forge,
+      forgeHost: resolved.forgeHost,
+      projectPath: resolved.projectPath,
+    }
+  }
+  return identity
 })
 
 const toNativeResponse = (response: unknown): Response => {

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -258,6 +258,20 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
         error.message ?? "GitLab request failed",
         "GITLAB_REQUEST_FAILED",
       )
+    case "AzureDevOpsProjectUnavailableError":
+      return gql(
+        `Azure DevOps project ${error.projectPath} was not found on ${error.forgeHost}. Check the organization, project, and repository, then try again.`,
+        "AZURE_DEVOPS_PROJECT_UNAVAILABLE",
+        {
+          forgeHost: error.forgeHost,
+          projectPath: error.projectPath,
+        },
+      )
+    case "AzureDevOpsRequestError":
+      return gql(
+        error.message ?? "Azure DevOps request failed",
+        "AZURE_DEVOPS_REQUEST_FAILED",
+      )
     case "GitHubThrottledError": {
       const retryAt = error.retryAt
       const retryTime =

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -10,6 +10,11 @@ import {
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
 import {
+  AzureDevOpsRequestError,
+  AzureDevOpsService,
+  type AzureDevOpsServiceShape,
+} from "@ready-for-agent/azure-devops-service"
+import {
   AgentBackendChangeBlockedError,
   DbService,
   type DbServiceShape,
@@ -260,6 +265,39 @@ const defaultGitlab: GitLabServiceShape = {
   deleteBranch: () => Effect.void,
 }
 
+const defaultAzureDevOps: AzureDevOpsServiceShape = {
+  verifyProject: (repository) => Effect.succeed(repository),
+  getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+  listReadyIssues: () => Effect.succeed([]),
+  hasCredentials: () => Effect.succeed(true),
+  hasAmbientCredentials: () => Effect.succeed(true),
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  ensurePullRequestLinkedToIssue: () => Effect.void,
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  getPullRequestCheckStatus: () =>
+    Effect.succeed({
+      _tag: "succeeded",
+      terminalChecks: [],
+      mergeability: "mergeable",
+      baseRefName: "main",
+      headPushedAt: null,
+      headSha: null,
+      createdAt: null,
+      isDraft: null,
+    }),
+  getPrStatusCheckDiagnostics: () => Effect.succeed([]),
+  markPullRequestReadyForReview: () => Effect.void,
+  getPullRequestLifecycleStatus: () =>
+    Effect.succeed({ _tag: "open" as const }),
+  mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
+}
+
 const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
   keymaxxerOverrides: Partial<KeymaxxerServiceShape> = {},
@@ -271,6 +309,7 @@ const makeRuntime = (
   }> = {},
   githubOverrides: Partial<GitHubServiceShape> = {},
   gitlabOverrides: Partial<GitLabServiceShape> = {},
+  azureDevOpsOverrides: Partial<AzureDevOpsServiceShape> = {},
 ) => {
   const db = stubDbService({
     getConfig: Effect.succeed(config),
@@ -457,6 +496,10 @@ const makeRuntime = (
       Layer.succeed(GitLabService, {
         ...defaultGitlab,
         ...gitlabOverrides,
+      }),
+      Layer.succeed(AzureDevOpsService, {
+        ...defaultAzureDevOps,
+        ...azureDevOpsOverrides,
       }),
       localGit,
       directoryPicker,
@@ -750,6 +793,167 @@ describe("GraphQL API", () => {
     expect(addRepositoryCalled).toBe(false)
   })
 
+  test("verifies an Azure DevOps project before adding the repository", async () => {
+    const actions: string[] = []
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        addRepository: (input) => {
+          actions.push(`add:${input.forgeHost}/${input.projectPath}`)
+          return Effect.succeed({ ...repository, ...input })
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: (identity) =>
+          Effect.sync(() => {
+            actions.push(`verify:${identity.forgeHost}/${identity.projectPath}`)
+            return identity
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation AddRepository($input: AddRepositoryInput!) {
+          addRepository(input: $input) { id }
+        }`,
+        variables: {
+          input: {
+            forge: "azure-devops",
+            forgeHost: "dev.azure.com",
+            projectPath: "acme/widgets",
+            localPath: "/tmp/acme-widgets",
+            isBare: false,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          id: repository.id,
+        },
+      },
+    })
+    expect(actions).toEqual([
+      "verify:dev.azure.com/acme/widgets",
+      "add:dev.azure.com/acme/widgets",
+    ])
+  })
+
+  test("rejects an Azure DevOps repository with no default branch before saving", async () => {
+    let addRepositoryCalled = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        addRepository: () => {
+          addRepositoryCalled = true
+          return Effect.succeed(repository)
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: (identity) =>
+          Effect.fail(
+            new AzureDevOpsRequestError({
+              message: `Repository ${identity.projectPath} has no default branch; push an initial commit first`,
+            }),
+          ),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation AddRepository($input: AddRepositoryInput!) {
+          addRepository(input: $input) { id }
+        }`,
+        variables: {
+          input: {
+            forge: "azure-devops",
+            forgeHost: "dev.azure.com",
+            projectPath: "acme/widgets",
+            localPath: "/tmp/acme-widgets",
+            isBare: false,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toMatchObject({
+      errors: [
+        {
+          message:
+            "Repository acme/widgets has no default branch; push an initial commit first",
+          extensions: { code: "AZURE_DEVOPS_REQUEST_FAILED" },
+        },
+      ],
+    })
+    expect(addRepositoryCalled).toBe(false)
+  })
+
+  test("accepts an Azure DevOps repository whose Git name differs from the project when it has a default branch", async () => {
+    let addedPath: string | null = null
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        addRepository: (input) => {
+          addedPath = input.projectPath
+          return Effect.succeed({ ...repository, ...input })
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: (identity) => Effect.succeed(identity),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation AddRepository($input: AddRepositoryInput!) {
+          addRepository(input: $input) { projectPath }
+        }`,
+        variables: {
+          input: {
+            forge: "azure-devops",
+            forgeHost: "dev.azure.com",
+            projectPath: "acme/Default/gantry",
+            localPath: "/tmp/gantry",
+            isBare: false,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          projectPath: "acme/Default/gantry",
+        },
+      },
+    })
+    expect(addedPath).toBe("acme/Default/gantry")
+  })
+
   test("suggests add repository command with npx when operator binary is not on PATH", async () => {
     const response = await createGraphqlApi(runtime, {
       commandExists: () => false,
@@ -896,6 +1100,67 @@ describe("GraphQL API", () => {
         },
       })
       expect(addRepositoryCalled).toBe(false)
+    } finally {
+      await inspectRuntime.dispose()
+    }
+  })
+
+  test("inspectLocalRepository returns Azure DevOps identity without Forge verification", async () => {
+    let verifyCalled = false
+    const inspectRuntime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        inspect: (path) =>
+          Effect.succeed({
+            forge: "azure-devops" as const,
+            forgeHost: "dev.azure.com",
+            projectPath: "acme/widgets",
+            localPath: path,
+            isBare: false,
+            paused: true as const,
+          }),
+      },
+      {},
+      {},
+      {
+        verifyProject: (identity) => {
+          verifyCalled = true
+          return Effect.fail(
+            new AzureDevOpsRequestError({
+              message: `Repository ${identity.projectPath} has no default branch; push an initial commit first`,
+            }),
+          )
+        },
+      },
+    )
+
+    try {
+      const response = await createGraphqlApi(inspectRuntime).fetch(
+        graphqlRequest({
+          query: `mutation {
+            inspectLocalRepository(path: "/tmp/empty-azure-repo") {
+              forge
+              forgeHost
+              projectPath
+            }
+          }`,
+        }),
+      )
+
+      expect(await response.json()).toEqual({
+        data: {
+          inspectLocalRepository: {
+            forge: "azure-devops",
+            forgeHost: "dev.azure.com",
+            projectPath: "acme/widgets",
+          },
+        },
+      })
+      expect(verifyCalled).toBe(false)
     } finally {
       await inspectRuntime.dispose()
     }

--- a/packages/graphql-api/test/to-graphql-error.test.ts
+++ b/packages/graphql-api/test/to-graphql-error.test.ts
@@ -136,4 +136,39 @@ describe("toGraphQLError", () => {
       reason: "not_paused",
     })
   })
+
+  test("maps AzureDevOpsRequestError to AZURE_DEVOPS_REQUEST_FAILED", () => {
+    const error = {
+      _tag: "AzureDevOpsRequestError" as const,
+      message:
+        "Repository acme/widgets has no default branch; push an initial commit first",
+    }
+
+    const gqlError = toGraphQLError(error)
+
+    expect(gqlError.message).toBe(
+      "Repository acme/widgets has no default branch; push an initial commit first",
+    )
+    expect(gqlError.extensions).toMatchObject({
+      code: "AZURE_DEVOPS_REQUEST_FAILED",
+    })
+  })
+
+  test("maps AzureDevOpsProjectUnavailableError to AZURE_DEVOPS_PROJECT_UNAVAILABLE", () => {
+    const error = {
+      _tag: "AzureDevOpsProjectUnavailableError" as const,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+    }
+
+    const gqlError = toGraphQLError(error)
+
+    expect(gqlError.message).toContain("acme/widgets")
+    expect(gqlError.extensions).toMatchObject({
+      code: "AZURE_DEVOPS_PROJECT_UNAVAILABLE",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+    })
+  })
 })


### PR DESCRIPTION
Empty Azure DevOps Git repositories could be added and then fail at worktree creation and Implement. The live case was size 0 with `defaultBranch: null`.

Before persistence, Azure verification now loads the Git repository (not only the project) and refuses add when there is no default branch. The operator-visible reason is to push an initial commit first. A Project Path whose Git name differs from the project is still accepted when that Git repository has a default branch. GitHub and GitLab add behaviour is unchanged.

Inspect remains a local preview so first-time Azure intake still works (inspect, add, then attach a token). The empty-repo check runs at add, which now requires a live Forge call and therefore an ambient PAT, matching GitLab's verify-at-add posture.

Verified with Azure verification tests for empty-repo reject and named-repo accept, plus GraphQL add and inspect tests.

Closes #1216