### PR TITLE
feat(lifecycle): return Implement With as a one-element Work Item list

### DIFF
--- a/.agents/skills/ready-for-agent/references/graphql-api.md
+++ b/.agents/skills/ready-for-agent/references/graphql-api.md
@@ -156,7 +156,7 @@ frequently comes back `MISSING` with null fields — that is expected, not a bug
 | --- | --- |
 | `implementNow(repositoryId, issueNumber)` | Full run: implement → review → PR → merge if allowed |
 | `implementLocally(repositoryId, issueNumber)` | Stops before commit/PR so a human can inspect |
-| `implementWith(repositoryId, issueNumber, profile, options)` | Run with a pinned backend/model profile |
+| `implementWith(repositoryId, issueNumber, profile, options)` | Run with a pinned backend/model profile; returns a one-element Work Item list |
 | `implementAllWithAutoMerge(repositoryId, issueNumber)` | Parent issue → implements all children, merge policy Always |
 | `queue(repositoryId, issueNumber)` | Enqueue rather than start immediately |
 | `startRepositoryIntake(repositoryId)` | Start **every** current candidate — check `intakeCandidates` first |

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -3269,8 +3269,10 @@ function RepositoryIssueRow({
       })
       return result.implementWith
     },
-    onSuccess: (workItem) => {
+    onSuccess: (workItems) => {
       setImplementWithOpen(false)
+      const [workItem] = workItems
+      if (workItem === undefined) return
       onImplementSuccess(workItem)
       void queryClient.invalidateQueries({
         queryKey: ["agentBackendStatus"],

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -859,6 +859,24 @@ describe("ImplementWithDialog interaction", () => {
   })
 })
 
+describe("Implement With leaf dialog caller", () => {
+  test("reads the mutation list's only Work Item", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/home-page-content.tsx"),
+      "utf8",
+    )
+    const start = source.indexOf("const implementWith = useMutation")
+    expect(start).toBeGreaterThan(-1)
+    const caller = source.slice(
+      start,
+      source.indexOf("const implementLocally = useMutation", start),
+    )
+    expect(caller).toContain("return result.implementWith")
+    expect(caller).toContain("const [workItem] = workItems")
+    expect(caller).toContain("onImplementSuccess(workItem)")
+  })
+})
+
 describe("Implement With preview query contract", () => {
   test("does not refetch the preview on focus, reconnect, or an interval", () => {
     const source = readFileSync(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -58,6 +58,7 @@ import {
   AutonomousRetryLimitReachedError,
   InvalidExecutionProfileError,
   IssueNotFoundError,
+  ParentIssueError,
   RetryNotEligibleError,
   STEP_RUN_REASON,
   SessionIdAmbiguousError,
@@ -5195,12 +5196,14 @@ describe("GraphQL API", () => {
             reviewThinkingLevel: null,
           })
           expect(options).toBeUndefined()
-          return Effect.succeed({
-            ...profiled,
-            mergeMode: "ordinary" as const,
-            autoMergeOverride: null,
-            pauseBeforeStep: null,
-          })
+          return Effect.succeed([
+            {
+              ...profiled,
+              mergeMode: "ordinary" as const,
+              autoMergeOverride: null,
+              pauseBeforeStep: null,
+            },
+          ])
         },
       },
     )
@@ -5244,21 +5247,129 @@ describe("GraphQL API", () => {
     )
     expect(await response.json()).toEqual({
       data: {
-        implementWith: {
-          id: workItem.id,
-          executionProfile: {
-            backend: { id: "opencode", label: "OpenCode" },
-            buildModel: "build-model",
-            buildThinkingLevel: "high",
-            reviewSameAsBuild: true,
-            reviewModel: "build-model",
-            reviewThinkingLevel: "high",
+        implementWith: [
+          {
+            id: workItem.id,
+            executionProfile: {
+              backend: { id: "opencode", label: "OpenCode" },
+              buildModel: "build-model",
+              buildThinkingLevel: "high",
+              reviewSameAsBuild: true,
+              reviewModel: "build-model",
+              reviewThinkingLevel: "high",
+            },
+            mergePolicy: null,
+            mergeMode: "ORDINARY",
+            pauseBeforeStep: null,
           },
-          mergePolicy: null,
-          mergeMode: "ORDINARY",
-          pauseBeforeStep: null,
-        },
+        ],
       },
+    })
+  })
+
+  test("implementWith returns a one-element Work Item list", async () => {
+    const profiled = {
+      ...workItem,
+      executionProfile: {
+        agentBackend: "opencode",
+        build: { model: "build-model", thinkingLevel: "high" },
+        review: { kind: "same_as_build" as const },
+      },
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        implementWith: () => Effect.succeed([profiled]),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation ImplementWith(
+          $repositoryId: ID!
+          $issueNumber: Int!
+          $profile: ExplicitWorkItemExecutionProfileInput!
+        ) {
+          implementWith(
+            repositoryId: $repositoryId
+            issueNumber: $issueNumber
+            profile: $profile
+          ) {
+            id
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+          profile: {
+            agentBackendId: "opencode",
+            buildModel: "build-model",
+            reviewSameAsBuild: true,
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        implementWith: [{ id: workItem.id }],
+      },
+    })
+  })
+
+  test("implementWith on a Parent Issue still fails as not a leaf", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        implementWith: () =>
+          Effect.fail(
+            new ParentIssueError({
+              repositoryId: repository.id,
+              issueNumber: 10,
+            }),
+          ),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation ImplementWith(
+          $repositoryId: ID!
+          $issueNumber: Int!
+          $profile: ExplicitWorkItemExecutionProfileInput!
+        ) {
+          implementWith(
+            repositoryId: $repositoryId
+            issueNumber: $issueNumber
+            profile: $profile
+          ) {
+            id
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: 10,
+          profile: {
+            agentBackendId: "opencode",
+            buildModel: "build-model",
+            reviewSameAsBuild: true,
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "Issue #10 has child issues and must target a leaf Issue",
+          extensions: expect.objectContaining({
+            code: "ISSUE_IS_PARENT",
+          }),
+        }),
+      ],
     })
   })
 
@@ -5334,7 +5445,7 @@ describe("GraphQL API", () => {
             mergePolicy: "classify",
             implementLocally: true,
           })
-          return Effect.succeed(profiled)
+          return Effect.succeed([profiled])
         },
       },
     )
