### PR TITLE
fix: treat Actions-write 403 on review rerun as a credential problem

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -10,6 +10,7 @@ import {
 } from "effect"
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
+  GITHUB_HELPER_PERMISSION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
   GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   type GitHubHelperOperation,
@@ -123,6 +124,17 @@ const authenticationError = (
   new GitHubRequestError({
     message: requestError(repository, operation, detail).message,
     statusCode: 401,
+  })
+
+const permissionError = (
+  repository: GitHubRepository,
+  operation: string,
+  detail?: string,
+) =>
+  new GitHubRequestError({
+    message: requestError(repository, operation, detail).message,
+    statusCode: 403,
+    retryable: false,
   })
 
 const repositoryUnavailable = (repository: GitHubRepository) =>
@@ -321,6 +333,9 @@ export const keymaxxerGitHubLayer = (options: {
                   input.repository,
                   input.describe,
                 )
+              }
+              if (result.exitCode === GITHUB_HELPER_PERMISSION_EXIT_CODE) {
+                return yield* permissionError(input.repository, input.describe)
               }
               if (result.exitCode === GITHUB_HELPER_TLS_TRUST_EXIT_CODE) {
                 const control = parseGitHubHelperControl(result.stderr)

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -14,6 +14,7 @@ import {
 import { TestClock } from "effect/testing"
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
+  GITHUB_HELPER_PERMISSION_EXIT_CODE,
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
@@ -21,6 +22,7 @@ import {
   INCOMPLETE_AUTOMATED_REVIEW_SIGNATURE,
   githubHelperSuccess,
   githubHelperThrottled,
+  isGitHubRequestError,
   serializeGitHubHelperControl,
 } from "@ready-for-agent/github-service"
 import {
@@ -518,6 +520,87 @@ describe("Keymaxxer-backed GitHub layer", () => {
             "new",
           )
         }).pipe(Effect.provide(layer))
+      }),
+  )
+
+  it.effect(
+    "maps a helper permission exit on workflow rerun without copying helper output",
+    () =>
+      Effect.gen(function* () {
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("TOKEN_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: GITHUB_HELPER_PERMISSION_EXIT_CODE,
+              stdout: "",
+              stderr:
+                'Resource not accessible by personal access token\n{"message":"Resource not accessible by personal access token"}',
+            }),
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const error = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github
+            .rerunWorkflowRun(acmeWidgets, 33232172979)
+            .pipe(Effect.flip)
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(isGitHubRequestError(error)).toBe(true)
+        if (!isGitHubRequestError(error)) {
+          return
+        }
+        expect(error.statusCode).toBe(403)
+        expect(error.retryable).toBe(false)
+        expect(error.message).not.toContain(
+          "Resource not accessible by personal access token",
+        )
+        expect(error.message).not.toContain("GitHub helper command failed")
+      }),
+  )
+
+  it.effect(
+    "keeps a helper authentication exit as HTTP 401, not a permission 403",
+    () =>
+      Effect.gen(function* () {
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("TOKEN_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
+              stdout: "",
+              stderr: "HTTP 401: Bad credentials",
+            }),
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const error = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github
+            .rerunWorkflowRun(acmeWidgets, 33232172979)
+            .pipe(Effect.flip)
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(isGitHubRequestError(error)).toBe(true)
+        if (!isGitHubRequestError(error)) {
+          return
+        }
+        expect(error.statusCode).toBe(401)
+        expect(error.message).not.toContain("Bad credentials")
       }),
   )
 

--- a/packages/github-service/src/bin/cli.ts
+++ b/packages/github-service/src/bin/cli.ts
@@ -10,6 +10,7 @@ import {
 } from "../lib/errors.js"
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
+  GITHUB_HELPER_PERMISSION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
   GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   githubHelperSuccess,
@@ -115,7 +116,9 @@ export const runGitHubCli = <A, E>(
         process.exitCode =
           error instanceof GitHubRequestError && error.statusCode === 401
             ? GITHUB_HELPER_AUTHENTICATION_EXIT_CODE
-            : 1
+            : error instanceof GitHubRequestError && error.statusCode === 403
+              ? GITHUB_HELPER_PERMISSION_EXIT_CODE
+              : 1
       }),
     ),
     BunRuntime.runMain,

