### PR TITLE
fix(azure-devops): complete Boards items that stay open after Merge PR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -392,7 +392,7 @@ The Lifecycle Step that changes a Work Item PR from draft to ready for review af
 The Lifecycle Step that decides whether a settled Work Item PR may be merged by the harness or requires a human.
 
 **Merge PR**:
-The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge. On Azure DevOps, a complete request that is still queued is in-flight merge work, not a Merge Revalidation Outcome or a rejected merge.
+The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge. On Azure DevOps, a complete request that is still queued is in-flight merge work, not a Merge Revalidation Outcome or a rejected merge. After a successful merge on Azure DevOps, if the Forge Issue is still open, Merge PR completes it to that type's Completed-category state and posts the hidden-marker completion summary once; an already completed Boards item is left in state.
 
 
 **local cleanup**:

--- a/README.md
+++ b/README.md
@@ -296,8 +296,8 @@ Azure DevOps is a first-class Forge. Ready discovery is a Boards tag
 `AZURE_DEVOPS_EXT_PAT` environment variable until credential UX
 ships. A repo with no default branch is not usable until `main` (or
 equivalent) exists. Default Merge Policy is Off; Always is required to
-auto-merge a no-CI Azure repo. Boards close-out is not yet at parity
-with GitHub and GitLab.
+auto-merge a no-CI Azure repo. After a successful merge, if the Boards
+item is still open the harness completes it.
 
 Details: [docs/azure-devops.md](docs/azure-devops.md). Token scopes:
 [issue #1213](https://github.com/berenddeboer/ready-for-agent/issues/1213).

--- a/apps/ready-for-agent/src/azure-devops-operator-docs.test.ts
+++ b/apps/ready-for-agent/src/azure-devops-operator-docs.test.ts
@@ -1,7 +1,7 @@
 /**
  * Operator-facing Azure DevOps docs: README Features / Requirements / add,
  * Boards tags, ambient PAT, empty default branch, Merge Policy Always for
- * no-CI, and no un-qualified Boards close-out claim.
+ * no-CI, and harness-owned Boards close-out after merge.
  */
 
 import { existsSync, readFileSync } from "node:fs"
@@ -91,12 +91,16 @@ describe("Azure DevOps operator documentation", () => {
     expect(readme).toMatch(/Boards tag/)
   })
 
-  test("operator docs qualify Boards close-out instead of claiming parity", () => {
+  test("operator docs describe harness-owned Boards close-out after merge", () => {
     const azureDoc = readFileSync(azureOperatorDocPath, "utf8")
+    const readme = readFileSync(publicReadmePath, "utf8")
     expect(azureDoc).toMatch(/close-out/)
-    expect(azureDoc).toMatch(/not yet|not at parity|still being finished/)
+    expect(azureDoc).toMatch(/still open/)
+    expect(azureDoc).toMatch(/Completed-category|Done on Basic|Closed on Agile/)
+    expect(azureDoc).not.toMatch(/not yet at parity|still being finished/)
     expect(azureDoc).not.toMatch(
       /work item close-out with a completion summary are all implemented/,
     )
+    expect(readme).not.toMatch(/Boards close-out is not yet at parity/)
   })
 })

--- a/docs/adr/0061-azure-devops-merge-and-status-mapping.md
+++ b/docs/adr/0061-azure-devops-merge-and-status-mapping.md
@@ -67,6 +67,19 @@ for any reason (network error, unexpected 404, decode failure) or finds no
 Completed-category state — matching the existing `CLOSED_STATE_NAMES`
 read-side heuristic used to classify Ready Issues' open/closed state.
 
+**Merge PR runs that close-out as a harness-owned backup after merge.**
+Linking the Boards item at Create PR plus `transitionWorkItems: true` on
+complete make Azure's own transition *possible*, but project board settings
+can refuse it and leave a tagged To Do item that would recandidate. After
+Merge PR observes `completed`, it calls `ensureIssueCompletedWithSummary`
+so a still-open Boards item reaches that type's Completed-category state
+and the hidden-marker comment is posted once. An item already Done/Closed
+is left in state. GitHub and GitLab close-out on merge is unchanged
+(`Closes #N`). Close-out stays inside Merge PR rather than routing through
+Close Issue so it uses the live Boards item (not the local Issue store)
+and so a close-out failure after a successful merge remains a retryable
+Merge PR Step Run — retry sees the PR already merged and repeats close-out.
+
 **Close-out cleanup is two separate calls, matching GitLab's shape.**
 `closeOpenPullRequestsForBranch` (`PATCH .../pullrequests/{id}` with
 `status: "abandoned"`) and `deleteBranch` (`POST .../refs` with a zero

--- a/docs/azure-devops.md
+++ b/docs/azure-devops.md
@@ -2,8 +2,8 @@
 
 Azure DevOps is a first-class Forge: add a local clone the same way as
 GitHub or GitLab. The harness lists Ready Issues, implements in a
-worktree, opens a pull request, watches status checks, and can merge.
-Boards close-out is not yet at parity with GitHub and GitLab.
+worktree, opens a pull request, watches status checks, can merge, and
+completes the Boards item after merge if Azure left it open.
 
 ## Ready discovery is a Boards tag
 
@@ -51,6 +51,9 @@ Pending, failed, and Expected checks still block Always.
 ## Boards close-out
 
 Create PR links the Boards work item to the PR so Azure can complete
-it on merge. That is not full close-out parity: a merged PR can leave
-the tagged item in To Do, and it would recandidate. Completing the
-Boards item after merge is still being finished.
+it on merge. After Merge PR reports the PR merged, if the Boards item
+is still open the harness completes it itself: that work-item type's
+Completed-category state (Done on Basic, Closed on Agile) plus the
+hidden-marker completion summary, posted once. An item already Done or
+Closed is left in state. Local cleanup then runs and the Work Item
+reaches Complete.

--- a/docs/forge-token-scopes.md
+++ b/docs/forge-token-scopes.md
@@ -42,16 +42,16 @@ full loop.
 | Create PR | **Pull requests:** Read and write | `api` | **Code:** Read & write. **Work Items:** Read & write (Boards ArtifactLink) |
 | Mark PR Ready for Review | **Pull requests:** Read and write | `api` | **Code:** Read & write |
 | Watch / status checks | **Actions:** Read and write (job logs and workflow reruns). **Commit statuses:** Read-only | `read_api` | **Code:** Read. **Build:** Read (logs). **Policy:** Read (branch policy evaluations) |
-| Merge PR | **Pull requests:** Read and write | `api` | **Code:** Read & write (same REST floor as Create PR). **Work Items:** Read & write (`transitionWorkItems` on complete — extra versus git + Create PR) |
+| Merge PR | **Pull requests:** Read and write | `api` | **Code:** Read & write (same REST floor as Create PR). **Work Items:** Read & write (`transitionWorkItems` on complete, plus harness close-out if the Boards item is still open) |
 | close-out | **Issues:** Read and write | `api` | **Work Items:** Read & write (comment + Completed-category state) |
 
 ### Azure DevOps: Merge PR needs more than git + Create PR
 
 Git fetch/push and Create PR succeed with **Code (Read & write)**
 alone. Completing the pull request does not: MERGE_PR PATCHes the PR
-to `completed` with `transitionWorkItems: true`, and close-out writes
-a Boards comment and Completed-category state. Those need
-**Work Items (Read & write)** as well.
+to `completed` with `transitionWorkItems: true`, then close-out writes
+a Boards comment and Completed-category state if the item is still
+open. Those need **Work Items (Read & write)** as well.
 
 Azure REST documents both create and complete as **Code (Read & write)**.
 Do not mint **Code (Read, write, & manage)** for Merge PR — that

--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -609,7 +609,7 @@ rfa:MergePr
   rfa:retryable true ;
   skos:prefLabel "Merge PR"@en ;
   skos:definition
-    "The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge. On Azure DevOps, a complete request that is still queued is in-flight merge work, not a Merge Revalidation Outcome or a rejected merge."@en .
+    "The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge. On Azure DevOps, a complete request that is still queued is in-flight merge work, not a Merge Revalidation Outcome or a rejected merge. After a successful merge on Azure DevOps, if the Forge Issue is still open, Merge PR completes it to that type's Completed-category state and posts the hidden-marker completion summary once; an already completed Boards item is left in state."@en .
 
 rfa:CloseIssue
   a owl:Class, owl:NamedIndividual, skos:Concept,

--- a/packages/azure-devops-service/test/azure-devops-service.spec.ts
+++ b/packages/azure-devops-service/test/azure-devops-service.spec.ts
@@ -1646,6 +1646,41 @@ describe("Azure DevOps ensureIssueCompletedWithSummary", () => {
     )
     expect(posted).toBe(false)
   })
+
+  test("leaves an already completed Boards item in state", async () => {
+    const methods: string[] = []
+    const service = makeAzureDevOpsServiceFromToken("test-pat", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      methods.push(`${method} ${url.pathname}`)
+      if (url.pathname.endsWith("/comments")) {
+        if (method === "POST") {
+          const posted = JSON.parse(String(init?.body)) as { text: string }
+          return json({ text: posted.text })
+        }
+        return json({ comments: [] })
+      }
+      return json({
+        id: 1,
+        fields: { "System.State": "Done", "System.WorkItemType": "Issue" },
+      })
+    }) as unknown as typeof fetch)
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        1,
+        "wi-1",
+        "All done",
+      ),
+    )
+
+    expect(methods.some((entry) => entry.startsWith("PATCH "))).toBe(false)
+    expect(methods.some((entry) => entry.startsWith("POST "))).toBe(true)
+  })
 })
 
 describe("Azure DevOps closeOpenPullRequestsForBranch", () => {

--- a/packages/work-item-lifecycle/src/lib/merge-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/merge-pr.ts
@@ -14,12 +14,27 @@ export class MergePrContextError extends Schema.TaggedErrorClass<MergePrContextE
   },
 ) {}
 