@@ -5371,11 +5482,13 @@ describe("GraphQL API", () => {
     )
     expect(await response.json()).toEqual({
       data: {
-        implementWith: {
-          mergePolicy: "CLASSIFY",
-          mergeMode: "ORDINARY",
-          pauseBeforeStep: "COMMIT",
-        },
+        implementWith: [
+          {
+            mergePolicy: "CLASSIFY",
+            mergeMode: "ORDINARY",
+            pauseBeforeStep: "COMMIT",
+          },
+        ],
       },
     })
   })
@@ -5403,7 +5516,7 @@ describe("GraphQL API", () => {
             mergePolicy: "always",
             implementLocally: false,
           })
-          return Effect.succeed(profiled)
+          return Effect.succeed([profiled])
         },
       },
     )
@@ -5440,11 +5553,13 @@ describe("GraphQL API", () => {
     )
     expect(await response.json()).toEqual({
       data: {
-        implementWith: {
-          mergePolicy: "ALWAYS",
-          mergeMode: "ALWAYS",
-          pauseBeforeStep: null,
-        },
+        implementWith: [
+          {
+            mergePolicy: "ALWAYS",
+            mergeMode: "ALWAYS",
+            pauseBeforeStep: null,
+          },
+        ],
       },
     })
   })
@@ -5472,7 +5587,7 @@ describe("GraphQL API", () => {
             mergePolicy: "off",
             implementLocally: false,
           })
-          return Effect.succeed(profiled)
+          return Effect.succeed([profiled])
         },
       },
     )