--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -87,6 +87,34 @@ export const isGitHubTlsTrustError = (
   "_tag" in value &&
   value._tag === "GitHubTlsTrustError"
 
+export const isGitHubRequestError = (
+  value: unknown,
+): value is GitHubRequestError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  value._tag === "GitHubRequestError"
+
+/** HTTP 403 permission (secret too narrow). Distinct from 401 authentication. */
+export const isGitHubPermissionError = (
+  value: unknown,
+): value is GitHubRequestError =>
+  isGitHubRequestError(value) && value.statusCode === 403
+
+/** Confirmed GitHub 4xx that did not start the requested mutation. */
+export const isGitHubClientRejection = (value: unknown): boolean => {
+  if (!isGitHubRequestError(value)) {
+    return false
+  }
+  const status = value.statusCode
+  return (
+    typeof status === "number" &&
+    Number.isInteger(status) &&
+    status >= 400 &&
+    status < 500
+  )
+}
+
 export type GitHubServiceError =
   | GitHubRepositoryUnavailableError
   | GitHubRequestError

--- a/packages/github-service/src/lib/github-helper-protocol.ts
+++ b/packages/github-service/src/lib/github-helper-protocol.ts
@@ -15,6 +15,11 @@ export const GITHUB_HELPER_AUTHENTICATION_EXIT_CODE = 4 as const
  * the parent rebuilds operator-facing remediation (no API/token material).
  */
 export const GITHUB_HELPER_TLS_TRUST_EXIT_CODE = 5 as const
+/**
+ * Typed helper exit for HTTP 403 permission (secret too narrow). Distinct from
+ * 401 authentication so the parent can speak without reading helper output.
+ */
+export const GITHUB_HELPER_PERMISSION_EXIT_CODE = 6 as const
 
 export interface GitHubHelperThrottle {
   readonly retryAt: number

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -3164,13 +3164,26 @@ const makeRerunWorkflowRun =
         signal,
       },
     )
-    if (!response.ok) {
-      throw new GitHubHttpError({
-        statusCode: response.status,
-        headers: response.headers,
-        message: `Failed to rerun workflow run ${workflowRunId} for ${repository.owner}/${repository.name}: ${response.statusText}: ${await response.text()}`,
-      })
+    if (response.ok) {
+      return
     }
+    const body = await response.text()
+    const throttle = githubThrottleFromResponse({
+      statusCode: response.status,
+      headers: response.headers,
+      message: `${response.statusText}: ${body}`,
+    })
+    if (throttle !== undefined) {
+      throw throttle
+    }
+    throw new GitHubHttpError({
+      statusCode: response.status,
+      headers: response.headers,
+      message:
+        response.status === 403
+          ? `Failed to rerun workflow run ${workflowRunId} for ${repository.owner}/${repository.name}: Actions write required`
+          : `Failed to rerun workflow run ${workflowRunId} for ${repository.owner}/${repository.name}: ${response.statusText}: ${body}`,
+    })
   }
 
 const makeUploadUserAttachment =

--- a/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
+++ b/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
@@ -5,11 +5,12 @@
  *
  * Contracts match {@link GitHubService.countOpenNonDraftPullRequests}:
  * paginated OPEN PRs, draft exclusion, 30s request timeout, two retries with
- * 500ms delay (no retry on HTTP 401), repository-unavailable when GitHub
+ * 500ms delay (no retry on HTTP 401 or 403), repository-unavailable when GitHub
  * returns a null repository.
  */
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
+  GITHUB_HELPER_PERMISSION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
   GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   type GitHubHelperThrottle,
@@ -278,7 +279,7 @@ const withTimeoutAndRetry = async <A>(
         error.statusCode = statusCode
       }
       lastError = error
