### PR TITLE
feat(lifecycle): enroll a Parent Issue's children through Implement With

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -3077,12 +3077,44 @@ function ParentIssueGroup({
   readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
   const queryClient = useQueryClient()
+  const [implementWithOpen, setImplementWithOpen] = useState(false)
   const openChildren = childIssues.filter((child) => child.state === "OPEN")
   const canImplementAll = isParentImplementAllWithAutoMergeEligible({
     openChildren,
     directChildren: childIssues,
     workItemsLoading,
   })
+  const applyCoveredWorkItems = (covered: readonly WorkItem[]) => {
+    const byId = new Map(covered.map((item) => [item.id, item]))
+    for (const [queryKey] of queryClient.getQueriesData<readonly WorkItem[]>({
+      queryKey: ["work-items", parent.repositoryId],
+    })) {
+      // queryKey: ["work-items", repositoryId, listKind | null, limit | null]
+      const listKind = queryKey[2]
+      const allowAppend = listKind === null || listKind === "WORKING"
+      queryClient.setQueryData<readonly WorkItem[]>(queryKey, (current) => {
+        const next: WorkItem[] = []
+        const seen = new Set<string>()
+        for (const item of current ?? []) {
+          const updated = byId.get(item.id)
+          if (updated !== undefined) {
+            next.push(updated)
+            seen.add(item.id)
+          } else {
+            next.push(item)
+          }
+        }
+        if (allowAppend) {
+          for (const item of covered) {
+            if (!seen.has(item.id)) {
+              next.push(item)
+            }
+          }
+        }
+        return next
+      })
+    }
+  }
   const implementAll = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -3099,36 +3131,29 @@ function ParentIssueGroup({
     // Covered rows may be newly created or adopted (same id, updated mergeMode).
     // Update matching ids in every work-items cache; only append missing ids
     // into the default Issues list and Jobs WORKING (never Failed/Completed).
+    onSuccess: applyCoveredWorkItems,
+  })
+  const implementWith = useMutation({
+    mutationFn: async (input: ImplementWithSubmitInput) => {
+      const result = await graphql.mutation({
+        implementWith: {
+          __args: {
+            repositoryId: parent.repositoryId,
+            issueNumber: parent.issueNumber,
+            profile: input.profile,
+            options: input.options,
+          },
+          ...workItemFields,
+        },
+      })
+      return result.implementWith
+    },
     onSuccess: (covered) => {
-      const byId = new Map(covered.map((item) => [item.id, item]))
-      for (const [queryKey] of queryClient.getQueriesData<readonly WorkItem[]>({
-        queryKey: ["work-items", parent.repositoryId],
-      })) {
-        // queryKey: ["work-items", repositoryId, listKind | null, limit | null]
-        const listKind = queryKey[2]
-        const allowAppend = listKind === null || listKind === "WORKING"
-        queryClient.setQueryData<readonly WorkItem[]>(queryKey, (current) => {
-          const next: WorkItem[] = []
-          const seen = new Set<string>()
-          for (const item of current ?? []) {
-            const updated = byId.get(item.id)
-            if (updated !== undefined) {
-              next.push(updated)
-              seen.add(item.id)
-            } else {
-              next.push(item)
-            }
-          }
-          if (allowAppend) {
-            for (const item of covered) {
-              if (!seen.has(item.id)) {
-                next.push(item)
-              }
-            }
-          }
-          return next
-        })
-      }
+      setImplementWithOpen(false)
+      applyCoveredWorkItems(covered)
+      void queryClient.invalidateQueries({
+        queryKey: ["agentBackendStatus"],
+      })
     },
   })
 
@@ -3169,15 +3194,25 @@ function ParentIssueGroup({
               <ParentIssueActionsMenu
                 parentIssueNumber={parent.issueNumber}
                 menuId={parent.id}
-                pending={implementAll.isPending}
+                implementAllPending={implementAll.isPending}
+                implementWithPending={implementWith.isPending}
                 // Error Banner is in-flow under the summary (not under the kebab).
                 errorMessage={null}
-                onImplementAllWithAutoMerge={() => implementAll.mutate()}
+                onImplementAllWithAutoMerge={() => {
+                  implementWith.reset()
+                  implementAll.mutate()
+                }}
+                onImplementAllWith={() => {
+                  implementAll.reset()
+                  implementWith.reset()
+                  setImplementWithOpen(true)
+                }}
               />
             )}
           </span>
         </summary>
-        {implementAll.isError && (
+        {(implementAll.isError ||
+          (implementWith.isError && !implementWithOpen)) && (
           <Banner
             className={cx(ui.bannerCompact, ui.parentIssueError)}
             tone="alarm"
@@ -3185,9 +3220,12 @@ function ParentIssueGroup({
             role="alert"
           >
             {startWorkBannerMessage({
-              error: implementAll.error,
-              fallback:
-                "Could not start Implement all with auto-merge. Refresh the issues and try again.",
+              error: implementAll.isError
+                ? implementAll.error
+                : implementWith.error,
+              fallback: implementAll.isError
+                ? "Could not start Implement all with auto-merge. Refresh the issues and try again."
+                : "Could not start Implement all with... Refresh the issues and try again.",
             })}
           </Banner>
         )}
@@ -3204,6 +3242,37 @@ function ParentIssueGroup({
           ))}
         </ul>
       </details>
+      {implementWithOpen && (
+        <ImplementWithIssueDialog
+          issueNumber={parent.issueNumber}
+          target="parent"
+          repositoryId={repository.id}
+          initialBackendId={repository.effectiveAgentBackend}
+          repositoryPrefs={{
+            defaultModel: repository.defaultModel,
+            defaultThinkingLevel: repository.defaultThinkingLevel,
+            reviewModel: repository.reviewModel,
+            reviewThinkingLevel: repository.reviewThinkingLevel,
+          }}
+          initialMergePolicy={repository.mergePolicy}
+          submitPending={implementWith.isPending}
+          submitError={
+            implementWith.isError
+              ? startWorkBannerMessage({
+                  error: implementWith.error,
+                  fallback:
+                    "Could not start Implement all with... Refresh the issues and try again.",
+                })
+              : null
+          }
+          onSubmit={(input) => implementWith.mutate(input)}
+          onCancel={() => {
+            if (!implementWith.isPending) {
+              setImplementWithOpen(false)
+            }
+          }}
+        />
+      )}
     </li>
   )
 }

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -42,6 +42,7 @@ type ImplementWithBackendOption = {
 
 export type ImplementWithDialogProps = {
   readonly issueNumber: number
+  readonly target?: "leaf" | "parent"
   readonly backendId: string
   readonly backends: readonly ImplementWithBackendOption[]
   readonly configurationMode: string | null
@@ -121,6 +122,7 @@ const sameAsBuildDraft = (
  */
 export function ImplementWithDialog({
   issueNumber,
+  target = "leaf",
   backendId,
   backends,
   configurationMode,
@@ -268,7 +270,7 @@ export function ImplementWithDialog({
       }),
       options: {
         mergePolicy,
-        implementLocally,
+        implementLocally: target === "parent" ? false : implementLocally,
       },
     })
   }
@@ -283,11 +285,14 @@ export function ImplementWithDialog({
         <div className={ui.dialogHeader}>
           <p className={ui.dialogKicker}>Implement With</p>
           <h2 id={titleId} className={ui.dialogTitle}>
-            Implement issue #{issueNumber} with...
+            {target === "parent"
+              ? "Implement all with..."
+              : `Implement issue #${issueNumber} with...`}
           </h2>
           <p className={ui.dialogLede}>
-            These choices apply only to this Work Item. They never change
-            Repository settings or Harness Config.
+            {target === "parent"
+              ? "These choices apply to each new child Work Item. They never change Repository settings or Harness Config."
+              : "These choices apply only to this Work Item. They never change Repository settings or Harness Config."}
           </p>
         </div>
         <div className={ui.dialogBodySectioned}>
@@ -575,23 +580,27 @@ export function ImplementWithDialog({
                 Repository Merge Policy later changes.
               </span>
             </label>
-            <label className={ui.dialogCheck}>
-              <input
-                type="checkbox"
-                className={ui.dialogCheckInput}
-                name="implementLocally"
-                checked={implementLocally}
-                disabled={submitPending}
-                onChange={(event) => setImplementLocally(event.target.checked)}
-              />
-              Implement locally
-              <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
-                Pause after Review so you can inspect the worktree. Agent Turns
-                and dependency installation keep their current capabilities.
-                Start continues to Commit and PR creation. A No-Change Outcome
-                pauses before Close Issue.
-              </span>
-            </label>
+            {target === "leaf" && (
+              <label className={ui.dialogCheck}>
+                <input
+                  type="checkbox"
+                  className={ui.dialogCheckInput}
+                  name="implementLocally"
+                  checked={implementLocally}
+                  disabled={submitPending}
+                  onChange={(event) =>
+                    setImplementLocally(event.target.checked)
+                  }
+                />
+                Implement locally
+                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                  Pause after Review so you can inspect the worktree. Agent
+                  Turns and dependency installation keep their current
+                  capabilities. Start continues to Commit and PR creation. A
+                  No-Change Outcome pauses before Close Issue.
+                </span>
+              </label>
+            )}
           </section>
 
           {submitError !== null && (

--- a/apps/harness/src/implement-with-issue-dialog.tsx
+++ b/apps/harness/src/implement-with-issue-dialog.tsx
@@ -34,6 +34,7 @@ const agentBackendsQuery = {
 
 export type ImplementWithIssueDialogProps = {
   readonly issueNumber: number
+  readonly target?: "leaf" | "parent"
   readonly repositoryId: string
   readonly initialBackendId: string
   readonly repositoryPrefs: ExecutionProfilePrefSource
@@ -51,6 +52,7 @@ export type ImplementWithIssueDialogProps = {
  */
 export function ImplementWithIssueDialog({
   issueNumber,
+  target = "leaf",
   repositoryId,
   initialBackendId,
   repositoryPrefs,
@@ -196,11 +198,14 @@ export function ImplementWithIssueDialog({
         <div className={ui.dialogHeader}>
           <p className={ui.dialogKicker}>Implement With</p>
           <h2 id={loadingTitleId} className={ui.dialogTitle}>
-            Implement issue #{issueNumber} with...
+            {target === "parent"
+              ? "Implement all with..."
+              : `Implement issue #${issueNumber} with...`}
           </h2>
           <p className={ui.dialogLede}>
-            These choices apply only to this Work Item. They never change
-            Repository settings or Harness Config.
+            {target === "parent"
+              ? "These choices apply to each new child Work Item. They never change Repository settings or Harness Config."
+              : "These choices apply only to this Work Item. They never change Repository settings or Harness Config."}
           </p>
         </div>
         <div className={ui.dialogBody}>
@@ -243,6 +248,7 @@ export function ImplementWithIssueDialog({
   return (
     <ImplementWithDialog
       issueNumber={issueNumber}
+      target={target}
       backendId={backendId}
       backends={
         backends.length > 0 ? backends : [{ id: backendId, label: backendId }]

--- a/apps/harness/src/parent-issue-actions-menu.tsx
+++ b/apps/harness/src/parent-issue-actions-menu.tsx
@@ -6,24 +6,29 @@ import { cx, ui } from "./ui.js"
 export type ParentIssueActionsMenuProps = {
   readonly parentIssueNumber: number
   readonly menuId: string
-  readonly pending: boolean
+  readonly implementAllPending: boolean
+  readonly implementWithPending: boolean
   readonly errorMessage: string | null
   readonly onImplementAllWithAutoMerge: () => void
+  readonly onImplementAllWith: () => void
 }
 
 /**
- * Parent Issue kebab with the sole action Implement all with auto-merge.
+ * Parent Issue kebab: Implement all with auto-merge, then Implement all with....
  * Presentational shell so accessibility and menu interaction can be tested
  * without the full Issues list.
  */
 export function ParentIssueActionsMenu({
   parentIssueNumber,
   menuId,
-  pending,
+  implementAllPending,
+  implementWithPending,
   errorMessage,
   onImplementAllWithAutoMerge,
+  onImplementAllWith,
 }: ParentIssueActionsMenuProps): ReactNode {
   const [menuOpen, setMenuOpen] = useState(false)
+  const pending = implementAllPending || implementWithPending
 
   useEffect(() => {
     if (!menuOpen) return
@@ -82,7 +87,22 @@ export function ParentIssueActionsMenu({
                 onImplementAllWithAutoMerge()
               }}
             >
-              {pending ? "Starting..." : "Implement all with auto-merge"}
+              {implementAllPending
+                ? "Starting..."
+                : "Implement all with auto-merge"}
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              className={ui.menuItem}
+              disabled={pending}
+              onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                event.stopPropagation()
+                setMenuOpen(false)
+                onImplementAllWith()
+              }}
+            >
+              {implementWithPending ? "Starting..." : "Implement all with..."}
             </button>
           </div>
         )}

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -159,6 +159,26 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).not.toContain("Auto-merge")
   })
 
+  test("parent rendering titles Implement all with... and omits Implement locally", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog {...baseProps} target="parent" />,
+    )
+    expect(html).toContain("Implement all with...")
+    expect(html).not.toContain("Implement issue #1034 with...")
+    expect(html).toContain("each new child Work Item")
+    expect(html).toContain("never change Repository settings or Harness Config")
+    expect(html).toContain('name="mergePolicy"')
+    expect(html).toContain("Off — human merge")
+    expect(html).toContain("Classify — risk-assessed merge")
+    expect(html).toContain("Always — skip classify")
+    expect(html).toContain(">Implement<")
+    expect(html).toContain(">Cancel<")
+    expect(html).not.toContain('name="implementLocally"')
+    expect(html).not.toContain("Implement locally")
+    expect(html).not.toContain("Implement now")
+    expect(html).not.toContain("Auto-merge")
+  })
+
   test("prefills Merge Policy from the live Repository and Implement locally to false", () => {
     const off = renderToStaticMarkup(
       <ImplementWithDialog {...baseProps} initialMergePolicy="OFF" />,
@@ -857,6 +877,29 @@ describe("ImplementWithDialog interaction", () => {
     })
     expect(backendChanges).toEqual(["claude"])
   })
+
+  test("parent submit pins Merge Policy and never requests a local pause", () => {
+    const { node, submitted } = render({ target: "parent" })
+    expect(node.querySelector('input[name="implementLocally"]')).toBeNull()
+    flushSync(() => {
+      selectNamed(node, "mergePolicy").value = "ALWAYS"
+      fire(selectNamed(node, "mergePolicy"), "change")
+    })
+    flushSync(() => {
+      fire(node.querySelector("form"), "submit")
+    })
+    expect(submitted.at(-1)).toEqual({
+      profile: {
+        agentBackendId: "opencode",
+        buildModel: "sonnet",
+        buildThinkingLevel: "high",
+        reviewSameAsBuild: true,
+        reviewModel: null,
+        reviewThinkingLevel: null,
+      },
+      options: { mergePolicy: "ALWAYS", implementLocally: false },
+    })
+  })
 })
 
 describe("Implement With leaf dialog caller", () => {
@@ -865,7 +908,9 @@ describe("Implement With leaf dialog caller", () => {
       join(import.meta.dir, "../src/home-page-content.tsx"),
       "utf8",
     )
-    const start = source.indexOf("const implementWith = useMutation")
+    const rowStart = source.indexOf("function RepositoryIssueRow")
+    expect(rowStart).toBeGreaterThan(-1)
+    const start = source.indexOf("const implementWith = useMutation", rowStart)
     expect(start).toBeGreaterThan(-1)
     const caller = source.slice(
       start,
@@ -874,6 +919,25 @@ describe("Implement With leaf dialog caller", () => {
     expect(caller).toContain("return result.implementWith")
     expect(caller).toContain("const [workItem] = workItems")
     expect(caller).toContain("onImplementSuccess(workItem)")
+  })
+})
+
+describe("Implement With parent dialog caller", () => {
+  test("forwards the covered list and opens the parent dialog", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/home-page-content.tsx"),
+      "utf8",
+    )
+    const groupStart = source.indexOf("function ParentIssueGroup")
+    const groupEnd = source.indexOf("function RepositoryIssueRow", groupStart)
+    expect(groupStart).toBeGreaterThan(-1)
+    const group = source.slice(groupStart, groupEnd)
+    expect(group).toContain("return result.implementWith")
+    expect(group).toContain("applyCoveredWorkItems(covered)")
+    expect(group).toContain('target="parent"')
+    expect(group).toContain("Implement all with...")
+    expect(group).not.toContain("Implement now")
+    expect(group).not.toContain("Implement locally")
   })
 })
 

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -76,17 +76,20 @@ describe("ParentIssueActionsMenu", () => {
       <ParentIssueActionsMenu
         parentIssueNumber={42}
         menuId="issue-parent-42"
-        pending={false}
+        implementAllPending={false}
+        implementWithPending={false}
         errorMessage={null}
         onImplementAllWithAutoMerge={() => undefined}
+        onImplementAllWith={() => undefined}
       />,
     )
     expect(html).toContain('aria-label="Actions for parent issue #42"')
     expect(html).toContain('aria-haspopup="menu"')
     expect(html).toContain("data-parent-issue-menu")
-    // Closed by default; sole action is Implement all with auto-merge only.
+    // Closed by default; actions are parent bulk starts only.
     expect(html).not.toContain("Implement now")
     expect(html).not.toContain("Queue")
+    expect(html).not.toContain("Implement locally")
   })
 
   test("shows parent-level error alert without partial-success copy", () => {
@@ -94,9 +97,11 @@ describe("ParentIssueActionsMenu", () => {
       <ParentIssueActionsMenu
         parentIssueNumber={7}
         menuId="issue-parent-7"
-        pending={true}
+        implementAllPending={true}
+        implementWithPending={false}
         errorMessage="Could not start Implement all with auto-merge. Refresh the issues and try again."
         onImplementAllWithAutoMerge={() => undefined}
+        onImplementAllWith={() => undefined}
       />,
     )
     expect(html).toContain('role="alert"')
@@ -109,7 +114,7 @@ describe("ParentIssueActionsMenu", () => {
     expect(html).not.toContain("absolute top-full right-0 z-10 mt-1 w-56")
   })
 
-  test("menu source exposes sole menuitem label Implement all with auto-merge", () => {
+  test("menu source exposes Implement all with auto-merge then Implement all with...", () => {
     // CI unit tests do not install Playwright browser binaries; lock the
     // accessible menu contract from the component source instead of chromium.
     const source = readFileSync(
@@ -119,9 +124,15 @@ describe("ParentIssueActionsMenu", () => {
     expect(source).toContain('role="menu"')
     expect(source).toContain('role="menuitem"')
     expect(source).toContain("Implement all with auto-merge")
+    expect(source).toContain("Implement all with...")
     expect(source).not.toContain("Implement now")
     expect(source).not.toContain('"Queue"')
-    expect(source.match(/role="menuitem"/g)?.length).toBe(1)
+    expect(source).not.toContain("Implement locally")
+    expect(source.match(/role="menuitem"/g)?.length).toBe(2)
+    const autoMerge = source.indexOf("Implement all with auto-merge")
+    const implementWith = source.indexOf('"Implement all with..."')
+    expect(autoMerge).toBeGreaterThan(0)
+    expect(implementWith).toBeGreaterThan(autoMerge)
   })
 
   test("menu uses Interchange mono uppercase menuitems and icon-btn trigger", () => {

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -88,6 +88,11 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
           `Parent Issue #${error.issueNumber} is not eligible for Implement all with auto-merge`,
         "IMPLEMENT_ALL_WITH_AUTO_MERGE_NOT_ELIGIBLE",
       )
+    case "ParentImplementWithPauseNotAllowedError":
+      return gql(
+        `Implement With cannot pause on Parent Issue #${error.issueNumber}`,
+        "PARENT_IMPLEMENT_WITH_PAUSE_NOT_ALLOWED",
+      )
     case "IssueBlockedError":
       return gql(
         `Issue #${error.issueNumber} is blocked by ${error.blockerCount} issue(s)`,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -58,7 +58,7 @@ import {
   AutonomousRetryLimitReachedError,
   InvalidExecutionProfileError,
   IssueNotFoundError,
-  ParentIssueError,
+  ParentImplementWithPauseNotAllowedError,
   RetryNotEligibleError,
   STEP_RUN_REASON,
   SessionIdAmbiguousError,
@@ -5318,7 +5318,106 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("implementWith on a Parent Issue still fails as not a leaf", async () => {
+  test("implementWith on a Parent Issue returns the covered child Work Items", async () => {
+    const childA = {
+      ...workItem,
+      id: makeWorkItemId(),
+      issueNumber: 43,
+      executionProfile: {
+        agentBackend: "opencode",
+        build: { model: "build-model", thinkingLevel: "high" },
+        review: { kind: "same_as_build" as const },
+      },
+      mergeMode: "ordinary" as const,
+      autoMergeOverride: true,
+    } as WorkItemRecord
+    const childB = {
+      ...workItem,
+      id: makeWorkItemId(),
+      issueNumber: 44,
+      executionProfile: {
+        agentBackend: "opencode",
+        build: { model: "build-model", thinkingLevel: "high" },
+        review: { kind: "same_as_build" as const },
+      },
+      mergeMode: "ordinary" as const,
+      autoMergeOverride: true,
+      waitingForBlockers: true,
+      holdsWorkerSlot: false,
+      stepRuns: [],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        implementWith: (repositoryId, issueNumber, profile, options) => {
+          expect(repositoryId).toBe(repository.id)
+          expect(issueNumber).toBe(10)
+          expect(profile.agentBackendId).toBe("opencode")
+          expect(options).toEqual({
+            mergePolicy: "classify",
+            implementLocally: false,
+          })
+          return Effect.succeed([childA, childB])
+        },
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation ImplementWith(
+          $repositoryId: ID!
+          $issueNumber: Int!
+          $profile: ExplicitWorkItemExecutionProfileInput!
+          $options: ImplementWithOptionsInput
+        ) {
+          implementWith(
+            repositoryId: $repositoryId
+            issueNumber: $issueNumber
+            profile: $profile
+            options: $options
+          ) {
+            id
+            issueNumber
+            mergePolicy
+            mergeMode
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: 10,
+          profile: {
+            agentBackendId: "opencode",
+            buildModel: "build-model",
+            buildThinkingLevel: "high",
+            reviewSameAsBuild: true,
+          },
+          options: { mergePolicy: "CLASSIFY", implementLocally: false },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        implementWith: [
+          {
+            id: childA.id,
+            issueNumber: 43,
+            mergePolicy: "CLASSIFY",
+            mergeMode: "ORDINARY",
+          },
+          {
+            id: childB.id,
+            issueNumber: 44,
+            mergePolicy: "CLASSIFY",
+            mergeMode: "ORDINARY",
+          },
+        ],
+      },
+    })
+  })
+
+  test("implementWith pause on a Parent Issue maps to a domain failure", async () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
@@ -5327,7 +5426,7 @@ describe("GraphQL API", () => {
       {
         implementWith: () =>
           Effect.fail(
-            new ParentIssueError({
+            new ParentImplementWithPauseNotAllowedError({
               repositoryId: repository.id,
               issueNumber: 10,
             }),
@@ -5340,11 +5439,13 @@ describe("GraphQL API", () => {
           $repositoryId: ID!
           $issueNumber: Int!
           $profile: ExplicitWorkItemExecutionProfileInput!
+          $options: ImplementWithOptionsInput
         ) {
           implementWith(
             repositoryId: $repositoryId
             issueNumber: $issueNumber
             profile: $profile
+            options: $options
           ) {
             id
           }
@@ -5357,6 +5458,7 @@ describe("GraphQL API", () => {
             buildModel: "build-model",
             reviewSameAsBuild: true,
           },
+          options: { mergePolicy: "CLASSIFY", implementLocally: true },
         },
       }),
     )
@@ -5364,9 +5466,9 @@ describe("GraphQL API", () => {
       data: null,
       errors: [
         expect.objectContaining({
-          message: "Issue #10 has child issues and must target a leaf Issue",
+          message: "Implement With cannot pause on Parent Issue #10",
           extensions: expect.objectContaining({
-            code: "ISSUE_IS_PARENT",
+            code: "PARENT_IMPLEMENT_WITH_PAUSE_NOT_ALLOWED",
           }),
         }),
       ],

--- a/packages/graphql-api/test/to-graphql-error.test.ts
+++ b/packages/graphql-api/test/to-graphql-error.test.ts
@@ -171,4 +171,21 @@ describe("toGraphQLError", () => {
       projectPath: "acme/widgets",
     })
   })
+
+  test("maps ParentImplementWithPauseNotAllowedError to PARENT_IMPLEMENT_WITH_PAUSE_NOT_ALLOWED", () => {
+    const error = {
+      _tag: "ParentImplementWithPauseNotAllowedError" as const,
+      repositoryId: "repo-1",
+      issueNumber: 10,
+    }
+
+    const gqlError = toGraphQLError(error)
+
+    expect(gqlError.message).toBe(
+      "Implement With cannot pause on Parent Issue #10",
+    )
+    expect(gqlError.extensions).toMatchObject({
+      code: "PARENT_IMPLEMENT_WITH_PAUSE_NOT_ALLOWED",
+    })
+  })
 })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -1109,12 +1109,14 @@ type Mutation {
   refreshRepository(repositoryId: ID!): RefreshJob!
   implementNow(repositoryId: ID!, issueNumber: Int!): WorkItem!
   """
-  Create a Work Item for an Actionable Issue with one complete Explicit Work
-  Item Execution Profile. Submission activates and inspects an otherwise
-  inactive shipped Agent Backend under the settings/create coordination
-  boundary. Partial profiles cannot be represented. Failure creates nothing
-  and leaves saved defaults unchanged. Returns a list whose only element is
-  that Work Item. A Parent Issue is rejected as not a leaf.
+  Create Work Items with one complete Explicit Work Item Execution Profile.
+  On an Actionable Issue, returns a list whose only element is that Work Item.
+  On a Parent Issue, enrolls the same open children as Implement all with
+  auto-merge: new children get the profile and Merge Policy pin; adopted
+  unfinished children get the pin only. A Parent Issue cannot pause. Submission
+  activates and inspects an otherwise inactive shipped Agent Backend under the
+  settings/create coordination boundary. Partial profiles cannot be represented.
+  Failure creates nothing and leaves saved defaults unchanged.
   """
   implementWith(
     repositoryId: ID!

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -1087,12 +1087,14 @@ type Mutation {
   refreshRepository(repositoryId: ID!): RefreshJob!
   implementNow(repositoryId: ID!, issueNumber: Int!): WorkItem!
   """
-  Create a Work Item for an Actionable Issue with one complete Explicit Work
-  Item Execution Profile. Submission activates and inspects an otherwise
-  inactive shipped Agent Backend under the settings/create coordination
-  boundary. Partial profiles cannot be represented. Failure creates nothing
-  and leaves saved defaults unchanged. Returns a list whose only element is
-  that Work Item. A Parent Issue is rejected as not a leaf.
+  Create Work Items with one complete Explicit Work Item Execution Profile.
+  On an Actionable Issue, returns a list whose only element is that Work Item.
+  On a Parent Issue, enrolls the same open children as Implement all with
+  auto-merge: new children get the profile and Merge Policy pin; adopted
+  unfinished children get the pin only. A Parent Issue cannot pause. Submission
+  activates and inspects an otherwise inactive shipped Agent Backend under the
+  settings/create coordination boundary. Partial profiles cannot be represented.
+  Failure creates nothing and leaves saved defaults unchanged.
   """
   implementWith(
     repositoryId: ID!

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -69,6 +69,18 @@ export class ImplementAllWithAutoMergeNotEligibleError extends Schema.TaggedErro
   },
 ) {}
 
+/**
+ * Implement With cannot request an Implement Locally pause on a Parent Issue.
+ * Bulk enrollment is always remote; the pause option fails closed.
+ */
+export class ParentImplementWithPauseNotAllowedError extends Schema.TaggedErrorClass<ParentImplementWithPauseNotAllowedError>()(
+  "ParentImplementWithPauseNotAllowedError",
+  {
+    repositoryId: Schema.String,
+    issueNumber: Schema.Finite,
+  },
+) {}
+
 export class IssueBlockedError extends Schema.TaggedErrorClass<IssueBlockedError>()(
   "IssueBlockedError",
   {

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -86,6 +86,7 @@ import {
   NeedsHumanHandoffNotEligibleError,
   NonTransactionalQueueError,
   NotAParentIssueError,
+  ParentImplementWithPauseNotAllowedError,
   ParentIssueError,
   ResetCleanupError,
   RetryNotEligibleError,
@@ -849,8 +850,6 @@ export type ImplementNowError =
   | EnqueueError
   | InvalidQueueNameError
 
-export type ImplementWithError = ImplementNowError
-
 export type ImplementAllWithAutoMergeError =
   | IssueNotFoundError
   | NotAParentIssueError
@@ -863,6 +862,11 @@ export type ImplementAllWithAutoMergeError =
   | DatabaseError
   | EnqueueError
   | InvalidQueueNameError
+
+export type ImplementWithError =
+  | ImplementNowError
+  | ImplementAllWithAutoMergeError
+  | ParentImplementWithPauseNotAllowedError
 
 export type QueueError =
   | IssueNotFoundError
@@ -1026,9 +1030,11 @@ export interface WorkItemLifecycleShape {
     issueNumber: number,
   ) => Effect.Effect<WorkItemRecord, ImplementNowError>
   /**
-   * Create a Work Item for an Actionable Issue with an Explicit Work Item
-   * Execution Profile. Returns a list whose only element is that Work Item.
-   * A Parent Issue is rejected as not a leaf.
+   * Implement With: persist an Explicit Work Item Execution Profile and
+   * optional Merge Policy pin. On an Actionable Issue, returns a one-element
+   * list. On a Parent Issue, enrolls the same open children as Implement All
+   * with Auto-merge: new children get the profile and pin; adopted unfinished
+   * children get the pin only. Cannot pause. Does not create a parent Work Item.
    */
   readonly implementWith: (
     repositoryId: string,
@@ -7524,7 +7530,7 @@ export const makeWorkItemLifecycleLive = (
           readonly executionProfile?: ExplicitWorkItemExecutionProfile
           readonly autoMergeOverride?: boolean | null
         },
-      ): Effect.Effect<WorkItemRecord, ImplementWithError> =>
+      ): Effect.Effect<WorkItemRecord, ImplementNowError> =>
         Effect.gen(function* () {
           const issues = yield* db.listIssues(repositoryId)
           const issue = issues.find(
@@ -7803,7 +7809,7 @@ export const makeWorkItemLifecycleLive = (
                 .pipe(
                   Effect.tapError(() => restoreAddedBackend),
                   Effect.catch(
-                    (error): Effect.Effect<never, ImplementWithError> => {
+                    (error): Effect.Effect<never, ImplementNowError> => {
                       if (error instanceof WorkItemLifecycleDatabaseError) {
                         return Effect.fail(error)
                       }
@@ -7862,6 +7868,401 @@ export const makeWorkItemLifecycleLive = (
         },
       )
 
+      const sqlMergeOverride = (value: boolean | null): number | null =>
+        value === null ? null : value ? 1 : 0
+
+      const snapshotParentOpenChildren = (
+        repositoryId: string,
+        parentIssueNumber: number,
+      ) =>
+        Effect.gen(function* () {
+          const issues = yield* db.listIssues(repositoryId)
+          const parent = issues.find(
+            (candidate) => candidate.issueNumber === parentIssueNumber,
+          )
+
+          if (!parent) {
+            return yield* new IssueNotFoundError({
+              repositoryId,
+              issueNumber: parentIssueNumber,
+            })
+          }
+
+          if (!parent.hasChildren) {
+            return yield* new NotAParentIssueError({
+              repositoryId,
+              issueNumber: parentIssueNumber,
+            })
+          }
+
+          const children = issues.filter(
+            (candidate) =>
+              candidate.parent !== null &&
+              candidate.parent.issueNumber === parentIssueNumber,
+          )
+
+          if (children.some((child) => child.hasChildren)) {
+            return yield* new UnsupportedIssueHierarchyError({
+              repositoryId,
+              issueNumber: parentIssueNumber,
+              message: `Issue #${parentIssueNumber} has grandchildren and is not a Supported Issue Hierarchy`,
+            })
+          }
+
+          const openChildren = children
+            .filter((child) => child.state === "OPEN")
+            .slice()
+            .sort((a, b) => {
+              const aPos = a.parentPosition ?? Number.MAX_SAFE_INTEGER
+              const bPos = b.parentPosition ?? Number.MAX_SAFE_INTEGER
+              if (aPos !== bPos) return aPos - bPos
+              return a.issueNumber - b.issueNumber
+            })
+
+          if (openChildren.length === 0) {
+            return yield* new ImplementAllWithAutoMergeNotEligibleError({
+              repositoryId,
+              issueNumber: parentIssueNumber,
+              reason: `Parent Issue #${parentIssueNumber} has no open Child Issues`,
+            })
+          }
+
+          return openChildren
+        })
+
+      const unfinishedIssueNumbers = (
+        items: readonly WorkItemRecord[],
+      ): ReadonlySet<number> => {
+        const unfinished = new Set<number>()
+        for (const item of items) {
+          if (
+            evaluateUnfinishedWorkItem(workItemPredicateInput(item))._tag ===
+            "match"
+          ) {
+            unfinished.add(item.issueNumber)
+          }
+        }
+        return unfinished
+      }
+
+      const mapParentEnrollmentError = (
+        error: unknown,
+        repositoryId: string,
+        parentIssueNumber: number,
+      ): Effect.Effect<never, ImplementAllWithAutoMergeError> => {
+        if (error instanceof WorkItemLifecycleDatabaseError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof EnqueueError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof InvalidQueueNameError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof AgentBackendUnavailableError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof BuildModelNotConfiguredError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof ImplementAllWithAutoMergeNotEligibleError) {
+          return Effect.fail(error)
+        }
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "_tag" in error &&
+          (error as { _tag: string })._tag === "SqlError"
+        ) {
+          const sqlError = error as SqlError
+          if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
+            return Effect.fail(
+              new ImplementAllWithAutoMergeNotEligibleError({
+                repositoryId,
+                issueNumber: parentIssueNumber,
+                reason: `A concurrent request enrolled a Child Issue of Parent Issue #${parentIssueNumber}`,
+              }),
+            )
+          }
+          return Effect.fail(toDatabaseError(sqlError))
+        }
+        return Effect.fail(
+          new WorkItemLifecycleDatabaseError({
+            message: `Unexpected transaction failure: ${String(error)}`,
+            cause: error,
+          }),
+        )
+      }
+
+      const enrollOpenChildren = (input: {
+        readonly repositoryId: string
+        readonly parentIssueNumber: number
+        readonly openChildren: ReadonlyArray<{
+          readonly issueNumber: number
+          readonly title: string
+          readonly blockedBy: ReadonlyArray<unknown>
+        }>
+        readonly pin: {
+          readonly mergeMode: MergeMode
+          readonly autoMergeOverride: boolean | null
+        }
+        readonly create: {
+          readonly agentBackendId: string
+          readonly executionProfile?: ExplicitWorkItemExecutionProfile
+        } | null
+      }): Effect.Effect<
+        readonly WorkItemId[],
+        ImplementAllWithAutoMergeError
+      > =>
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis
+          const step: OperationalLifecycleStep = "create_worktree"
+          const openChildren = input.openChildren
+          const { repositoryId, parentIssueNumber, pin, create } = input
+
+          return yield* sql
+            .withTransaction(
+              Effect.gen(function* () {
+                const limit = yield* maxWorkerSlots()
+                let occupied = yield* countOccupiedWorkerSlots()
+                const workItemIds: WorkItemId[] = []
+
+                for (const child of openChildren) {
+                  const unfinishedRows = (yield* sql
+                    .unsafe(
+                      `SELECT id FROM work_item
+                         WHERE repository_id = ?
+                           AND issue_number = ?
+                           AND state NOT IN ('complete', 'failed', 'abandoned')
+                         LIMIT 1`,
+                      [repositoryId, child.issueNumber],
+                    )
+                    .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                    readonly id: string
+                  }[]
+
+                  const existingId = unfinishedRows[0]?.id
+                  if (existingId !== undefined) {
+                    const adoptedRows = (yield* sql
+                      .unsafe(
+                        `UPDATE work_item
+                           SET merge_mode = ?, auto_merge_override = ?, updated_at = ?
+                           WHERE id = ?
+                             AND state NOT IN ('complete', 'failed', 'abandoned')
+                           RETURNING id`,
+                        [
+                          pin.mergeMode,
+                          sqlMergeOverride(pin.autoMergeOverride),
+                          now,
+                          existingId,
+                        ],
+                      )
+                      .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                      readonly id: string
+                    }[]
+                    if (adoptedRows[0]?.id === undefined) {
+                      return yield* new ImplementAllWithAutoMergeNotEligibleError(
+                        {
+                          repositoryId,
+                          issueNumber: parentIssueNumber,
+                          reason: `A concurrent request changed a Child Issue of Parent Issue #${parentIssueNumber}`,
+                        },
+                      )
+                    }
+                    workItemIds.push(existingId as WorkItemId)
+                    continue
+                  }
+
+                  if (create === null) {
+                    return yield* new ImplementAllWithAutoMergeNotEligibleError(
+                      {
+                        repositoryId,
+                        issueNumber: parentIssueNumber,
+                        reason: `A concurrent request changed a Child Issue of Parent Issue #${parentIssueNumber}`,
+                      },
+                    )
+                  }
+
+                  const workItemId = makeWorkItemId()
+                  const blocked = child.blockedBy.length > 0
+                  const admit = !blocked && occupied < limit
+                  const executionProfile = create.executionProfile
+                  yield* sql.unsafe(
+                    `INSERT INTO work_item (
+                     id, repository_id, issue_number, agent_backend,
+                      issue_title, state, state_ready_at, paused,
+                      waiting_since, waiting_for_blockers, merge_mode, auto_merge_override,
+                      holds_worker_slot,
+                      pause_before_step, worktree_path, session_id, failure_code,
+                      failure_message,
+                      execution_profile_present, execution_profile_build_model,
+                      execution_profile_build_thinking_level,
+                      execution_profile_review_same_as_build,
+                      execution_profile_review_model,
+                      execution_profile_review_thinking_level,
+                      created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                    [
+                      workItemId,
+                      repositoryId,
+                      child.issueNumber,
+                      create.agentBackendId,
+                      child.title,
+                      step,
+                      now,
+                      blocked || admit ? null : now,
+                      blocked ? 1 : 0,
+                      pin.mergeMode,
+                      sqlMergeOverride(pin.autoMergeOverride),
+                      admit ? 1 : 0,
+                      executionProfile === undefined ? 0 : 1,
+                      executionProfile?.build.model ?? null,
+                      executionProfile?.build.thinkingLevel ?? null,
+                      executionProfile === undefined
+                        ? 0
+                        : executionProfile.review.kind === "same_as_build"
+                          ? 1
+                          : 0,
+                      executionProfile?.review.kind === "explicit"
+                        ? executionProfile.review.model
+                        : null,
+                      executionProfile?.review.kind === "explicit"
+                        ? executionProfile.review.thinkingLevel
+                        : null,
+                      now,
+                      now,
+                    ],
+                  )
+                  if (admit) {
+                    occupied += 1
+                    yield* enqueueStepRunForWorkItem(workItemId, step, now)
+                  }
+
+                  workItemIds.push(workItemId)
+                }
+
+                return workItemIds
+              }),
+            )
+            .pipe(
+              Effect.catch((error) =>
+                mapParentEnrollmentError(
+                  error,
+                  repositoryId,
+                  parentIssueNumber,
+                ),
+              ),
+            )
+        })
+
+      const coveredWorkItems = (
+        coveredIds: readonly WorkItemId[],
+        repositoryId: string,
+      ) =>
+        Effect.gen(function* () {
+          const covered = yield* Effect.forEach(
+            coveredIds,
+            (workItemId) =>
+              getWorkItem(workItemId).pipe(
+                Effect.catchTag(
+                  "WorkItemNotFoundError",
+                  (error) =>
+                    new WorkItemLifecycleDatabaseError({
+                      message: `Work Item missing after parent enrollment: ${error.workItemId}`,
+                      cause: error,
+                    }),
+                ),
+              ),
+            { concurrency: 1 },
+          )
+          yield* notifyWorkItemsChanged(repositoryId)
+          return covered
+        })
+
+      const activateExplicitProfile = (
+        explicitProfile: ExplicitWorkItemExecutionProfile,
+      ) =>
+        Effect.gen(function* () {
+          if (!isSelectableAgentBackendId(explicitProfile.agentBackend)) {
+            return yield* new AgentBackendUnavailableError({
+              message: `Unknown or unsupported Agent Backend: ${explicitProfile.agentBackend}`,
+              reason: `Unknown or unsupported Agent Backend: ${explicitProfile.agentBackend}`,
+            })
+          }
+          const captureBackendId = explicitProfile.agentBackend
+          const priorStatus =
+            yield* activeAgentBackend.getBackendStatus(captureBackendId)
+          const addedForAttempt = priorStatus === null
+          const previousSelectedOrInUse = addedForAttempt
+            ? yield* db.listSelectedOrInUseBackendIds
+            : []
+          const restoreAddedBackend = addedForAttempt
+            ? activeAgentBackend.setSelectedOrInUse(
+                previousSelectedOrInUse.filter((id): id is AgentBackendId =>
+                  isSelectableAgentBackendId(id),
+                ),
+                inspectInput,
+              )
+            : Effect.void
+          if (addedForAttempt) {
+            const nextSelectedOrInUse = [
+              ...new Set([
+                ...previousSelectedOrInUse.filter((id): id is AgentBackendId =>
+                  isSelectableAgentBackendId(id),
+                ),
+                captureBackendId,
+              ]),
+            ]
+            yield* activeAgentBackend.setSelectedOrInUse(
+              nextSelectedOrInUse,
+              inspectInput,
+            )
+          }
+          const captureStatus =
+            yield* activeAgentBackend.getBackendStatus(captureBackendId)
+          if (captureStatus === null) {
+            yield* restoreAddedBackend
+            return yield* new AgentBackendUnavailableError({
+              message: `Agent Backend is not Active: ${explicitProfile.agentBackend}`,
+              reason: "Agent Backend is not Active",
+            })
+          }
+          if (captureStatus.kind === "unavailable") {
+            yield* restoreAddedBackend
+            return yield* new AgentBackendUnavailableError({
+              message: captureStatus.reason ?? "Agent Backend is unavailable",
+              reason: captureStatus.reason ?? "Agent Backend is unavailable",
+            })
+          }
+          const catalogError = validateExecutionProfileCatalog({
+            backendLabel: captureStatus.backend.label,
+            catalog: captureStatus.models,
+            profile: explicitProfile,
+          })
+          if (catalogError !== null) {
+            yield* restoreAddedBackend
+            return yield* catalogError
+          }
+          yield* activeAgentBackend
+            .requireAgentTurnsAllowed(captureBackendId)
+            .pipe(
+              Effect.mapError(
+                (error) =>
+                  new AgentBackendUnavailableError({
+                    message: error.message,
+                    reason: error.reason,
+                  }),
+              ),
+              Effect.tapError(() => restoreAddedBackend),
+            )
+          const activeRegistration =
+            yield* activeAgentBackend.getRegistration(captureBackendId)
+          return {
+            agentBackendId: activeRegistration.descriptor.id,
+            restoreAddedBackend,
+          }
+        })
+
       const implementWith = Effect.fn("WorkItemLifecycle.implementWith")(
         function* (
           repositoryId: string,
@@ -7881,6 +8282,50 @@ export const makeWorkItemLifecycleLive = (
                   autoMergeOverride: null,
                 }
               : encodeWorkItemMergePolicyPin(options.mergePolicy)
+          const issues = yield* db.listIssues(repositoryId)
+          const issue = issues.find(
+            (candidate) => candidate.issueNumber === issueNumber,
+          )
+          if (issue?.hasChildren) {
+            if (options.implementLocally) {
+              return yield* new ParentImplementWithPauseNotAllowedError({
+                repositoryId,
+                issueNumber,
+              })
+            }
+            const openChildren = yield* snapshotParentOpenChildren(
+              repositoryId,
+              issueNumber,
+            )
+            const unfinished = unfinishedIssueNumbers(
+              yield* listWorkItemsForRepository(repositoryId),
+            )
+            const mayNeedCreate = openChildren.some(
+              (child) => !unfinished.has(child.issueNumber),
+            )
+            const coveredIds = yield* activeAgentBackend.withConfigCoordination(
+              Effect.gen(function* () {
+                const captured = yield* activateExplicitProfile(decoded)
+                const ids = yield* enrollOpenChildren({
+                  repositoryId,
+                  parentIssueNumber: issueNumber,
+                  openChildren,
+                  pin,
+                  create: mayNeedCreate
+                    ? {
+                        agentBackendId: captured.agentBackendId,
+                        executionProfile: decoded,
+                      }
+                    : null,
+                }).pipe(Effect.tapError(() => captured.restoreAddedBackend))
+                if (!mayNeedCreate) {
+                  yield* captured.restoreAddedBackend
+                }
+                return ids
+              }),
+            )
+            return yield* coveredWorkItems(coveredIds, repositoryId)
+          }
           const created = yield* createWorkItem(repositoryId, issueNumber, {
             pauseBeforeStep: options.implementLocally ? "commit" : null,
             executionProfile: decoded,
@@ -7909,264 +8354,17 @@ export const makeWorkItemLifecycleLive = (
       const implementAllWithAutoMerge = Effect.fn(
         "WorkItemLifecycle.implementAllWithAutoMerge",
       )(function* (repositoryId: string, parentIssueNumber: number) {
-        const issues = yield* db.listIssues(repositoryId)
-        const parent = issues.find(
-          (candidate) => candidate.issueNumber === parentIssueNumber,
+        const openChildren = yield* snapshotParentOpenChildren(
+          repositoryId,
+          parentIssueNumber,
         )
-
-        if (!parent) {
-          return yield* new IssueNotFoundError({
-            repositoryId,
-            issueNumber: parentIssueNumber,
-          })
-        }
-
-        if (!parent.hasChildren) {
-          return yield* new NotAParentIssueError({
-            repositoryId,
-            issueNumber: parentIssueNumber,
-          })
-        }
-
-        const children = issues.filter(
-          (candidate) =>
-            candidate.parent !== null &&
-            candidate.parent.issueNumber === parentIssueNumber,
+        const unfinished = unfinishedIssueNumbers(
+          yield* listWorkItemsForRepository(repositoryId),
         )
-
-        if (children.some((child) => child.hasChildren)) {
-          return yield* new UnsupportedIssueHierarchyError({
-            repositoryId,
-            issueNumber: parentIssueNumber,
-            message: `Issue #${parentIssueNumber} has grandchildren and is not a Supported Issue Hierarchy`,
-          })
-        }
-
-        // Snapshot open direct children at acceptance; closed children and
-        // children added later are out of scope for this request.
-        const openChildren = children
-          .filter((child) => child.state === "OPEN")
-          .slice()
-          .sort((a, b) => {
-            const aPos = a.parentPosition ?? Number.MAX_SAFE_INTEGER
-            const bPos = b.parentPosition ?? Number.MAX_SAFE_INTEGER
-            if (aPos !== bPos) return aPos - bPos
-            return a.issueNumber - b.issueNumber
-          })
-
-        if (openChildren.length === 0) {
-          return yield* new ImplementAllWithAutoMergeNotEligibleError({
-            repositoryId,
-            issueNumber: parentIssueNumber,
-            reason: `Parent Issue #${parentIssueNumber} has no open Child Issues`,
-          })
-        }
-
-        // Pre-scan only decides whether any create may need Agent Backend
-        // resolution. The transaction re-reads unfinished rows so concurrent
-        // create/abandon races stay all-or-nothing.
-        const repositoryWorkItems =
-          yield* listWorkItemsForRepository(repositoryId)
-        const unfinishedByIssue = new Map<number, WorkItemId>()
-        for (const item of repositoryWorkItems) {
-          if (
-            evaluateUnfinishedWorkItem(workItemPredicateInput(item))._tag ===
-            "match"
-          ) {
-            unfinishedByIssue.set(item.issueNumber, item.id)
-          }
-        }
-
         const mayNeedCreate = openChildren.some(
-          (child) => !unfinishedByIssue.has(child.issueNumber),
+          (child) => !unfinished.has(child.issueNumber),
         )
-
-        const mapTransactionError = (
-          error: unknown,
-        ): Effect.Effect<never, ImplementAllWithAutoMergeError> => {
-          if (error instanceof WorkItemLifecycleDatabaseError) {
-            return Effect.fail(error)
-          }
-          if (error instanceof EnqueueError) {
-            return Effect.fail(error)
-          }
-          if (error instanceof InvalidQueueNameError) {
-            return Effect.fail(error)
-          }
-          if (error instanceof AgentBackendUnavailableError) {
-            return Effect.fail(error)
-          }
-          if (error instanceof BuildModelNotConfiguredError) {
-            return Effect.fail(error)
-          }
-          // Domain eligibility failures raised inside the transaction (e.g.
-          // pure-adopt concurrent abandon) must keep their tag for GraphQL.
-          if (error instanceof ImplementAllWithAutoMergeNotEligibleError) {
-            return Effect.fail(error)
-          }
-          if (
-            typeof error === "object" &&
-            error !== null &&
-            "_tag" in error &&
-            (error as { _tag: string })._tag === "SqlError"
-          ) {
-            const sqlError = error as SqlError
-            if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
-              return Effect.fail(
-                new ImplementAllWithAutoMergeNotEligibleError({
-                  repositoryId,
-                  issueNumber: parentIssueNumber,
-                  reason: `A concurrent request enrolled a Child Issue of Parent Issue #${parentIssueNumber}`,
-                }),
-              )
-            }
-            return Effect.fail(toDatabaseError(sqlError))
-          }
-          return Effect.fail(
-            new WorkItemLifecycleDatabaseError({
-              message: `Unexpected transaction failure: ${String(error)}`,
-              cause: error,
-            }),
-          )
-        }
-
-        const enrollOpenChildren = (
-          agentBackendId: string | null,
-        ): Effect.Effect<
-          readonly WorkItemId[],
-          ImplementAllWithAutoMergeError
-        > =>
-          Effect.gen(function* () {
-            const now = yield* Clock.currentTimeMillis
-            const step: OperationalLifecycleStep = "create_worktree"
-
-            return yield* sql
-              .withTransaction(
-                Effect.gen(function* () {
-                  const limit = yield* maxWorkerSlots()
-                  let occupied = yield* countOccupiedWorkerSlots()
-                  const workItemIds: WorkItemId[] = []
-
-                  for (const child of openChildren) {
-                    const unfinishedRows = (yield* sql
-                      .unsafe(
-                        `SELECT id FROM work_item
-                         WHERE repository_id = ?
-                           AND issue_number = ?
-                           AND state NOT IN ('complete', 'failed', 'abandoned')
-                         LIMIT 1`,
-                        [repositoryId, child.issueNumber],
-                      )
-                      .pipe(Effect.mapError(toDatabaseError))) as readonly {
-                      readonly id: string
-                    }[]
-
-                    const existingId = unfinishedRows[0]?.id
-                    if (existingId !== undefined) {
-                      // Adopt only: durable Merge Mode Always. Do not touch
-                      // state, admission, Step Runs, Session, worktree, PR, or
-                      // Needs Human handoff. RETURNING rejects a concurrent
-                      // terminal transition so we never report a false adopt.
-                      const adoptedRows = (yield* sql
-                        .unsafe(
-                          `UPDATE work_item
-                           SET merge_mode = 'always', updated_at = ?
-                           WHERE id = ?
-                             AND state NOT IN ('complete', 'failed', 'abandoned')
-                           RETURNING id`,
-                          [now, existingId],
-                        )
-                        .pipe(Effect.mapError(toDatabaseError))) as readonly {
-                        readonly id: string
-                      }[]
-                      if (adoptedRows[0]?.id === undefined) {
-                        return yield* new ImplementAllWithAutoMergeNotEligibleError(
-                          {
-                            repositoryId,
-                            issueNumber: parentIssueNumber,
-                            reason: `A concurrent request changed a Child Issue of Parent Issue #${parentIssueNumber}`,
-                          },
-                        )
-                      }
-                      workItemIds.push(existingId as WorkItemId)
-                      continue
-                    }
-
-                    if (agentBackendId === null) {
-                      // Race: pre-scan expected pure adopt, but a concurrent
-                      // abandon left this child without an unfinished WI.
-                      return yield* new ImplementAllWithAutoMergeNotEligibleError(
-                        {
-                          repositoryId,
-                          issueNumber: parentIssueNumber,
-                          reason: `A concurrent request changed a Child Issue of Parent Issue #${parentIssueNumber}`,
-                        },
-                      )
-                    }
-
-                    const workItemId = makeWorkItemId()
-                    const blocked = child.blockedBy.length > 0
-
-                    if (blocked) {
-                      yield* sql.unsafe(
-                        `INSERT INTO work_item (
-                     id, repository_id, issue_number, agent_backend,
-                      issue_title, state, state_ready_at, paused,
-                      waiting_since, waiting_for_blockers, merge_mode, holds_worker_slot,
-                      pause_before_step, worktree_path, session_id, failure_code,
-                      failure_message, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, 1, 'always', 0, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
-                        [
-                          workItemId,
-                          repositoryId,
-                          child.issueNumber,
-                          agentBackendId,
-                          child.title,
-                          step,
-                          now,
-                          now,
-                          now,
-                        ],
-                      )
-                    } else {
-                      const admit = occupied < limit
-                      yield* sql.unsafe(
-                        `INSERT INTO work_item (
-                     id, repository_id, issue_number, agent_backend,
-                      issue_title, state, state_ready_at, paused,
-                      waiting_since, waiting_for_blockers, merge_mode, holds_worker_slot,
-                      pause_before_step, worktree_path, session_id, failure_code,
-                      failure_message, created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 'always', ?, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
-                        [
-                          workItemId,
-                          repositoryId,
-                          child.issueNumber,
-                          agentBackendId,
-                          child.title,
-                          step,
-                          now,
-                          admit ? null : now,
-                          admit ? 1 : 0,
-                          now,
-                          now,
-                        ],
-                      )
-                      if (admit) {
-                        occupied += 1
-                        yield* enqueueStepRunForWorkItem(workItemId, step, now)
-                      }
-                    }
-
-                    workItemIds.push(workItemId)
-                  }
-
-                  return workItemIds
-                }),
-              )
-              .pipe(Effect.catch(mapTransactionError))
-          })
-
+        const pin = encodeWorkItemMergePolicyPin("always")
         const coveredIds = mayNeedCreate
           ? yield* activeAgentBackend.withConfigCoordination(
               Effect.gen(function* () {
@@ -8199,29 +8397,23 @@ export const makeWorkItemLifecycleLive = (
                 yield* resolveModelsForBackend(repositoryId, captureBackendId)
                 const activeRegistration =
                   yield* activeAgentBackend.getRegistration(captureBackendId)
-                const agentBackendId = activeRegistration.descriptor.id
-                return yield* enrollOpenChildren(agentBackendId)
+                return yield* enrollOpenChildren({
+                  repositoryId,
+                  parentIssueNumber,
+                  openChildren,
+                  pin,
+                  create: { agentBackendId: activeRegistration.descriptor.id },
+                })
               }),
             )
-          : yield* enrollOpenChildren(null)
-
-        const covered = yield* Effect.forEach(
-          coveredIds,
-          (workItemId) =>
-            getWorkItem(workItemId).pipe(
-              Effect.catchTag(
-                "WorkItemNotFoundError",
-                (error) =>
-                  new WorkItemLifecycleDatabaseError({
-                    message: `Work Item missing after implement-all adopt/create: ${error.workItemId}`,
-                    cause: error,
-                  }),
-              ),
-            ),
-          { concurrency: 1 },
-        )
-        yield* notifyWorkItemsChanged(repositoryId)
-        return covered
+          : yield* enrollOpenChildren({
+              repositoryId,
+              parentIssueNumber,
+              openChildren,
+              pin,
+              create: null,
+            })
+        return yield* coveredWorkItems(coveredIds, repositoryId)
       })
 
       const queueIssue = Effect.fn("WorkItemLifecycle.queue")(function* (

--- a/packages/work-item-lifecycle/test/implement-with.spec.ts
+++ b/packages/work-item-lifecycle/test/implement-with.spec.ts
@@ -1,4 +1,5 @@
 import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import {
   AGENT_BACKEND_IDS,
   ActiveAgentBackend,
@@ -10,17 +11,27 @@ import {
   DbServiceLive,
   type DbServiceShape,
 } from "@ready-for-agent/db-service"
+import {
+  EnqueueError,
+  type JobId,
+  QueueService,
+} from "@ready-for-agent/queue-service"
+import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
+  ImplementAllWithAutoMergeNotEligibleError,
   InstallCommandError,
   InvalidExecutionProfileError,
   type LifecycleStepContext,
   LifecycleSteps,
   type LifecycleStepsShape,
   AgentBackendUnavailableError as LifecycleUnavailableError,
+  ParentImplementWithPauseNotAllowedError,
   ParentIssueError,
   STEP_RUN_REASON,
   UnfinishedWorkItemExistsError,
+  UnsupportedIssueHierarchyError,
+  WORK_ITEM_LIFECYCLE_QUEUE,
   WorkItemLifecycle,
   WorkItemLifecycleLive,
   stubActiveAgentBackendLayer,
@@ -152,6 +163,69 @@ const storeOpenLeafIssue = (
     blockedBy: [],
   })
 
+const storeOpenParentIssue = (
+  db: Pick<DbServiceShape, "storeIssue">,
+  repositoryId: string,
+  issueNumber: number,
+) =>
+  db.storeIssue({
+    repositoryId,
+    issueNumber,
+    title: `Parent ${issueNumber}`,
+    body: "body",
+    url: `https://github.com/acme/widgets/issues/${issueNumber}`,
+    state: "OPEN",
+    githubCreatedAt: new Date(),
+    issueAuthor: null,
+    parent: null,
+    parentPosition: null,
+    hasChildren: true,
+    blockedBy: [],
+  })
+
+const storeOpenChildIssue = (
+  db: Pick<DbServiceShape, "storeIssue">,
+  repositoryId: string,
+  issueNumber: number,
+  parentIssueNumber: number,
+  extra?: {
+    readonly parentPosition?: number
+    readonly state?: "OPEN" | "CLOSED"
+    readonly blockedBy?: readonly {
+      readonly issueNumber: number
+      readonly issueUrl: string
+    }[]
+    readonly hasChildren?: boolean
+  },
+) =>
+  db.storeIssue({
+    repositoryId,
+    issueNumber,
+    title: `Child ${issueNumber}`,
+    body: "body",
+    url: `https://github.com/acme/widgets/issues/${issueNumber}`,
+    state: extra?.state ?? "OPEN",
+    githubCreatedAt: new Date(),
+    issueAuthor: null,
+    parent: {
+      issueNumber: parentIssueNumber,
+      issueUrl: `https://github.com/acme/widgets/issues/${parentIssueNumber}`,
+    },
+    parentPosition: extra?.parentPosition ?? 0,
+    hasChildren: extra?.hasChildren ?? false,
+    blockedBy: extra?.blockedBy ?? [],
+  })
+
+const expectedExplicitReviewProfile = {
+  agentBackend: "opencode",
+  build: { model: "build-model", thinkingLevel: "high" },
+  review: {
+    kind: "explicit" as const,
+    model: "review-model",
+    thinkingLevel: "max",
+  },
+}
+
 const seedHarness = (
   db: Pick<DbServiceShape, "updateConfig">,
   input: {
@@ -253,46 +327,463 @@ describe("implementWith", () => {
     )
   })
 
-  it("rejects a Parent Issue as not a leaf", async () => {
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const db = yield* DbService
-        const lifecycle = yield* WorkItemLifecycle
-        const repo = yield* db.addRepository({
-          forge: "github",
-          forgeHost: "github.com",
-          projectPath: "acme/widgets",
-          localPath: "/repos/acme/widgets-implement-with-parent.git",
-          isBare: true,
-        })
-        yield* seedHarness(db, {
-          selectedAgentBackend: "opencode",
-          defaultModel: "settings-build",
-        })
-        yield* db.storeIssue({
-          repositoryId: repo.id,
-          issueNumber: 30,
-          title: "Parent",
-          body: "body",
-          url: "https://github.com/acme/widgets/issues/30",
-          state: "OPEN",
-          githubCreatedAt: new Date(),
-          issueAuthor: null,
-          parent: null,
-          parentPosition: null,
-          hasChildren: true,
-          blockedBy: [],
-        })
-        const error = yield* Effect.flip(
-          lifecycle.implementWith(repo.id, 30, sameAsBuildProfile, {
-            mergePolicy: "off",
-            implementLocally: false,
-          }),
-        )
-        expect(error).toBeInstanceOf(ParentIssueError)
-        expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 30)).toEqual([])
-      }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
-    )
+  describe("on a Parent Issue", () => {
+    it("enrolls the same open children as Implement All with the submitted profile and pin", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-parent.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "settings-build",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 30)
+          yield* storeOpenChildIssue(db, repo.id, 31, 30, { parentPosition: 0 })
+          yield* storeOpenChildIssue(db, repo.id, 32, 30, {
+            parentPosition: 1,
+            blockedBy: [
+              {
+                issueNumber: 1,
+                issueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+          yield* storeOpenChildIssue(db, repo.id, 33, 30, {
+            parentPosition: 2,
+            state: "CLOSED",
+          })
+
+          const covered = yield* lifecycle.implementWith(
+            repo.id,
+            30,
+            explicitReviewProfile,
+            { mergePolicy: "classify", implementLocally: false },
+          )
+          expect(covered.map((item) => item.issueNumber)).toEqual([31, 32])
+          expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 30)).toEqual(
+            [],
+          )
+
+          const unblocked = covered[0]!
+          expect(unblocked.executionProfile).toEqual(
+            expectedExplicitReviewProfile,
+          )
+          expect(unblocked.mergeMode).toBe("ordinary")
+          expect(unblocked.autoMergeOverride).toBe(true)
+          expect(unblocked.pauseBeforeStep).toBeNull()
+          expect(unblocked.waitingForBlockers).toBe(false)
+          expect(unblocked.holdsWorkerSlot).toBe(true)
+          expect(unblocked.stepRuns).toHaveLength(1)
+
+          const blocked = covered[1]!
+          expect(blocked.executionProfile).toEqual(
+            expectedExplicitReviewProfile,
+          )
+          expect(blocked.mergeMode).toBe("ordinary")
+          expect(blocked.autoMergeOverride).toBe(true)
+          expect(blocked.pauseBeforeStep).toBeNull()
+          expect(blocked.waitingForBlockers).toBe(true)
+          expect(blocked.holdsWorkerSlot).toBe(false)
+          expect(blocked.stepRuns).toHaveLength(0)
+
+          expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 33)).toEqual(
+            [],
+          )
+
+          yield* storeOpenChildIssue(db, repo.id, 34, 30, { parentPosition: 3 })
+          const again = yield* lifecycle.implementWith(
+            repo.id,
+            30,
+            explicitReviewProfile,
+            { mergePolicy: "off", implementLocally: false },
+          )
+          expect(again.map((item) => item.issueNumber).sort()).toEqual([
+            31, 32, 34,
+          ])
+          const later = again.find((item) => item.issueNumber === 34)!
+          expect(later.executionProfile).toEqual(expectedExplicitReviewProfile)
+          expect(later.autoMergeOverride).toBe(false)
+          expect(later.pauseBeforeStep).toBeNull()
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
+
+    it("adopts unfinished children by writing the pin only", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-adopt.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "build-model",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 40)
+          yield* storeOpenChildIssue(db, repo.id, 41, 40)
+
+          const existing = yield* lifecycle.implementNow(repo.id, 41)
+          expect(existing.executionProfile).toBeNull()
+          expect(existing.mergeMode).toBe("ordinary")
+          expect(existing.autoMergeOverride).toBeNull()
+          yield* sql.unsafe(
+            `UPDATE work_item
+             SET state = 'needs_human',
+                 session_id = 'ses_parent_adopt',
+                 worktree_path = '/tmp/worktrees/parent-adopt',
+                 pull_request_number = 88,
+                 failure_code = 'needs_human',
+                 failure_message = 'Human merge required',
+                 holds_worker_slot = 0
+             WHERE id = ?`,
+            [existing.id],
+          )
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'succeeded',
+                 step = 'decide_pr_merge',
+                 finished_at = ?
+             WHERE work_item_id = ?`,
+            [Date.now(), existing.id],
+          )
+
+          const covered = yield* lifecycle.implementWith(
+            repo.id,
+            40,
+            explicitReviewProfile,
+            { mergePolicy: "always", implementLocally: false },
+          )
+          expect(covered).toHaveLength(1)
+          const adopted = covered[0]!
+          expect(adopted.id).toBe(existing.id)
+          expect(adopted.executionProfile).toBeNull()
+          expect(adopted.mergeMode).toBe("always")
+          expect(adopted.autoMergeOverride).toBeNull()
+          expect(adopted.pauseBeforeStep).toBeNull()
+          expect(adopted.state).toBe("needs_human")
+          expect(adopted.sessionId).toBe("ses_parent_adopt")
+          expect(adopted.worktreePath).toBe("/tmp/worktrees/parent-adopt")
+          expect(adopted.pullRequestNumber).toBe(88)
+          expect(adopted.failureCode).toBe("needs_human")
+          expect(adopted.stepRuns.every((run) => run.status !== "queued")).toBe(
+            true,
+          )
+          expect(adopted.stepRuns.some((run) => run.step === "merge_pr")).toBe(
+            false,
+          )
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
+
+    it("starts a queued blocked child remotely with the profile and pin once blockers lift", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-blocked.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "settings-build",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 50)
+          yield* storeOpenChildIssue(db, repo.id, 51, 50, {
+            blockedBy: [
+              {
+                issueNumber: 1,
+                issueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+
+          const [held] = yield* lifecycle.implementWith(
+            repo.id,
+            50,
+            explicitReviewProfile,
+            { mergePolicy: "off", implementLocally: false },
+          )
+          expect(held.waitingForBlockers).toBe(true)
+          expect(held.pauseBeforeStep).toBeNull()
+
+          yield* storeOpenChildIssue(db, repo.id, 51, 50, { blockedBy: [] })
+          expect(yield* lifecycle.releaseWaitingForBlockers(repo.id)).toBe(1)
+
+          const released = yield* lifecycle.getWorkItem(held.id)
+          expect(released.waitingForBlockers).toBe(false)
+          expect(released.holdsWorkerSlot).toBe(true)
+          expect(released.pauseBeforeStep).toBeNull()
+          expect(released.executionProfile).toEqual(
+            expectedExplicitReviewProfile,
+          )
+          expect(released.autoMergeOverride).toBe(false)
+          expect(released.mergeMode).toBe("ordinary")
+          expect(released.stepRuns).toHaveLength(1)
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
+
+    it("creates nothing when any covered child cannot be enrolled", async () => {
+      let enqueueCalls = 0
+      const failingEnqueueQueue = stubQueueService({
+        enqueue: () => {
+          enqueueCalls += 1
+          if (enqueueCalls >= 2) {
+            return Effect.fail(
+              new EnqueueError({
+                queue: WORK_ITEM_LIFECYCLE_QUEUE,
+                message: "injected enqueue failure on second child",
+              }),
+            )
+          }
+          return Effect.succeed("qjob-01ARZ3NDEKTSV4RRFFQ69G5FAV" as JobId)
+        },
+      })
+      const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(catalogLayer()),
+        Layer.provideMerge(stubGitHubServiceLayer()),
+        Layer.provideMerge(stubGitLabServiceLayer()),
+        Layer.provideMerge(stubAzureDevOpsServiceLayer()),
+        Layer.provideMerge(
+          Layer.succeed(LifecycleSteps, LifecycleSteps.of(successfulSteps)),
+        ),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(
+          Layer.succeed(QueueService, QueueService.of(failingEnqueueQueue)),
+        ),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-atomic.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "settings-build",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 60)
+          yield* storeOpenChildIssue(db, repo.id, 61, 60, { parentPosition: 0 })
+          yield* storeOpenChildIssue(db, repo.id, 62, 60, { parentPosition: 1 })
+
+          const error = yield* Effect.flip(
+            lifecycle.implementWith(repo.id, 60, explicitReviewProfile, {
+              mergePolicy: "classify",
+              implementLocally: false,
+            }),
+          )
+          expect(error).toBeInstanceOf(EnqueueError)
+          expect(yield* lifecycle.listWorkItemsForRepository(repo.id)).toEqual(
+            [],
+          )
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+
+    it("rejects an explicit Implement Locally pause and creates nothing", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-pause.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "settings-build",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 70)
+          yield* storeOpenChildIssue(db, repo.id, 71, 70)
+
+          const error = yield* Effect.flip(
+            lifecycle.implementWith(repo.id, 70, explicitReviewProfile, {
+              mergePolicy: "classify",
+              implementLocally: true,
+            }),
+          )
+          expect(error).toBeInstanceOf(ParentImplementWithPauseNotAllowedError)
+          expect(yield* lifecycle.listWorkItemsForRepository(repo.id)).toEqual(
+            [],
+          )
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
+
+    it("refuses unsupported hierarchy and parents with no open children", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-ineligible.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "settings-build",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 80)
+          yield* storeOpenChildIssue(db, repo.id, 81, 80, {
+            hasChildren: true,
+          })
+          const unsupported = yield* Effect.flip(
+            lifecycle.implementWith(repo.id, 80, explicitReviewProfile, {
+              mergePolicy: "off",
+              implementLocally: false,
+            }),
+          )
+          expect(unsupported).toBeInstanceOf(UnsupportedIssueHierarchyError)
+
+          yield* storeOpenParentIssue(db, repo.id, 90)
+          yield* storeOpenChildIssue(db, repo.id, 91, 90, { state: "CLOSED" })
+          const noOpen = yield* Effect.flip(
+            lifecycle.implementWith(repo.id, 90, explicitReviewProfile, {
+              mergePolicy: "off",
+              implementLocally: false,
+            }),
+          )
+          expect(noOpen).toBeInstanceOf(
+            ImplementAllWithAutoMergeNotEligibleError,
+          )
+          expect(yield* lifecycle.listWorkItemsForRepository(repo.id)).toEqual(
+            [],
+          )
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
+
+    it("creates nothing when the catalog is empty", async () => {
+      const liveCatalog = [...catalog]
+      const mutableLayer = stubActiveAgentBackendLayer({
+        registration: opencodeRegistration,
+        models: liveCatalog,
+      })
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-with-parent-catalog.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "build-model",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 100)
+          yield* storeOpenChildIssue(db, repo.id, 101, 100)
+          const existing = yield* lifecycle.implementNow(repo.id, 101)
+          expect(existing.mergeMode).toBe("ordinary")
+          liveCatalog.splice(0, liveCatalog.length)
+
+          const error = yield* Effect.flip(
+            lifecycle.implementWith(repo.id, 100, explicitReviewProfile, {
+              mergePolicy: "always",
+              implementLocally: false,
+            }),
+          )
+          expect(error).toBeInstanceOf(InvalidExecutionProfileError)
+          const reloaded = yield* lifecycle.getWorkItem(existing.id)
+          expect(reloaded.mergeMode).toBe("ordinary")
+          expect(reloaded.autoMergeOverride).toBeNull()
+        }).pipe(Effect.provide(lifecycleLayer(mutableLayer))),
+      )
+    })
+
+    it("leaves Implement All with Auto-merge pinning Always with no profile", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-implement-all-still.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "build-model",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 110)
+          yield* storeOpenChildIssue(db, repo.id, 111, 110)
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repo.id,
+            110,
+          )
+          expect(covered).toHaveLength(1)
+          expect(covered[0]!.executionProfile).toBeNull()
+          expect(covered[0]!.mergeMode).toBe("always")
+          expect(covered[0]!.pauseBeforeStep).toBeNull()
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
+
+    it("keeps Implement Now and Implement Locally rejected as not a leaf", async () => {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const lifecycle = yield* WorkItemLifecycle
+          const repo = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: "/repos/acme/widgets-parent-leaf-commands.git",
+            isBare: true,
+          })
+          yield* seedHarness(db, {
+            selectedAgentBackend: "opencode",
+            defaultModel: "build-model",
+          })
+          yield* storeOpenParentIssue(db, repo.id, 120)
+          yield* storeOpenChildIssue(db, repo.id, 121, 120)
+          const now = yield* Effect.flip(lifecycle.implementNow(repo.id, 120))
+          expect(now).toBeInstanceOf(ParentIssueError)
+          const locally = yield* Effect.flip(
+            lifecycle.implementLocally(repo.id, 120),
+          )
+          expect(locally).toBeInstanceOf(ParentIssueError)
+          expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 120)).toEqual(
+            [],
+          )
+        }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+      )
+    })
   })
 
   it("creates a Work Item with a durable complete explicit profile", async () => {


### PR DESCRIPTION
Parent Issues could only start children with Implement all with auto-merge: repository defaults and an Always pin. Choosing a backend, models, or a Merge Policy other than Always meant repeating Implement With on each child.

This change allows Implement With on a Parent Issue (#1242). The parent kebab keeps Implement all with auto-merge first and adds Implement all with… directly below. That dialog is the existing Implement With form without Implement Locally, titled Implement all with…, with Implement / Cancel, and pre-filled from the Repository.

Submit uses the same atomic enrollment snapshot as Implement all with auto-merge: open children at accept time, later children excluded, unsupported hierarchy refused. New child Work Items get the submitted Explicit Work Item Execution Profile and Merge Policy pin and start remotely (blocked children Queue, then start remotely with that profile and pin). Unfinished children are adopted: the pin is written, profile and pause are not rewritten, there is no Reset, and a merge-related Needs Human handoff stays stopped. The parent itself is not enrolled and is not closed or updated. Implement all with auto-merge still pins Always with no explicit profile and no dialog. Implement Now and Implement Locally on a parent still fail as not a leaf. An explicit Implement Locally pause on a parent fails and creates nothing.

Verified at the existing Implement With command (enrollment, pin vs profile, pause rejected, atomic rollback, empty catalog creates nothing) plus parent kebab order and dialog chrome, GraphQL list mapping, and Implement all with auto-merge regression.

Review deferred internal copy and backend-activate duplication in the parent enrollment helper; no operator-facing contract change.

Closes #1242