@@ -5509,11 +5624,13 @@ describe("GraphQL API", () => {
     )
     expect(await response.json()).toEqual({
       data: {
-        implementWith: {
-          mergePolicy: "OFF",
-          mergeMode: "ORDINARY",
-          pauseBeforeStep: null,
-        },
+        implementWith: [
+          {
+            mergePolicy: "OFF",
+            mergeMode: "ORDINARY",
+            pauseBeforeStep: null,
+          },
+        ],
       },
     })
   })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -1113,14 +1113,15 @@ type Mutation {
   Item Execution Profile. Submission activates and inspects an otherwise
   inactive shipped Agent Backend under the settings/create coordination
   boundary. Partial profiles cannot be represented. Failure creates nothing
-  and leaves saved defaults unchanged.
+  and leaves saved defaults unchanged. Returns a list whose only element is
+  that Work Item. A Parent Issue is rejected as not a leaf.
   """
   implementWith(
     repositoryId: ID!
     issueNumber: Int!
     profile: ExplicitWorkItemExecutionProfileInput!
     options: ImplementWithOptionsInput
-  ): WorkItem!
+  ): [WorkItem!]!
   """
   Create a Work Item that runs local steps through Review, then pauses before Commit.
   """

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -1091,14 +1091,15 @@ type Mutation {
   Item Execution Profile. Submission activates and inspects an otherwise
   inactive shipped Agent Backend under the settings/create coordination
   boundary. Partial profiles cannot be represented. Failure creates nothing
-  and leaves saved defaults unchanged.
+  and leaves saved defaults unchanged. Returns a list whose only element is
+  that Work Item. A Parent Issue is rejected as not a leaf.
   """
   implementWith(
     repositoryId: ID!
     issueNumber: Int!
     profile: ExplicitWorkItemExecutionProfileInput!
     options: ImplementWithOptionsInput
-  ): WorkItem!
+  ): [WorkItem!]!
   """
   Create a Work Item that runs local steps through Review, then pauses before Commit.
   """

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1025,12 +1025,17 @@ export interface WorkItemLifecycleShape {
     repositoryId: string,
     issueNumber: number,
   ) => Effect.Effect<WorkItemRecord, ImplementNowError>