-      if (statusCode === 401 || attempt >= MAX_RETRIES) {
+      if (statusCode === 401 || statusCode === 403 || attempt >= MAX_RETRIES) {
         throw error
       }
       attempt += 1
@@ -467,7 +468,11 @@ export const runOpenNonDraftPullRequestCountCli = async (
     }
     return {
       exitCode:
-        result.statusCode === 401 ? GITHUB_HELPER_AUTHENTICATION_EXIT_CODE : 1,
+        result.statusCode === 401
+          ? GITHUB_HELPER_AUTHENTICATION_EXIT_CODE
+          : result.statusCode === 403
+            ? GITHUB_HELPER_PERMISSION_EXIT_CODE
+            : 1,
       stdout: "",
       stderr: "Failed to count open pull requests\n",
     }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -21,6 +21,9 @@ import {
   formatUserFacingError,
   isDeterministicForgeAuthFailure,
   isDeterministicForgeAuthHttpStatus,
+  isGitHubClientRejection,
+  isGitHubPermissionError,
+  isGitHubRequestError,
   logErrorAnnotations,
   makeGitHubServiceFromToken,
   makeGitHubServiceTest,
@@ -1958,6 +1961,91 @@ describe("GitHubService live implementation", () => {
       "POST https://api.github.com/repos/acme/widgets/actions/runs/29906669357/rerun",
     ])
   })