+const AZURE_BOARDS_MERGE_COMPLETION_SUMMARY =
+  "Completed after the pull request merged."
+
+const azureBoardsMergeCompletionSummary = (
+  context: LifecycleStepContext,
+): string => {
+  const persisted = context.completionSummary?.trim()
+  if (persisted !== undefined && persisted !== "") {
+    return persisted
+  }
+  return AZURE_BOARDS_MERGE_COMPLETION_SUMMARY
+}
+
 /**
  * Production Merge PR Lifecycle Step.
  * After Decide PR Merge chooses clanker merge, merges the open PR/MR on the
  * Work Item branch via the Forge API (token-backed; expected head SHA).
  * GitHub squash-merges; GitLab and Azure DevOps defer merge method to
- * project/repository settings.
+ * project/repository settings. On Azure DevOps, a successful merge then
+ * completes the Boards Issue if it is still open (harness-owned backup for
+ * `transitionWorkItems`).
  */
 export const mergePr = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -57,7 +72,20 @@ export const mergePr = (context: LifecycleStepContext) =>
       }
       case "azure-devops": {
         const azureDevOps = yield* AzureDevOpsService
-        return yield* azureDevOps.mergePullRequest(repository, branch, options)
+        const result = yield* azureDevOps.mergePullRequest(
+          repository,
+          branch,
+          options,
+        )
+        if (result._tag === "merged") {
+          yield* azureDevOps.ensureIssueCompletedWithSummary(
+            repository,
+            context.issueNumber,
+            context.workItemId,
+            azureBoardsMergeCompletionSummary(context),
+          )
+        }
+        return result
       }
       case "github": {
         const github = yield* GitHubService

--- a/packages/work-item-lifecycle/test/merge-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/merge-pr.spec.ts
@@ -1,5 +1,6 @@
 import { Effect, Layer } from "effect"
 import {
+  AzureDevOpsRequestError,
   AzureDevOpsService,
   type AzureDevOpsServiceShape,
 } from "@ready-for-agent/azure-devops-service"
@@ -340,6 +341,7 @@ describe("mergePr", () => {
         expect(options).toBeUndefined()
         return Effect.succeed({ _tag: "merged" as const })
       },
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } as AzureDevOpsServiceShape)
 
     await Effect.runPromise(
@@ -373,6 +375,7 @@ describe("mergePr", () => {
         seenOptions = options
         return Effect.succeed({ _tag: "merged" as const })
       },
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } as AzureDevOpsServiceShape)
 
     await Effect.runPromise(
@@ -382,5 +385,272 @@ describe("mergePr", () => {
     )
 
     expect(seenOptions).toEqual({ acceptNoChecks: true })
+  })
+
+  it("completes a still-open Azure Boards Issue after merge", async () => {
+    const closeOutCalls: Array<{
+      issueNumber: number
+      workItemId: string
+      summary: string
+      projectPath: string
+    }> = []
+    const azureDevOpsRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/widgets",
+    })
+    const azureDevOpsDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([azureDevOpsRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () =>
+        Effect.die("GitHub must not merge an Azure DevOps repo"),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.die("GitHub must not close an Azure DevOps Issue"),
+    } as GitHubServiceShape)
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+      ensureIssueCompletedWithSummary: (
+        forgeRepository,
+        issueNumber,
+        workItemId,
+        summaryMarkdown,
+      ) =>
+        Effect.sync(() => {
+          closeOutCalls.push({
+            issueNumber,
+            workItemId,
+            summary: summaryMarkdown,
+            projectPath: forgeRepository.projectPath,
+          })
+        }),
+    } as AzureDevOpsServiceShape)
+
+    const result = await Effect.runPromise(
+      mergePr(context).pipe(
+        Effect.provide(Layer.mergeAll(azureDevOpsDb, github, azureDevOps)),
+      ),
+    )
+
+    expect(result).toEqual({ _tag: "merged" })
+    expect(closeOutCalls).toEqual([
+      {
+        issueNumber: 42,
+        workItemId: context.workItemId,
+        summary: "Completed after the pull request merged.",
+        projectPath: "acme/widgets",
+      },
+    ])
+  })
+
+  it("posts the persisted completion summary when Merge PR already has one", async () => {
+    const summaries: string[] = []
+    const azureDevOpsRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/widgets",
+    })
+    const azureDevOpsDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([azureDevOpsRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () =>
+        Effect.die("GitHub must not merge an Azure DevOps repo"),
+    } as GitHubServiceShape)
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+      ensureIssueCompletedWithSummary: (
+        _forgeRepository,
+        _issueNumber,
+        _workItemId,
+        summaryMarkdown,
+      ) =>
+        Effect.sync(() => {
+          summaries.push(summaryMarkdown)
+        }),
+    } as AzureDevOpsServiceShape)
+
+    await Effect.runPromise(
+      mergePr({
+        ...context,
+        completionSummary: "Findings complete.",
+      }).pipe(
+        Effect.provide(Layer.mergeAll(azureDevOpsDb, github, azureDevOps)),
+      ),
+    )
+
+    expect(summaries).toEqual(["Findings complete."])
+  })
+
+  it("still asks Azure to complete the Boards Issue when merge already linked it", async () => {
+    const calls: string[] = []
+    const azureDevOpsRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/widgets",
+    })
+    const azureDevOpsDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([azureDevOpsRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () =>
+        Effect.die("GitHub must not merge an Azure DevOps repo"),
+    } as GitHubServiceShape)
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      mergePullRequest: () =>
+        Effect.sync(() => {
+          calls.push("merge")
+          return { _tag: "merged" as const }
+        }),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.sync(() => {
+          calls.push("close-out")
+        }),
+    } as AzureDevOpsServiceShape)
+
+    await Effect.runPromise(
+      mergePr(context).pipe(
+        Effect.provide(Layer.mergeAll(azureDevOpsDb, github, azureDevOps)),
+      ),
+    )
+
+    expect(calls).toEqual(["merge", "close-out"])
+  })
+
+  it("does not complete an Azure Boards Issue when merge is not yet merged", async () => {
+    let closeOutCalls = 0
+    const azureDevOpsRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/widgets",
+    })
+    const azureDevOpsDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([azureDevOpsRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () =>
+        Effect.die("GitHub must not merge an Azure DevOps repo"),
+    } as GitHubServiceShape)
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      mergePullRequest: () =>
+        Effect.succeed({
+          _tag: "needs_human" as const,
+          reason: "merge_rejected" as const,
+          message: "Azure DevOps rejected the merge",
+        }),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.sync(() => {
+          closeOutCalls += 1
+        }),
+    } as AzureDevOpsServiceShape)
+
+    const result = await Effect.runPromise(
+      mergePr(context).pipe(
+        Effect.provide(Layer.mergeAll(azureDevOpsDb, github, azureDevOps)),
+      ),
+    )
+
+    expect(result._tag).toBe("needs_human")
+    expect(closeOutCalls).toBe(0)
+  })
+
+  it("fails Merge PR when Azure close-out fails after a successful merge", async () => {
+    const azureDevOpsRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/widgets",
+    })
+    const azureDevOpsDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([azureDevOpsRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () =>
+        Effect.die("GitHub must not merge an Azure DevOps repo"),
+    } as GitHubServiceShape)
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.fail(
+          new AzureDevOpsRequestError({
+            message:
+              "Failed to complete Azure Boards Issue #42 for acme/widgets",
+            statusCode: 401,
+          }),
+        ),
+    } as AzureDevOpsServiceShape)
+
+    const error = await Effect.runPromise(
+      mergePr(context).pipe(
+        Effect.provide(Layer.mergeAll(azureDevOpsDb, github, azureDevOps)),
+        Effect.flip,
+      ),
+    )
+
+    expect(error).toBeInstanceOf(AzureDevOpsRequestError)
+  })
+
+  it("does not close a GitHub Issue after merge", async () => {
+    let closeOutCalls = 0
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.sync(() => {
+          closeOutCalls += 1
+        }),
+    } as GitHubServiceShape)
+
+    await Effect.runPromise(
+      mergePr(context).pipe(Effect.provide(Layer.merge(db, github))),
+    )
+
+    expect(closeOutCalls).toBe(0)
+  })
+
+  it("does not close a GitLab Issue after merge", async () => {
+    let githubCloseOut = 0
+    let gitlabCloseOut = 0
+    const gitlabRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/widgets",
+      localPath: "/repos/widgets",
+    })
+    const gitlabDb = stubDbServiceLayer({
+      listRepositories: Effect.succeed([gitlabRepository]),
+    })
+    const github = Layer.succeed(GitHubService, {
+      mergePullRequest: () => Effect.die("GitHub must not merge a GitLab repo"),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.sync(() => {
+          githubCloseOut += 1
+        }),
+    } as GitHubServiceShape)
+    const gitlab = Layer.succeed(GitLabService, {
+      mergePullRequest: () => Effect.succeed({ _tag: "merged" as const }),
+      ensureIssueCompletedWithSummary: () =>
+        Effect.sync(() => {
+          gitlabCloseOut += 1
+        }),
+    } as GitLabServiceShape)
+
+    await Effect.runPromise(
+      mergePr(context).pipe(
+        Effect.provide(Layer.mergeAll(gitlabDb, github, gitlab)),
+      ),
+    )
+
+    expect(githubCloseOut).toBe(0)
+    expect(gitlabCloseOut).toBe(0)
   })
 })


### PR DESCRIPTION
Azure Merge PR could leave a tagged Boards item in To Do after the pull request completed. Create PR linking only makes Azure's own complete-on-merge transition possible; project board settings can refuse it, and the open item recandidates. See issue #1217.

After Merge PR reports the Azure pull request merged, the harness now runs the existing close-out: post the hidden-marker completion summary once, then move a still-open Boards item to that type's Completed-category state (Done on Basic, Closed on Agile). Already Done or Closed items are left in state. GitHub and GitLab still auto-close on merge. Local cleanup still follows a successful Merge PR.

Close-out stays in Merge PR so it uses live Azure rather than the local Issue store. A close-out failure after a real merge is a retryable Merge PR: retry sees the PR already merged and repeats close-out.

Verified with Merge PR tests (still-open after merge, backup after merge, GitHub/GitLab unchanged, close-out failure), Azure close-out tests (already completed is a no-op), lifecycle-model glossary parity, and operator-docs checks. Local review reported no findings.

Human merge and Refresh do not run this backup; they still rely on Azure's own transition when a link is present.

Closes #1217