+  /**
+   * Create a Work Item for an Actionable Issue with an Explicit Work Item
+   * Execution Profile. Returns a list whose only element is that Work Item.
+   * A Parent Issue is rejected as not a leaf.
+   */
   readonly implementWith: (
     repositoryId: string,
     issueNumber: number,
     profile: ImplementWithProfileInput,
     options?: ImplementWithOptionsInput,
-  ) => Effect.Effect<WorkItemRecord, ImplementWithError>
+  ) => Effect.Effect<readonly WorkItemRecord[], ImplementWithError>
   readonly implementLocally: (
     repositoryId: string,
     issueNumber: number,
@@ -7876,12 +7881,13 @@ export const makeWorkItemLifecycleLive = (
                   autoMergeOverride: null,
                 }
               : encodeWorkItemMergePolicyPin(options.mergePolicy)
-          return yield* createWorkItem(repositoryId, issueNumber, {
+          const created = yield* createWorkItem(repositoryId, issueNumber, {
             pauseBeforeStep: options.implementLocally ? "commit" : null,
             executionProfile: decoded,
             mergeMode: pin.mergeMode,
             autoMergeOverride: pin.autoMergeOverride,
           })
+          return [created]
         },
       )
 

--- a/packages/work-item-lifecycle/test/implement-with.spec.ts
+++ b/packages/work-item-lifecycle/test/implement-with.spec.ts
@@ -18,6 +18,7 @@ import {
   LifecycleSteps,
   type LifecycleStepsShape,
   AgentBackendUnavailableError as LifecycleUnavailableError,
+  ParentIssueError,
   STEP_RUN_REASON,
   UnfinishedWorkItemExistsError,
   WorkItemLifecycle,
@@ -207,6 +208,93 @@ const advanceToQueued = (
   })
 
 describe("implementWith", () => {
+  it("returns a one-element list containing the created Work Item", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          localPath: "/repos/acme/widgets-implement-with-list.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 1)
+        const created = yield* lifecycle.implementWith(
+          repo.id,
+          1,
+          explicitReviewProfile,
+          { mergePolicy: "classify", implementLocally: true },
+        )
+        expect(created).toHaveLength(1)
+        const workItem = created.at(0)
+        expect(workItem).toBeDefined()
+        if (workItem === undefined) return
+        expect(workItem.executionProfile).toEqual({
+          agentBackend: "opencode",
+          build: { model: "build-model", thinkingLevel: "high" },
+          review: {
+            kind: "explicit",
+            model: "review-model",
+            thinkingLevel: "max",
+          },
+        })
+        expect(workItem.mergeMode).toBe("ordinary")
+        expect(workItem.autoMergeOverride).toBe(true)
+        expect(workItem.pauseBeforeStep).toBe("commit")
+        const reloaded = yield* lifecycle.getWorkItem(workItem.id)
+        expect(reloaded.executionProfile).toEqual(workItem.executionProfile)
+      }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+    )
+  })
+
+  it("rejects a Parent Issue as not a leaf", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          localPath: "/repos/acme/widgets-implement-with-parent.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        yield* db.storeIssue({
+          repositoryId: repo.id,
+          issueNumber: 30,
+          title: "Parent",
+          body: "body",
+          url: "https://github.com/acme/widgets/issues/30",
+          state: "OPEN",
+          githubCreatedAt: new Date(),
+          issueAuthor: null,
+          parent: null,
+          parentPosition: null,
+          hasChildren: true,
+          blockedBy: [],
+        })
+        const error = yield* Effect.flip(
+          lifecycle.implementWith(repo.id, 30, sameAsBuildProfile, {
+            mergePolicy: "off",
+            implementLocally: false,
+          }),
+        )
+        expect(error).toBeInstanceOf(ParentIssueError)
+        expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 30)).toEqual([])
+      }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+    )
+  })
+
   it("creates a Work Item with a durable complete explicit profile", async () => {
     await Effect.runPromise(
       Effect.gen(function* () {
@@ -224,7 +312,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 1)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           1,
           explicitReviewProfile,
@@ -262,7 +350,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 2)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           2,
           sameAsBuildProfile,
@@ -358,7 +446,7 @@ describe("implementWith", () => {
         expect(
           yield* backends.getBackendStatus(AGENT_BACKEND_IDS.grok),
         ).toBeNull()
-        const created = yield* lifecycle.implementWith(repo.id, 5, {
+        const [created] = yield* lifecycle.implementWith(repo.id, 5, {
           ...sameAsBuildProfile,
           agentBackendId: "grok",
         })
@@ -471,7 +559,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 7)
-        const first = yield* lifecycle.implementWith(
+        const [first] = yield* lifecycle.implementWith(
           repo.id,
           7,
           sameAsBuildProfile,
@@ -512,7 +600,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 16)
-        const created = yield* lifecycle.implementWith(repo.id, 16, {
+        const [created] = yield* lifecycle.implementWith(repo.id, 16, {
           ...sameAsBuildProfile,
           agentBackendId: "grok",
         })
@@ -567,7 +655,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 8)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           8,
           explicitReviewProfile,
@@ -655,7 +743,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 9)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           9,
           sameAsBuildProfile,
@@ -718,7 +806,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 10)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           10,
           sameAsBuildProfile,
@@ -779,7 +867,7 @@ describe("implementWith", () => {
         yield* storeOpenLeafIssue(db, repo.id, 12)
         const first = yield* lifecycle.implementNow(repo.id, 11)
         expect(first.waitingSince).toBeNull()
-        const waiter = yield* lifecycle.implementWith(
+        const [waiter] = yield* lifecycle.implementWith(
           repo.id,
           12,
           sameAsBuildProfile,
@@ -814,7 +902,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 20)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           20,
           sameAsBuildProfile,
@@ -858,7 +946,7 @@ describe("implementWith", () => {
           waitForReadyForReviewChecks: true,
         })
         yield* storeOpenLeafIssue(db, repo.id, 21)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           21,
           sameAsBuildProfile,
@@ -902,7 +990,7 @@ describe("implementWith", () => {
           waitForReadyForReviewChecks: true,
         })
         yield* storeOpenLeafIssue(db, repo.id, 22)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           22,
           sameAsBuildProfile,
@@ -955,7 +1043,7 @@ describe("implementWith", () => {
           waitForReadyForReviewChecks: true,
         })
         yield* storeOpenLeafIssue(db, repo.id, 25)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           25,
           sameAsBuildProfile,
@@ -987,7 +1075,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 23)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           23,
           explicitReviewProfile,
@@ -1068,7 +1156,7 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 24)
-        const created = yield* lifecycle.implementWith(
+        const [created] = yield* lifecycle.implementWith(
           repo.id,
           24,
           sameAsBuildProfile,


### PR DESCRIPTION
## Why

Implement With currently returns a single Work Item. Parent enrollment (#1240 / #1242) needs the same command to return every covered child without a second mutation. This slice keeps leaf behavior and changes only the return shape.

## What Changed

On an Actionable Issue, Implement With still creates one Work Item with an Explicit Work Item Execution Profile, a concrete Merge Policy pin, and optional Implement Locally pause. The command and GraphQL mutation now return a list whose only element is that Work Item. Callers that omit options still leave Merge Policy unset and stay remote. A Parent Issue is still rejected as not a leaf.

The leaf Implement with... dialog still submits, cancels, and fails as before; on success it reads the list's only Work Item. Implement Now, Implement Locally, Queue, and Implement All with Auto-merge are unchanged.

## Verification

Covered at the existing Implement With command, GraphQL mutation, and leaf dialog caller seams: one-element list return, parent still fails as not a leaf, omitted options stay remote with Merge Policy unset, and existing profile/pin/pause cases. Harness typecheck passed. Review found no blocking issues.

Parent enrollment is the next ticket (#1242).

Closes #1241