+
+  it("accepts HTTP 204 as a successful workflow rerun", async () => {
+    const service = makeGitHubServiceFromToken("token", async (input, init) => {
+      if (
+        String(input).includes("/actions/runs/204/rerun") &&
+        init?.method === "POST"
+      ) {
+        return new Response(null, { status: 204 })
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" })
+    })
+
+    await Effect.runPromise(service.rerunWorkflowRun(repository, 204))
+  })
+
+  it.effect(
+    "maps a permission 403 on workflow rerun without copying the GitHub body",
+    () =>
+      Effect.gen(function* () {
+        const service = makeGitHubServiceFromToken(
+          "token",
+          async (input, init) => {
+            if (
+              String(input).includes("/actions/runs/33232172979/rerun") &&
+              init?.method === "POST"
+            ) {
+              return new Response(
+                JSON.stringify({
+                  message: "Resource not accessible by personal access token",
+                  documentation_url:
+                    "https://docs.github.com/rest/actions/workflow-runs",
+                }),
+                {
+                  status: 403,
+                  statusText: "Forbidden",
+                  headers: {
+                    "X-Accepted-GitHub-Permissions": "actions=write",
+                  },
+                },
+              )
+            }
+            return new Response("not found", { status: 404 })
+          },
+        )
+
+        const error = yield* service
+          .rerunWorkflowRun(repository, 33232172979)
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(error.statusCode).toBe(403)
+        expect(error.retryable).toBe(false)
+        expect(error.message).not.toContain(
+          "Resource not accessible by personal access token",
+        )
+        expect(error.message).not.toContain("documentation_url")
+        expect(formatUserFacingError(error)).not.toContain(
+          "Resource not accessible by personal access token",
+        )
+      }),
+  )
+
+  it.effect(
+    "keeps a throttled 403 on workflow rerun as GitHub throttling",
+    () =>
+      Effect.gen(function* () {
+        const resetSeconds = Math.floor(Date.now() / 1_000) + 120
+        const service = makeGitHubServiceFromToken("token", async () => {
+          return new Response("API rate limit exceeded", {
+            status: 403,
+            headers: {
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": String(resetSeconds),
+            },
+          })
+        })
+
+        const error = yield* service
+          .rerunWorkflowRun(repository, 1)
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubThrottledError)
+        expect(error.retryAt).toBe(resetSeconds * 1_000)
+      }),
+  )
 
   it("uploads a user attachment and returns the GitHub CDN URL", async () => {
     const dir = await mkdtemp(join(tmpdir(), "rfa-upload-"))
@@ -4638,6 +4726,24 @@ describe("user-facing error formatting", () => {
     expect(isDeterministicForgeAuthHttpStatus(401)).toBe(true)
     expect(isDeterministicForgeAuthHttpStatus(403)).toBe(true)
     expect(isDeterministicForgeAuthHttpStatus(503)).toBe(false)
+    const permission = new GitHubRequestError({
+      message: "Failed to rerun workflow run for acme/widgets",
+      statusCode: 403,
+    })
+    const unauthorized = new GitHubRequestError({
+      message: "Failed to rerun workflow run for acme/widgets",
+      statusCode: 401,
+    })
+    const serverError = new GitHubRequestError({
+      message: "Failed to rerun workflow run for acme/widgets",
+      statusCode: 502,
+    })
+    expect(isGitHubRequestError(permission)).toBe(true)
+    expect(isGitHubPermissionError(permission)).toBe(true)
+    expect(isGitHubPermissionError(unauthorized)).toBe(false)
+    expect(isGitHubClientRejection(permission)).toBe(true)
+    expect(isGitHubClientRejection(unauthorized)).toBe(true)
+    expect(isGitHubClientRejection(serverError)).toBe(false)
     expect(
       extractHttpStatus(
         new GitHubRequestError({

--- a/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
+++ b/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, test } from "vitest"
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
+  GITHUB_HELPER_PERMISSION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
   GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   parseGitHubHelperControl,
@@ -384,6 +385,30 @@ describe("runOpenNonDraftPullRequestCountCli", () => {
     )
 
     expect(result.exitCode).toBe(GITHUB_HELPER_AUTHENTICATION_EXIT_CODE)
+  })
+
+  test("preserves HTTP 403 as the permission exit code", async () => {
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/widgets")],
+      {
+        env: { GITHUB_TOKEN: "read-only-token" },
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              message: "Resource not accessible by personal access token",
+            }),
+            {
+              status: 403,
+              statusText: "Forbidden",
+            },
+          ),
+      },
+    )
+
+    expect(result.exitCode).toBe(GITHUB_HELPER_PERMISSION_EXIT_CODE)
+    expect(result.stderr).not.toContain(
+      "Resource not accessible by personal access token",
+    )
   })
 
   test("serializes TLS trust failures as versioned non-secret control", async () => {

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -11,6 +11,8 @@ import {
   type PrStatusCheckDiagnostic,
   type PullRequestCheckStatus,
   type TerminalPrStatusCheck,
+  isGitHubClientRejection,
+  isGitHubPermissionError,
   isGitHubThrottledError,
   isRecognizedAutomatedReviewerName,
   workflowNameFromCheckName,
@@ -158,6 +160,17 @@ export const automatedReviewIncompleteRerunLimitReason = (
   workflowIdentity: string,
 ): string =>
   `Automated review ${workflowIdentity} is still incomplete after autonomous recovery was already used on this workflow run; inspect or run that GitHub review workflow or check manually, then Retry checks.`
+
+/** Published operator list of minimum Forge token scopes. */
+const FORGE_TOKEN_SCOPES_DOC_URL =
+  "https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md"
+
+/**
+ * Operator-facing copy when GitHub refuses a workflow rerun because the
+ * repository token cannot write Actions. Retry checks stays available.
+ */
+export const actionsWriteRequiredRerunReason = (): string =>
+  `The repository token cannot rerun GitHub Actions workflows. Recreate it with Create token so Actions is Read and write, then Retry checks. Minimum scopes: ${FORGE_TOKEN_SCOPES_DOC_URL}`
 
 interface ObservedPrStatusCheckRow {
   readonly id: string
@@ -572,8 +585,11 @@ const reserveAutomatedReviewRerun = (
     return { _tag: "reserved" as const, id }
   })
 
-/** A confirmed GitHub throttle never started the rerun, so it consumes no budget. */
-const releaseThrottledAutomatedReviewRerun = (permitId: string) =>
+/**
+ * A confirmed GitHub rejection never started the rerun, so it consumes no
+ * budget. Used for throttle, 403 permission, and other 4xx client rejections.
+ */
+const releaseReservedAutomatedReviewRerun = (permitId: string) =>
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
     yield* sql.unsafe(
@@ -581,6 +597,40 @@ const releaseThrottledAutomatedReviewRerun = (permitId: string) =>
        WHERE id = ? AND status = 'reserved'`,
       [permitId],
     )
+  })
+
+const settleAuthorizedReviewRerunFailure = (
+  permitId: string,
+  failure: unknown,
+  handledCheckIds: readonly string[],
+) =>
+  Effect.gen(function* () {
+    if (isGitHubThrottledError(failure)) {
+      yield* releaseReservedAutomatedReviewRerun(permitId)
+      return yield* failure
+    }
+    if (isGitHubPermissionError(failure)) {
+      yield* releaseReservedAutomatedReviewRerun(permitId)
+      return {
+        _tag: "needs_human" as const,
+        reason: actionsWriteRequiredRerunReason(),
+        handledCheckIds,
+      } satisfies PrStatusCheckInvestigationResult
+    }
+    if (isGitHubClientRejection(failure)) {
+      yield* releaseReservedAutomatedReviewRerun(permitId)
+    }
+    const detail =
+      typeof failure === "object" &&
+      failure !== null &&
+      "message" in failure &&
+      typeof failure.message === "string" &&
+      failure.message.trim() !== ""
+        ? failure.message
+        : "GitHub workflow rerun failed"
+    return yield* new PrStatusChecksUnresolvedError({
+      message: `Manual fixing may be required. ${detail}. Please fix or rerun the checks on GitHub, then click Retry checks.`,
+    })
   })
 
 /** Mark the permit complete and record the Check-Start Anchor together. */
@@ -963,20 +1013,11 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
             github.rerunWorkflowRun(repository, evidence.workflowRunId),
           )
           if (rerunResult._tag === "Failure") {
-            if (isGitHubThrottledError(rerunResult.failure)) {
-              yield* releaseThrottledAutomatedReviewRerun(permit.id)
-              return yield* rerunResult.failure
-            }
-            const detail =
-              "_tag" in rerunResult.failure &&
-              "message" in rerunResult.failure &&
-              typeof rerunResult.failure.message === "string" &&
-              rerunResult.failure.message.trim() !== ""
-                ? rerunResult.failure.message
-                : "GitHub workflow rerun failed"
-            return yield* new PrStatusChecksUnresolvedError({
-              message: `Manual fixing may be required. ${detail}. Please fix or rerun the checks on GitHub, then click Retry checks.`,
-            })
+            return yield* settleAuthorizedReviewRerunFailure(
+              permit.id,
+              rerunResult.failure,
+              handledCheckIds,
+            )
           }
           yield* completeAuthorizedReviewRerun(
             permit.id,
@@ -1264,22 +1305,11 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
         github.rerunWorkflowRun(repository, investigation.workflowRunId),
       )
       if (rerunResult._tag === "Failure") {
-        if (isGitHubThrottledError(rerunResult.failure)) {
-          yield* releaseThrottledAutomatedReviewRerun(permit.id)
-          return yield* rerunResult.failure
-        }
-        // Reservation remains so a crash or indeterminate response cannot
-        // unlock unbounded extra GitHub rerun calls after restart.
-        const detail =
-          "_tag" in rerunResult.failure &&
-          "message" in rerunResult.failure &&
-          typeof rerunResult.failure.message === "string" &&
-          rerunResult.failure.message.trim() !== ""
-            ? rerunResult.failure.message
-            : "GitHub workflow rerun failed"
-        return yield* new PrStatusChecksUnresolvedError({
-          message: `Manual fixing may be required. ${detail}. Please fix or rerun the checks on GitHub, then click Retry checks.`,
-        })
+        return yield* settleAuthorizedReviewRerunFailure(
+          permit.id,
+          rerunResult.failure,
+          handledCheckIds,
+        )
       }
       yield* completeAuthorizedReviewRerun(
         permit.id,

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -33,6 +33,7 @@ import {
   AUTOMATED_REVIEW_INCOMPLETE_RERUN_LIMIT,
   AUTOMATED_REVIEW_RERUN_LIMIT,
   type LifecycleStepContext,
+  actionsWriteRequiredRerunReason,
   automatedReviewIncompleteRerunLimitReason,
   automatedReviewRerunLimitReason,
   formatAutomatedReviewWorkflowIdentity,
@@ -45,6 +46,10 @@ import {
   watchPrStatusChecks,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
+
+/** Spec-derived operator copy for Actions-write 403 (issue #1237), not recomputed from production. */
+const ACTIONS_WRITE_REQUIRED_RERUN_COPY =
+  "The repository token cannot rerun GitHub Actions workflows. Recreate it with Create token so Actions is Read and write, then Retry checks. Minimum scopes: https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md"
 
 const repository = makeRepositoryRecord({ localPath: "/repos/widgets" })
 const mergeable = {
@@ -2982,6 +2987,9 @@ describe("PR status check steps", () => {
     ).toBe(
       'Automated review workflow "Claude Code Review" is still incomplete after autonomous recovery was already used on this workflow run; inspect or run that GitHub review workflow or check manually, then Retry checks.',
     )
+    expect(actionsWriteRequiredRerunReason()).toBe(
+      ACTIONS_WRITE_REQUIRED_RERUN_COPY,
+    )
     expect(
       automatedReviewRerunLimitReason(
         formatAutomatedReviewWorkflowIdentity("Claude Code Review"),
@@ -3108,6 +3116,158 @@ describe("PR status check steps", () => {
     )
 
     expect(rerunIds).toEqual([workflowRunId])
+  })
+
+  it("hands off a 403 incomplete recovery rerun as a credential problem without spending the budget", async () => {
+    const rerunIds: number[] = []
+    const headSha = "sha-incomplete-403"
+    const workflowRunId = 33232172979
+    const greenStatus = {
+      _tag: "succeeded" as const,
+      ...mergeable,
+      headSha,
+      terminalChecks: [
+        {
+          externalId: "actions-job:review",
+          name: "Claude Code Review/claude-review",
+          outcome: "green" as const,
+        },
+      ],
+    }
+    const incompleteEvidence = {
+      _tag: "incomplete" as const,
+      signature: INCOMPLETE_AUTOMATED_REVIEW_SIGNATURE,
+      workflowRunId,
+      workflowName: "Claude Code Review",
+      detail: "Visibly incomplete automated review comment from claude[bot]",
+    }
+    let acceptRerun = false
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        const sql = yield* SqlClient.SqlClient
+        const now = Date.now()
+        yield* sql.unsafe(
+          `INSERT INTO pr_status_check (
+             id, work_item_id, external_id, name, outcome,
+             handled_at, observed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, 'Claude Code Review/claude-review', 'green', NULL, ?, ?, ?)`,
+          [
+            "psc-incomplete-403-1",
+            context.workItemId,
+            "actions-job:review-403-1",
+            now,
+            now,
+            now,
+          ],
+        )
+        const first = yield* investigatePrStatusChecks(context)
+        expect(first._tag).toBe("needs_human")
+        if (first._tag === "needs_human") {
+          expect(first.reason).toBe(ACTIONS_WRITE_REQUIRED_RERUN_COPY)
+          expect(first.reason).not.toContain(
+            "fix or rerun the checks on GitHub",
+          )
+          expect(first.reason).not.toContain("Failed to rerun workflow run")
+          expect(first.handledCheckIds).toEqual(["psc-incomplete-403-1"])
+        }
+        const afterDenied = (yield* sql.unsafe(
+          `SELECT COUNT(*) AS count FROM automated_review_rerun
+           WHERE work_item_id = ? AND head_sha = ? AND workflow_run_id = ?`,
+          [context.workItemId, headSha, String(workflowRunId)],
+        )) as readonly { readonly count: number }[]
+        expect(Number(afterDenied[0]?.count)).toBe(0)
+
+        yield* sql.unsafe(
+          `UPDATE pr_status_check
+           SET handled_at = ?, updated_at = ?
+           WHERE id = ?`,
+          [Date.now(), Date.now(), "psc-incomplete-403-1"],
+        )
+        yield* sql.unsafe(
+          `INSERT INTO pr_status_check (
+             id, work_item_id, external_id, name, outcome,
+             handled_at, observed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, 'Claude Code Review/claude-review', 'green', NULL, ?, ?, ?)`,
+          [
+            "psc-incomplete-403-2",
+            context.workItemId,
+            "actions-job:review-403-2",
+            Date.now(),
+            Date.now(),
+            Date.now(),
+          ],
+        )
+        const second = yield* investigatePrStatusChecks(context)
+        expect(second._tag).toBe("needs_human")
+        if (second._tag === "needs_human") {
+          expect(second.reason).toBe(ACTIONS_WRITE_REQUIRED_RERUN_COPY)
+        }
+
+        acceptRerun = true
+        yield* sql.unsafe(
+          `UPDATE pr_status_check
+           SET handled_at = ?, updated_at = ?
+           WHERE id = ?`,
+          [Date.now(), Date.now(), "psc-incomplete-403-2"],
+        )
+        yield* sql.unsafe(
+          `INSERT INTO pr_status_check (
+             id, work_item_id, external_id, name, outcome,
+             handled_at, observed_at, created_at, updated_at
+           ) VALUES (?, ?, ?, 'Claude Code Review/claude-review', 'green', NULL, ?, ?, ?)`,
+          [
+            "psc-incomplete-403-3",
+            context.workItemId,
+            "actions-job:review-403-3",
+            Date.now(),
+            Date.now(),
+            Date.now(),
+          ],
+        )
+        const recovered = yield* investigatePrStatusChecks(context)
+        expect(recovered).toEqual({
+          _tag: "checks_triggered",
+          handledCheckIds: ["psc-incomplete-403-3"],
+          checkStartAnchorRecorded: true,
+        })
+        const permits = (yield* sql.unsafe(
+          `SELECT status FROM automated_review_rerun
+           WHERE work_item_id = ? AND head_sha = ? AND workflow_run_id = ?`,
+          [context.workItemId, headSha, String(workflowRunId)],
+        )) as readonly { readonly status: string }[]
+        expect(permits).toEqual([{ status: "completed" }])
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith(greenStatus, {
+              observeAutomatedReviewEvidence: () =>
+                Effect.succeed(incompleteEvidence),
+              rerunWorkflowRun: (_repo, runId) => {
+                rerunIds.push(runId)
+                return acceptRerun
+                  ? Effect.void
+                  : Effect.fail(
+                      new GitHubRequestError({
+                        message:
+                          "Failed to rerun workflow run for acme/widgets",
+                        statusCode: 403,
+                        retryable: false,
+                      }),
+                    )
+              },
+            }),
+            keymaxxer,
+            opencodeWith(["should not run for harness-classified incomplete"]),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(rerunIds).toEqual([workflowRunId, workflowRunId, workflowRunId])
   })
 
   it("treats legacy null-signature agent reruns as spent incomplete recovery", async () => {
@@ -3680,6 +3840,144 @@ describe("PR status check steps", () => {
     )
 
     expect(rerunCalls).toBe(AUTOMATED_REVIEW_RERUN_LIMIT + 1)
+  })
+
+  it("hands off a 403 agent RERUN_REVIEW as a credential problem without spending the budget", async () => {
+    const workflowRunId = 33232172979
+    let acceptRerun = false
+    const status = {
+      _tag: "succeeded" as const,
+      ...mergeable,
+      headSha: "sha-agent-403",
+      terminalChecks: [
+        {
+          externalId: "actions-job:review",
+          name: "Claude Code Review/claude-review",
+          outcome: "green" as const,
+        },
+      ],
+    }
+    const rerunVerdict = `READY_FOR_AGENT_RESULT: RERUN_REVIEW: ${workflowRunId} Claude Code Review`
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        const sql = yield* SqlClient.SqlClient
+        const denied = yield* investigatePrStatusChecks(context)
+        expect(denied._tag).toBe("needs_human")
+        if (denied._tag === "needs_human") {
+          expect(denied.reason).toBe(ACTIONS_WRITE_REQUIRED_RERUN_COPY)
+          expect(denied.reason).not.toContain(
+            "fix or rerun the checks on GitHub",
+          )
+        }
+        const afterDenied = (yield* sql.unsafe(
+          `SELECT COUNT(*) AS count FROM automated_review_rerun WHERE work_item_id = ?`,
+          [context.workItemId],
+        )) as readonly { readonly count: number }[]
+        expect(Number(afterDenied[0]?.count)).toBe(0)
+
+        acceptRerun = true
+        const recovered = yield* investigatePrStatusChecks(context)
+        expect(recovered).toEqual({
+          _tag: "checks_triggered",
+          handledCheckIds: [expect.any(String)],
+          checkStartAnchorRecorded: true,
+        })
+        const permits = (yield* sql.unsafe(
+          `SELECT status FROM automated_review_rerun WHERE work_item_id = ?`,
+          [context.workItemId],
+        )) as readonly { readonly status: string }[]
+        expect(permits).toEqual([{ status: "completed" }])
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith(status, {
+              rerunWorkflowRun: () =>
+                acceptRerun
+                  ? Effect.void
+                  : Effect.fail(
+                      new GitHubRequestError({
+                        message:
+                          "Failed to rerun workflow run for acme/widgets",
+                        statusCode: 403,
+                        retryable: false,
+                      }),
+                    ),
+            }),
+            keymaxxer,
+            opencodeWith([rerunVerdict, rerunVerdict]),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("keeps a 401 review rerun as the existing authentication failure", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        const sql = yield* SqlClient.SqlClient
+        const investigation = yield* Effect.result(
+          investigatePrStatusChecks(context),
+        )
+        const permits = (yield* sql.unsafe(
+          `SELECT COUNT(*) AS count FROM automated_review_rerun WHERE work_item_id = ?`,
+          [context.workItemId],
+        )) as readonly { readonly count: number }[]
+        return { investigation, permitCount: Number(permits[0]?.count) }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith(
+              {
+                _tag: "succeeded",
+                ...mergeable,
+                headSha: "sha-401-rerun",
+                terminalChecks: [
+                  {
+                    externalId: "actions-job:1",
+                    name: "review",
+                    outcome: "green",
+                  },
+                ],
+              },
+              {
+                rerunWorkflowRun: () =>
+                  Effect.fail(
+                    new GitHubRequestError({
+                      message: "Failed to rerun workflow run for acme/widgets",
+                      statusCode: 401,
+                    }),
+                  ),
+              },
+            ),
+            keymaxxer,
+            opencodeWith([
+              "need rerun\nREADY_FOR_AGENT_RESULT: RERUN_REVIEW: 99 Review Bot",
+            ]),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(result.investigation._tag).toBe("Failure")
+    if (result.investigation._tag === "Failure") {
+      expect(result.investigation.failure.message).toContain(
+        "Failed to rerun workflow run",
+      )
+      expect(result.investigation.failure.message).not.toContain("Create token")
+      expect(result.investigation.failure.message).not.toContain(
+        "cannot rerun GitHub Actions",
+      )
+    }
+    expect(result.permitCount).toBe(0)
   })
 
   it("keeps a reserved permit when the GitHub rerun response is indeterminate", async () => {


### PR DESCRIPTION
When an incomplete automated review needed a workflow rerun, a PAT that could read Actions but not write them failed GitHub with 403. That signal was dropped at the credential boundary, so the card looked like a CI failure (“fix or rerun the checks on GitHub”). The harness had already reserved the one incomplete-review rerun, so Retry checks then reported the budget spent even after a correct token was minted. Create token has requested Actions write since #371; existing fine-grained PATs are not upgraded in place.

Investigate PR Status Checks now hands off to Needs Human as a credential problem: recreate the repository token with Create token so Actions is Read and write, then Retry checks. A GitHub 403 on the rerun POST is a typed permission failure (sibling of today’s 401 helper exit). Helper output and GitHub JSON are not copied into GraphQL.

The reserved review-rerun permit is deleted when GitHub rejects the call (403 and other 4xx). It is completed only after GitHub accepts (201/204). Incomplete recovery (limit 1) and agent `RERUN_REVIEW` (limit 3) both use that rule. Throttle still postpones. 401 stays the existing authentication failure.

Unchanged: Create token scopes, Checks API 403 fallback, Watch / job-log / Create PR on Actions read, no startup PAT probe, no automatic secret rotation. GitHub’s own rerun UI remains an escape hatch.

Verified at Investigate with a 403 GitHub double (Needs Human, credential copy, zero reserved permits; a later success still spends one permit and re-anchors Watch) and at the Keymaxxer helper layer (permission exit → HTTP 403 without helper stderr; 401 remains distinct).

Closes #1237