### PR TITLE
fix(lifecycle): stop retrying deterministic Forge 401/403 failures

### DIFF
--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -308,6 +308,12 @@ rfa:CopyGenerationReason
   skos:definition
     "Mid-run: Commit is generating shared publication copy via an Agent Turn before the native git commit attempt."@en .
 
+rfa:ForgeAuthRejectedReason
+  a rfa:StepRunReason ;
+  skos:notation "forge_auth_rejected" ;
+  skos:definition
+    "The Step Run ended because the Forge rejected credentials or permission with HTTP 401 or 403. Deterministic; not retryable and does not consume Autonomous Retry Budget."@en .
+
 rfa:GitHubThrottledReason
   a rfa:StepRunReason ;
   skos:notation "github_throttled" ;

--- a/packages/github-service/src/lib/user-facing-error.ts
+++ b/packages/github-service/src/lib/user-facing-error.ts
@@ -102,7 +102,7 @@ const nextCause = (value: unknown): unknown => {
  * Prefer the typed `statusCode` field, then `HTTP NNN` in messages or
  * postcondition `diagnostics`. Never copies nested response bodies.
  */
-const extractHttpStatus = (error: unknown): number | undefined => {
+export const extractHttpStatus = (error: unknown): number | undefined => {
   const seen = new Set<unknown>()
   let current: unknown = error
   let fromText: number | undefined
@@ -127,6 +127,15 @@ const extractHttpStatus = (error: unknown): number | undefined => {
     current = nextCause(current)
   }
   return fromText
+}
+
+/** HTTP 401 and 403 are deterministic Forge auth/permission failures. */
+export const isDeterministicForgeAuthHttpStatus = (status: number): boolean =>
+  status === 401 || status === 403
+
+export const isDeterministicForgeAuthFailure = (error: unknown): boolean => {
+  const status = extractHttpStatus(error)
+  return status !== undefined && isDeterministicForgeAuthHttpStatus(status)
 }
 
 const httpSuffix = (status: number, message: string): string => {

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -17,7 +17,10 @@ import {
   buildReasonDetail,
   extractCauseChain,
   extractErrorCode,
+  extractHttpStatus,
   formatUserFacingError,
+  isDeterministicForgeAuthFailure,
+  isDeterministicForgeAuthHttpStatus,
   logErrorAnnotations,
   makeGitHubServiceFromToken,
   makeGitHubServiceTest,
@@ -4598,6 +4601,51 @@ describe("user-facing error formatting", () => {
     })
     expect(flattened).toContain("HTTP 401")
     expect(flattened).toContain("No open pull request found")
+  })
+
+  it("treats 401 and 403 as deterministic Forge auth failures, not 503", () => {
+    expect(
+      isDeterministicForgeAuthFailure(
+        new GitHubRequestError({
+          message: "Failed to merge pull request for acme/widgets:branch",
+          statusCode: 401,
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      isDeterministicForgeAuthFailure(
+        new GitHubRequestError({
+          message: "Failed to merge pull request for acme/widgets:branch",
+          statusCode: 403,
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      isDeterministicForgeAuthFailure(
+        new GitHubRequestError({
+          message: "Failed to merge pull request for acme/widgets:branch",
+          statusCode: 503,
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      isDeterministicForgeAuthFailure({
+        _tag: "CreatePrPostconditionError",
+        message: "No open pull request found",
+        diagnostics: "createDraftPullRequest failed: HTTP 401 Unauthorized",
+      }),
+    ).toBe(true)
+    expect(isDeterministicForgeAuthHttpStatus(401)).toBe(true)
+    expect(isDeterministicForgeAuthHttpStatus(403)).toBe(true)
+    expect(isDeterministicForgeAuthHttpStatus(503)).toBe(false)
+    expect(
+      extractHttpStatus(
+        new GitHubRequestError({
+          message: "Failed to merge pull request for acme/widgets:branch",
+          statusCode: 503,
+        }),
+      ),
+    ).toBe(503)
   })
 
   it("does not duplicate an HTTP status already in the message", () => {

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -217,7 +217,12 @@ export const workItemCanRetry = (workItem: WorkItemRecord): boolean => {
     return false
   }
 
-  const latestStatus = latestStepRun(workItem)?.status
+  const latest = latestStepRun(workItem)
+  if (latest?.reasonCode === STEP_RUN_REASON.forgeAuthRejected) {
+    return false
+  }
+
+  const latestStatus = latest?.status
   return latestStatus === "failed" || latestStatus === "interrupted"
 }
 

--- a/packages/graphql-api/test/repository-retry.test.ts
+++ b/packages/graphql-api/test/repository-retry.test.ts
@@ -4,6 +4,7 @@ import {
   AutonomousRetryDeferredError,
   AutonomousRetryLimitReachedError,
   RetryNotEligibleError,
+  STEP_RUN_REASON,
   type WorkItemRecord,
   WorkItemTerminalError,
 } from "@ready-for-agent/work-item-lifecycle"
@@ -235,6 +236,21 @@ describe("snapshotRetryTargets", () => {
     waitingForBlockers: true,
     stepRuns: [],
   })
+  const forgeAuthRejected = workItemWith({
+    id: "wi-forge-auth",
+    issueNumber: 33,
+    state: "merge_pr",
+    stepRuns: [
+      {
+        ...baseStepRun,
+        step: "merge_pr",
+        status: "failed",
+        reasonCode: STEP_RUN_REASON.forgeAuthRejected,
+        reasonMessage:
+          "Failed to merge pull request 42 for acme/widgets: HTTP 401 Unauthorized",
+      },
+    ],
+  })
   const terminalFailed = workItemWith({
     id: "wi-terminal-failed",
     issueNumber: 30,
@@ -280,6 +296,19 @@ describe("snapshotRetryTargets", () => {
       "wi-nh-review",
       "wi-legacy-failed",
     ])
+  })
+
+  test("all-retryable skips deterministic Forge 401/403 so Autonomous Retry Budget is not spent", () => {
+    const snapshot = snapshotRetryTargets({
+      selector: { kind: "all-retryable" },
+      repositoryId: "repo-1",
+      workItems: [forgeAuthRejected, failedInterrupted],
+    })
+    expect(Array.isArray(snapshot)).toBe(true)
+    if (!Array.isArray(snapshot)) {
+      throw new Error("expected snapshot list")
+    }
+    expect(snapshot.map((item) => item.id)).toEqual(["wi-failed"])
   })
 
   test("all-retryable skips parked Attention cards whose Issue is no longer Relevant", () => {

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -880,6 +880,32 @@ describe("operator Retry eligibility and latest Step Run reason", () => {
     ],
   })
 
+  test("Forge HTTP 401/403 Step Run is not retryable, including Autonomous Retry", () => {
+    const mergePrAuthRejected = workItemWith({
+      state: "merge_pr",
+      stepRuns: [
+        {
+          ...baseStepRun,
+          step: "merge_pr",
+          status: "failed",
+          reasonCode: STEP_RUN_REASON.forgeAuthRejected,
+          reasonMessage:
+            "Failed to merge pull request 42 for acme/widgets: HTTP 401 Unauthorized",
+          reasonDetail: null,
+        },
+      ],
+    })
+    expect(workItemCanRetry(mergePrAuthRejected)).toBe(false)
+    expect(workItemCanAutonomousRetry(mergePrAuthRejected)).toBe(false)
+    expect(workItemLatestStepRunReason(mergePrAuthRejected)).toEqual({
+      code: "forge_auth_rejected",
+      message:
+        "Failed to merge pull request 42 for acme/widgets: HTTP 401 Unauthorized",
+      retryAt: null,
+      detail: null,
+    })
+  })
+
   test("retryable failed Step Run keeps canRetry and structured reason with detail", () => {
     expect(workItemCanRetry(implementFailedWithDetail)).toBe(true)
     expect(workItemStatus(implementFailedWithDetail)).toBe("failed")

--- a/packages/lifecycle-model/src/generated/work-item-state.ts
+++ b/packages/lifecycle-model/src/generated/work-item-state.ts
@@ -56,6 +56,7 @@ export const STEP_RUN_REASONS = [
   "agent_model_not_in_catalog",
   "build_model_not_configured",
   "copy_generation",
+  "forge_auth_rejected",
   "github_throttled",
   "green-no-review-evidence",
   "handler_defect",
@@ -101,6 +102,8 @@ export const STEP_RUN_REASON = {
   buildModelNotConfigured: "build_model_not_configured",
   /** Mid-run: Commit is generating shared publication copy via an Agent Turn before the native git commit attempt. */
   copyGeneration: "copy_generation",
+  /** The Step Run ended because the Forge rejected credentials or permission with HTTP 401 or 403. Deterministic; not retryable and does not consume Autonomous Retry Budget. */
+  forgeAuthRejected: "forge_auth_rejected",
   /** Watch PR Status Checks stopped cleanly at GitHub's explicit retry time. */
   githubThrottled: "github_throttled",
   /** A green-only Status Check Handoff completed without an Agent Turn because harness-owned GitHub observation found no positive automated-review evidence. */

--- a/packages/lifecycle-model/test/step-run-reason.test.ts
+++ b/packages/lifecycle-model/test/step-run-reason.test.ts
@@ -57,6 +57,7 @@ describe("generated STEP_RUN_REASON", () => {
     expect(STEP_RUN_REASON.agentBackendAuthRejected).toBe(
       "agent_backend_auth_rejected",
     )
+    expect(STEP_RUN_REASON.forgeAuthRejected).toBe("forge_auth_rejected")
     expect(STEP_RUN_REASON.waitingForAgentTurn).toBe("waiting_for_agent_turn")
     expect(STEP_RUN_REASON.issueClosedPrClosedUnmerged).toBe(
       "issue_closed_pr_closed_unmerged",

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -37,6 +37,7 @@ import {
   type PullRequestLifecycleStatus,
   buildReasonDetail,
   formatUserFacingError,
+  isDeterministicForgeAuthFailure,
   isGitHubThrottledError,
   logErrorAnnotations,
   parseReasonDetail,
@@ -360,6 +361,12 @@ const classifyHandlerFailure = (
       return {
         reasonCode: STEP_RUN_REASON.prStatusChecksUnresolved,
         reasonMessage: error.message,
+      }
+    }
+    if (isDeterministicForgeAuthFailure(error)) {
+      return {
+        reasonCode: STEP_RUN_REASON.forgeAuthRejected,
+        reasonMessage: handlerFailureMessage(error),
       }
     }
     return {
@@ -5581,7 +5588,7 @@ export const makeWorkItemLifecycleLive = (
         const startLatest = yield* loadLatestStepRunRow(workItemId)
         const startHasActive = yield* loadHasActiveStepRun(workItemId)
         if (
-          Boolean(workItem.paused) &&
+          workItem.paused &&
           parkedAttentionEligibilityFromRow(
             workItem,
             startLatest,
@@ -7198,6 +7205,15 @@ export const makeWorkItemLifecycleLive = (
           return yield* new RetryNotEligibleError({
             workItemId,
             reason: "paused",
+          })
+        }
+        if (
+          autonomous !== undefined &&
+          latest?.reason_code === STEP_RUN_REASON.forgeAuthRejected
+        ) {
+          return yield* new RetryNotEligibleError({
+            workItemId,
+            reason: STEP_RUN_REASON.forgeAuthRejected,
           })
         }
         if (autonomous !== undefined) {

--- a/packages/work-item-lifecycle/test/forge-auth-rejected.spec.ts
+++ b/packages/work-item-lifecycle/test/forge-auth-rejected.spec.ts
@@ -1,0 +1,439 @@
+import { Effect, Layer, Option } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { AzureDevOpsRequestError } from "@ready-for-agent/azure-devops-service"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import { GitHubRequestError } from "@ready-for-agent/github-service"
+import { GitLabRequestError } from "@ready-for-agent/gitlab-service"
+import { QueueService } from "@ready-for-agent/queue-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  CreatePrPostconditionError,
+  LifecycleSteps,
+  type LifecycleStepsShape,
+  MarkPrReadyForReviewPostconditionError,
+  RetryNotEligibleError,
+  STEP_RUN_REASON,
+  WORK_ITEM_LIFECYCLE_QUEUE,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+  type WorkItemRecord,
+  stubActiveAgentBackendLayer,
+  stubAzureDevOpsServiceLayer,
+  stubGitHubServiceLayer,
+  stubGitLabServiceLayer,
+} from "../src/index.js"
+import { describe, expect, it, setDefaultTimeout } from "bun:test"
+
+setDefaultTimeout(30_000)
+
+const successfulSteps: LifecycleStepsShape = {
+  createWorktree: () =>
+    Effect.succeed({
+      worktreePath: "/tmp/worktrees/acme-widgets-42",
+      startingCommitOid: "abc123",
+    }),
+  installDependencies: () => Effect.void,
+  implement: () => Effect.succeed("ses_test"),
+  assessChanges: () => Effect.succeed({ _tag: "changes" }),
+  preCommit: () => Effect.void,
+  review: () => Effect.succeed({ _tag: "clean" as const }),
+  commit: () =>
+    Effect.succeed({
+      _tag: "committed" as const,
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  createPr: () =>
+    Effect.succeed({
+      pullRequestNumber: 101,
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  watchPrStatusChecks: () =>
+    Effect.succeed({
+      _tag: "succeeded",
+      createdAt: new Date(0),
+      headSha: "head",
+      headPushedAt: new Date(0),
+      isDraft: false,
+    }),
+  resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
+  investigatePrStatusChecks: () =>
+    Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
+  markPrReadyForReview: () => Effect.succeed({ completion: "native" as const }),
+  decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+  mergePr: () => Effect.succeed({ _tag: "merged" }),
+  closeIssue: () => Effect.void,
+  localCleanup: () => Effect.void,
+  removeWorktree: () => Effect.void,
+}
+
+const sampleRepository = {
+  forge: "github" as const,
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+  localPath: "/repos/acme/widgets.git",
+  isBare: true,
+}
+
+const sampleIssueFields = {
+  title: "Implement feature",
+  body: "Issue body",
+  url: "https://github.com/acme/widgets/issues/42",
+  state: "OPEN" as const,
+  githubCreatedAt: new Date("2026-01-15T12:00:00.000Z"),
+  issueAuthor: null,
+  parent: null,
+  parentPosition: null,
+  hasChildren: false,
+  blockedBy: [],
+}
+
+const makeTestLayer = (steps: LifecycleStepsShape) =>
+  WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(stubActiveAgentBackendLayer()),
+    Layer.provideMerge(stubGitHubServiceLayer()),
+    Layer.provideMerge(stubGitLabServiceLayer()),
+    Layer.provideMerge(stubAzureDevOpsServiceLayer()),
+    Layer.provideMerge(Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps))),
+    Layer.provideMerge(DbServiceLive),
+    Layer.provideMerge(SqliteQueueServiceLive),
+    Layer.provideMerge(DatabaseTest),
+  )
+
+const runWithSteps = <A, E>(
+  steps: LifecycleStepsShape,
+  test: Effect.Effect<
+    A,
+    E,
+    | WorkItemLifecycle
+    | DbService
+    | QueueService
+    | SqlClient.SqlClient
+    | LifecycleSteps
+  >,
+): Promise<A> => Effect.runPromise(Effect.provide(test, makeTestLayer(steps)))
+
+const seedHarnessBuildModel = Effect.gen(function* () {
+  const db = yield* DbService
+  const config = yield* db.getConfig
+  if (config.defaultModel !== null && config.defaultThinkingLevel !== null) {
+    return
+  }
+  yield* db.updateConfig({
+    selectedAgentBackend: "opencode",
+    defaultModel: config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+    defaultThinkingLevel: config.defaultThinkingLevel ?? "low",
+    reviewModel: config.reviewModel,
+    reviewThinkingLevel: config.reviewThinkingLevel,
+    maxConcurrentAgentTurns: config.maxConcurrentAgentTurns,
+    maxConcurrentWorkItems: config.maxConcurrentWorkItems,
+  })
+})
+
+const seedIssue = Effect.gen(function* () {
+  const db = yield* DbService
+  yield* seedHarnessBuildModel
+  const repository = yield* db.addRepository(sampleRepository)
+  const issue = yield* db.storeIssue({
+    repositoryId: repository.id,
+    issueNumber: 42,
+    ...sampleIssueFields,
+  })
+  return { repository, issue }
+})
+
+const makeQueuedJobsAvailable = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+  yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+})
+
+const claimAndRunPending = Effect.gen(function* () {
+  const lifecycle = yield* WorkItemLifecycle
+  const queue = yield* QueueService
+  yield* makeQueuedJobsAvailable
+  const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+  expect(Option.isSome(claimed)).toBe(true)
+  if (Option.isNone(claimed)) {
+    return yield* Effect.die("expected a queued lifecycle job")
+  }
+  const payload = claimed.value.payload as { stepRunId: string }
+  return yield* lifecycle.runStep(payload.stepRunId)
+})
+
+const forgetCreatePrDraftProvenance = (workItemId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `UPDATE work_item
+       SET check_start_last_observed_is_draft = NULL,
+           check_start_anchor_at = 0
+       WHERE id = ?`,
+      [workItemId],
+    )
+  })
+
+const runUntilLatestFailed = Effect.gen(function* () {
+  const lifecycle = yield* WorkItemLifecycle
+  const { repository, issue } = yield* seedIssue
+  const created = yield* lifecycle.implementNow(
+    repository.id,
+    issue.issueNumber,
+  )
+  let current: WorkItemRecord = created
+  for (let index = 0; index < 8; index += 1) {
+    const result = yield* claimAndRunPending
+    expect(result._tag).toBe("processed")
+    if (result._tag !== "processed") {
+      return yield* Effect.die("expected processed step")
+    }
+    current = result.workItem
+    if (current.stepRuns.at(-1)?.status === "failed") {
+      return current
+    }
+  }
+  yield* forgetCreatePrDraftProvenance(current.id)
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const result = yield* claimAndRunPending
+    expect(result._tag).toBe("processed")
+    if (result._tag !== "processed") {
+      return yield* Effect.die("expected processed step")
+    }
+    current = result.workItem
+    if (current.stepRuns.at(-1)?.status === "failed") {
+      return current
+    }
+  }
+  return yield* Effect.die(
+    `expected a failed Step Run, last state ${current.state}`,
+  )
+})
+
+const countPermits = (workItemId: string, step: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const rows = (yield* sql.unsafe(
+      `SELECT COUNT(*) AS count FROM autonomous_retry
+       WHERE work_item_id = ? AND lifecycle_step = ?`,
+      [workItemId, step],
+    )) as readonly { readonly count: number }[]
+    return Number(rows[0]?.count ?? 0)
+  })
+
+const expectForgeAuthRejected = (workItem: WorkItemRecord, status: number) => {
+  const latest = workItem.stepRuns.at(-1)
+  expect(latest?.status).toBe("failed")
+  expect(latest?.reasonCode).toBe(STEP_RUN_REASON.forgeAuthRejected)
+  expect(latest?.reasonMessage).toContain(`HTTP ${String(status)}`)
+}
+
+describe("deterministic Forge 401/403 classification (issue #1218)", () => {
+  it("classifies Azure MERGE_PR 401 as non-retryable and does not consume Autonomous Retry Budget", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      mergePr: () =>
+        Effect.fail(
+          new AzureDevOpsRequestError({
+            message: "Failed to merge pull request 42 for acme/widgets",
+            statusCode: 401,
+            cause: Object.assign(
+              new Error(
+                "Failed to merge pull request 42 for acme/widgets: Azure DevOps returned HTTP 401",
+              ),
+              { statusCode: 401 },
+            ),
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const failed = yield* runUntilLatestFailed
+        expect(failed.state).toBe("merge_pr")
+        expectForgeAuthRejected(failed, 401)
+
+        const blocked = yield* Effect.flip(
+          lifecycle.retry(failed.id, { autonomous: { maxRetries: 3 } }),
+        )
+        expect(blocked).toBeInstanceOf(RetryNotEligibleError)
+        if (blocked instanceof RetryNotEligibleError) {
+          expect(blocked.reason).toBe(STEP_RUN_REASON.forgeAuthRejected)
+        }
+        expect(yield* countPermits(failed.id, "merge_pr")).toBe(0)
+      }),
+    )
+  })
+
+  it("keeps a transient Azure MERGE_PR 503 retryable and still consumes Autonomous Retry Budget", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      mergePr: () =>
+        Effect.fail(
+          new AzureDevOpsRequestError({
+            message: "Failed to merge pull request 42 for acme/widgets",
+            statusCode: 503,
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const failed = yield* runUntilLatestFailed
+        expect(failed.state).toBe("merge_pr")
+        const latest = failed.stepRuns.at(-1)
+        expect(latest?.status).toBe("failed")
+        expect(latest?.reasonCode).toBe(STEP_RUN_REASON.handlerFailed)
+        expect(latest?.reasonMessage).toContain("HTTP 503")
+
+        const retried = yield* lifecycle.retry(failed.id, {
+          autonomous: { maxRetries: 3 },
+        })
+        expect(retried.stepRuns.at(-1)?.status).toBe("queued")
+        expect(yield* countPermits(failed.id, "merge_pr")).toBe(1)
+      }),
+    )
+  })
+
+  it("classifies GitHub Create PR 401 the same way, including wrapped postcondition diagnostics", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      createPr: () =>
+        Effect.fail(
+          new CreatePrPostconditionError({
+            repositoryId: "repo-1",
+            message:
+              "No open pull request found for acme/widgets:branch after native attempt and agent fallback",
+            diagnostics:
+              "createDraftPullRequest failed: Failed to create draft pull request for acme/widgets:branch: HTTP 401 Unauthorized",
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const failed = yield* runUntilLatestFailed
+        expect(failed.state).toBe("create_pr")
+        expectForgeAuthRejected(failed, 401)
+      }),
+    )
+  })
+
+  it("classifies GitLab Mark PR Ready for Review 403 as non-retryable", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      watchPrStatusChecks: () =>
+        Effect.succeed({
+          _tag: "succeeded",
+          createdAt: new Date(0),
+          headSha: "head",
+          headPushedAt: new Date(0),
+          isDraft: true,
+        }),
+      markPrReadyForReview: () =>
+        Effect.fail(
+          new MarkPrReadyForReviewPostconditionError({
+            repositoryId: "repo-1",
+            message:
+              "Pull request for acme/widgets:branch is still a draft after native attempt and agent fallback",
+            diagnostics:
+              "markPullRequestReadyForReview failed: Failed to mark merge request ready for acme/widgets: HTTP 403 Forbidden",
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const failed = yield* runUntilLatestFailed
+        expect(failed.state).toBe("mark_pr_ready_for_review")
+        expectForgeAuthRejected(failed, 403)
+      }),
+    )
+  })
+
+  it("classifies GitHub close-out 401 as non-retryable", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      assessChanges: () =>
+        Effect.succeed({
+          _tag: "no_change" as const,
+          completionSummary: "Findings only.",
+        }),
+      closeIssue: () =>
+        Effect.fail(
+          new GitHubRequestError({
+            message: "Failed to close issue #42 for acme/widgets",
+            statusCode: 401,
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const failed = yield* runUntilLatestFailed
+        expect(failed.state).toBe("close_issue")
+        expectForgeAuthRejected(failed, 401)
+      }),
+    )
+  })
+
+  it("classifies GitLab MERGE_PR 403 as non-retryable", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      mergePr: () =>
+        Effect.fail(
+          new GitLabRequestError({
+            message: "Failed to merge merge request for acme/widgets",
+            statusCode: 403,
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const failed = yield* runUntilLatestFailed
+        expect(failed.state).toBe("merge_pr")
+        expectForgeAuthRejected(failed, 403)
+      }),
+    )
+  })
+
+  it("keeps a transport failure without an HTTP status as retryable handler_failed", () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      mergePr: () =>
+        Effect.fail(
+          new AzureDevOpsRequestError({
+            message: "Failed to merge pull request 42 for acme/widgets",
+            code: "ENOTFOUND",
+          }),
+        ),
+    }
+
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const failed = yield* runUntilLatestFailed
+        expect(failed.stepRuns.at(-1)?.reasonCode).toBe(
+          STEP_RUN_REASON.handlerFailed,
+        )
+        const retried = yield* lifecycle.retry(failed.id, {
+          autonomous: { maxRetries: 3 },
+        })
+        expect(retried.stepRuns.at(-1)?.status).toBe("queued")
+        expect(yield* countPermits(failed.id, "merge_pr")).toBe(1)
+      }),
+    )
+  })
+})


### PR DESCRIPTION
A bad or narrow Azure PAT used to fail Merge PR as a generic handler failure, stay retryable, and burn Autonomous Retry Budget on every ticket in a batch (#1218). HTTP status is already on the card; this change stops the retry loop.

Forge HTTP 401 and 403 from Create PR, Mark PR Ready for Review, Merge PR, and close-out now record `forge_auth_rejected` (ontology-owned). Those cards are not retryable and do not consume Autonomous Retry Budget. GitHub and GitLab get the same classification. Transient 5xx and transport failures stay retryable, and the operator-visible message still includes the HTTP status.

Verification: lifecycle tests cover Azure merge 401 (non-retryable, budget untouched) versus 503 (retryable); GitHub Create PR 401 and close-out 401; GitLab Mark Ready 403 and merge 403. Projection tests assert `canRetry: false` so `--all-retryable` skips these items. Review of the uncommitted change found no contract issues.

Limitation: GitHub GraphQL permission errors that return HTTP 200 without a 401/403 status still classify as ordinary handler failures. Explicit GitHub 403 throttle evidence still postpones rather than becoming non-retryable.

Closes #1218