### PR TITLE
feat: opt Repositories into GitHub CI Gate Definitions from live Actions workflows

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -195,6 +195,25 @@ const agentBackendsQuery = {
   },
 }
 
+const ciGateCatalogQuery = (repositoryId: string) => ({
+  queryKey: ["ciGateCatalog", repositoryId] as const,
+  queryFn: async () => {
+    const result = await graphql.query({
+      ciGateCatalog: {
+        __args: { repositoryId },
+        error: true,
+        definitions: {
+          identity: true,
+          displayLabel: true,
+          kind: true,
+          diagnosticMetadata: true,
+        },
+      },
+    })
+    return result.ciGateCatalog
+  },
+})
+
 /** Empty select value means inherit the harness default (null override). */
 const HARNESS_DEFAULT_BACKEND_VALUE = ""
 
@@ -860,6 +879,10 @@ function RepositoryCard({
     ...agentBackendsQuery,
     enabled: dialogOpen,
   })
+  const ciGateCatalog = useQuery({
+    ...ciGateCatalogQuery(repository.id),
+    enabled: dialogOpen,
+  })
   const [forge, setForge] = useState<Forge>(repository.forge)
   const [forgeHost, setForgeHost] = useState(repository.forgeHost)
   const [projectPath, setProjectPath] = useState(repository.projectPath)
@@ -884,6 +907,11 @@ function RepositoryCard({
   )
   const [waitForReadyForReviewChecks, setWaitForReadyForReviewChecks] =
     useState(repository.waitForReadyForReviewChecks)
+  const [selectedCiGateIdentities, setSelectedCiGateIdentities] = useState(() =>
+    repository.selectedCiGateDefinitions.map(
+      (definition) => definition.identity,
+    ),
+  )
   const [previewModels, setPreviewModels] = useState<
     readonly AgentModelOption[] | null
   >(null)
@@ -929,6 +957,7 @@ function RepositoryCard({
       mergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
       includeAllIssueAuthors: boolean
       waitForReadyForReviewChecks: boolean
+      selectedCiGateDefinitionIdentities: string[]
     }) => {
       const result = await graphql.mutation({
         updateRepositorySettings: {
@@ -949,6 +978,12 @@ function RepositoryCard({
           mergePolicy: true,
           includeAllIssueAuthors: true,
           waitForReadyForReviewChecks: true,
+          selectedCiGateDefinitions: {
+            identity: true,
+            displayLabel: true,
+            kind: true,
+            diagnosticMetadata: true,
+          },
           issuesReconciledAt: true,
           blockingUnfinishedWorkItemCount: true,
         },
@@ -1090,6 +1125,11 @@ function RepositoryCard({
     setMergePolicy(repository.mergePolicy)
     setIncludeAllIssueAuthors(repository.includeAllIssueAuthors)
     setWaitForReadyForReviewChecks(repository.waitForReadyForReviewChecks)
+    setSelectedCiGateIdentities(
+      repository.selectedCiGateDefinitions.map(
+        (definition) => definition.identity,
+      ),
+    )
     setPreviewModels(null)
     setPreviewProvider(null)
     setPreviewWarnings([])
@@ -1119,6 +1159,7 @@ function RepositoryCard({
     void config.refetch()
     void models.refetch()
     void agentBackends.refetch()
+    void ciGateCatalog.refetch()
   }
 
   /**
@@ -1613,6 +1654,27 @@ function RepositoryCard({
     blockSaveForBuildThinking ||
     blockSaveForReviewThinking
 
+  const ciGateCatalogDefinitions =
+    ciGateCatalog.data !== undefined && ciGateCatalog.data.error === null
+      ? ciGateCatalog.data.definitions
+      : null
+  const unavailableCiGateDefinitions =
+    ciGateCatalogDefinitions === null
+      ? []
+      : repository.selectedCiGateDefinitions.filter(
+          (definition) =>
+            selectedCiGateIdentities.includes(definition.identity) &&
+            !ciGateCatalogDefinitions.some(
+              (entry) => entry.identity === definition.identity,
+            ),
+        )
+  const persistedCiGateDefinitions =
+    ciGateCatalog.data?.error === undefined || ciGateCatalog.data.error === null
+      ? []
+      : repository.selectedCiGateDefinitions.filter((definition) =>
+          selectedCiGateIdentities.includes(definition.identity),
+        )
+
   const saveSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     if (repositorySettingsSaveBlocked) {
@@ -1634,6 +1696,7 @@ function RepositoryCard({
       mergePolicy,
       includeAllIssueAuthors,
       waitForReadyForReviewChecks,
+      selectedCiGateDefinitionIdentities: [...selectedCiGateIdentities],
     })
   }
 
@@ -2183,6 +2246,144 @@ function RepositoryCard({
 
               <section
                 className={ui.dialogSection}
+                aria-labelledby={`repo-sec-ci-gate-${repository.id}`}
+              >
+                <div className={ui.dialogSectionHead}>
+                  <h3
+                    id={`repo-sec-ci-gate-${repository.id}`}
+                    className={ui.dialogSectionTitle}
+                  >
+                    CI Gate
+                  </h3>
+                  <span className={ui.dialogSectionMeta}>
+                    Default-branch CI
+                  </span>
+                </div>
+                {ciGateCatalog.isPending ? (
+                  <p className={ui.dialogFieldHint}>
+                    Loading CI Gate Definitions…
+                  </p>
+                ) : null}
+                {ciGateCatalog.data?.error ? (
+                  <p className={ui.dialogFieldHint} role="alert">
+                    {ciGateCatalog.data.error}
+                  </p>
+                ) : null}
+                {ciGateCatalogDefinitions !== null
+                  ? ciGateCatalogDefinitions.map((definition) => {
+                      const checked = selectedCiGateIdentities.includes(
+                        definition.identity,
+                      )
+                      return (
+                        <label
+                          key={definition.identity}
+                          className={ui.dialogCheck}
+                        >
+                          <input
+                            type="checkbox"
+                            className={ui.dialogCheckInput}
+                            name="selectedCiGateDefinitionIdentities"
+                            value={definition.identity}
+                            checked={checked}
+                            onChange={(event) => {
+                              const nextChecked = event.target.checked
+                              setSelectedCiGateIdentities((current) =>
+                                nextChecked
+                                  ? current.includes(definition.identity)
+                                    ? current
+                                    : [...current, definition.identity]
+                                  : current.filter(
+                                      (identity) =>
+                                        identity !== definition.identity,
+                                    ),
+                              )
+                            }}
+                          />
+                          {definition.displayLabel}
+                          {definition.diagnosticMetadata !== null &&
+                          definition.diagnosticMetadata !== "" ? (
+                            <span
+                              className={cx(
+                                ui.dialogFieldHint,
+                                ui.dialogCheckHint,
+                              )}
+                            >
+                              {definition.diagnosticMetadata}
+                            </span>
+                          ) : null}
+                        </label>
+                      )
+                    })
+                  : null}
+                {unavailableCiGateDefinitions.map((definition) => (
+                  <label
+                    key={`unavailable-${definition.identity}`}
+                    className={ui.dialogCheck}
+                  >
+                    <input
+                      type="checkbox"
+                      className={ui.dialogCheckInput}
+                      name="selectedCiGateDefinitionIdentities"
+                      value={definition.identity}
+                      checked
+                      onChange={() => {
+                        setSelectedCiGateIdentities((current) =>
+                          current.filter(
+                            (identity) => identity !== definition.identity,
+                          ),
+                        )
+                      }}
+                    />
+                    {definition.displayLabel} (unavailable)
+                    {definition.diagnosticMetadata !== null &&
+                    definition.diagnosticMetadata !== "" ? (
+                      <span
+                        className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}
+                      >
+                        {definition.diagnosticMetadata}
+                      </span>
+                    ) : null}
+                  </label>
+                ))}
+                {persistedCiGateDefinitions.map((definition) => (
+                  <label
+                    key={`persisted-${definition.identity}`}
+                    className={ui.dialogCheck}
+                  >
+                    <input
+                      type="checkbox"
+                      className={ui.dialogCheckInput}
+                      name="selectedCiGateDefinitionIdentities"
+                      value={definition.identity}
+                      checked
+                      onChange={() => {
+                        setSelectedCiGateIdentities((current) =>
+                          current.filter(
+                            (identity) => identity !== definition.identity,
+                          ),
+                        )
+                      }}
+                    />
+                    {definition.displayLabel}
+                    {definition.diagnosticMetadata !== null &&
+                    definition.diagnosticMetadata !== "" ? (
+                      <span
+                        className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}
+                      >
+                        {definition.diagnosticMetadata}
+                      </span>
+                    ) : null}
+                  </label>
+                ))}
+                <span className={ui.dialogFieldHint}>
+                  {selectedCiGateIdentities.length === 0
+                    ? "No CI Gate Definitions selected — Repository CI Gate is disabled."
+                    : "Selected definitions watch default-branch CI. Empty selection disables the Repository CI Gate."}
+                </span>
+              </section>
+
+              <section
+                className={ui.dialogSection}
                 aria-labelledby={`repo-sec-agent-${repository.id}`}
               >
                 <div className={ui.dialogSectionHead}>
@@ -2631,6 +2832,16 @@ function RepositoryCard({
                     : repository.mergePolicy === "CLASSIFY"
                       ? "Classify"
                       : "Off"}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>CI Gate</dt>
+                <dd>
+                  {repository.selectedCiGateDefinitions.length === 0
+                    ? "Disabled"
+                    : repository.selectedCiGateDefinitions
+                        .map((definition) => definition.displayLabel)
+                        .join(", ")}
                 </dd>
               </div>
             </dl>

--- a/apps/harness/src/repositories-query.ts
+++ b/apps/harness/src/repositories-query.ts
@@ -39,7 +39,7 @@ export const decodeForge = (value: unknown): Forge => {
   }
 }
 
-export type CiGateDefinition = {
+type CiGateDefinition = {
   identity: string
   displayLabel: string
   kind: string

--- a/apps/harness/src/repositories-query.ts
+++ b/apps/harness/src/repositories-query.ts
@@ -39,6 +39,13 @@ export const decodeForge = (value: unknown): Forge => {
   }
 }
 
+export type CiGateDefinition = {
+  identity: string
+  displayLabel: string
+  kind: string
+  diagnosticMetadata: string | null
+}
+
 export type Repository = {
   id: string
   forge: Forge
@@ -56,6 +63,7 @@ export type Repository = {
   mergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
   includeAllIssueAuthors: boolean
   waitForReadyForReviewChecks: boolean
+  selectedCiGateDefinitions: readonly CiGateDefinition[]
   issuesReconciledAt: string | null
   blockingUnfinishedWorkItemCount: number
   credential: RepositoryCredential
@@ -86,6 +94,12 @@ export const repositoriesQuery = {
         mergePolicy: true,
         includeAllIssueAuthors: true,
         waitForReadyForReviewChecks: true,
+        selectedCiGateDefinitions: {
+          identity: true,
+          displayLabel: true,
+          kind: true,
+          diagnosticMetadata: true,
+        },
         issuesReconciledAt: true,
         blockingUnfinishedWorkItemCount: true,
       },

--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -397,6 +397,15 @@ export const ambientGitHubLayer = (options: {
                 service.listReadyIssues(repository, operationOptions),
             ),
         ),
+        listCiGateCatalog: Effect.fn("AmbientGitHub.listCiGateCatalog")(
+          (repository, operationOptions?: GitHubOperationOptions) =>
+            authenticated(
+              operationOptions?.origin ?? "operator",
+              repository,
+              (service) =>
+                service.listCiGateCatalog(repository, operationOptions),
+            ),
+        ),
       } satisfies GitHubServiceShape
     }),
   )

--- a/apps/harness/src/server/forge-helper-schemas.ts
+++ b/apps/harness/src/server/forge-helper-schemas.ts
@@ -131,6 +131,15 @@ export const SerializedPrStatusCheckDiagnostics = Schema.Array(
   SerializedPrStatusCheckDiagnostic,
 )
 
+export const SerializedCiGateCatalog = Schema.Array(
+  Schema.Struct({
+    identity: RequiredString,
+    displayLabel: RequiredString,
+    kind: RequiredString,
+    diagnosticMetadata: Schema.NullOr(Schema.String),
+  }),
+)
+
 const SerializedPullRequestCheckStatusFields = {
   mergeability: Schema.Literals(["mergeable", "conflicting", "unknown"]),
   baseRefName: Schema.NullOr(Schema.String),

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -32,6 +32,7 @@ import {
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import {
+  SerializedCiGateCatalog,
   SerializedMergePullRequestResult,
   SerializedPrStatusCheckDiagnostics,
   SerializedPullRequestCheckStatus,
@@ -871,6 +872,20 @@ export const keymaxxerGitHubLayer = (options: {
               describe: "list Ready-labeled Issues",
               origin: operationOptions?.origin ?? "polling",
               decode: (stdout) => parseIssues(stdout, repository),
+            }),
+        ),
+        listCiGateCatalog: Effect.fn("KeymaxxerGitHub.listCiGateCatalog")(
+          (repository, operationOptions?: GitHubOperationOptions) =>
+            callHelper({
+              operation: "list-ci-gate-catalog",
+              repository,
+              describe: "list CI Gate Definitions",
+              origin: operationOptions?.origin ?? "operator",
+              decode: decodeJson(
+                SerializedCiGateCatalog,
+                repository,
+                "decode CI Gate catalog",
+              ),
             }),
         ),
       }

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -54,6 +54,7 @@ const serviceWithList = (
   rerunWorkflowRun: () => Effect.void,
   uploadUserAttachment: () => Effect.die("not used"),
   ensureIssueCompletedWithSummary: () => Effect.die("not used"),
+  listCiGateCatalog: () => Effect.succeed([]),
 })
 
 const serviceWithAuthenticatedUser = (

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -261,6 +261,7 @@ const defaultGithubLayer = Layer.mergeAll(
         "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
       ),
     ensureIssueCompletedWithSummary: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     listReadyIssues: () => Effect.succeed([]),
   } satisfies GitHubServiceShape),
@@ -837,6 +838,7 @@ describe("Job worker", () => {
             "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
           ),
         ensureIssueCompletedWithSummary: () => Effect.void,
+        listCiGateCatalog: () => Effect.succeed([]),
         getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
         listReadyIssues: () =>
           Effect.succeed([

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1877,6 +1877,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           rerunWorkflowRun: () => Effect.die("not used"),
           uploadUserAttachment: () => Effect.die("not used"),
           ensureIssueCompletedWithSummary: () => Effect.die("not used"),
+          listCiGateCatalog: () => Effect.succeed([]),
         } satisfies GitHubServiceShape
         const scope = yield* Effect.scope
         const keymaxxerContext = yield* Layer.buildWithScope(
@@ -1981,6 +1982,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           rerunWorkflowRun: () => Effect.die("not used"),
           uploadUserAttachment: () => Effect.die("not used"),
           ensureIssueCompletedWithSummary: () => Effect.die("not used"),
+          listCiGateCatalog: () => Effect.succeed([]),
         } satisfies GitHubServiceShape
         const scope = yield* Effect.scope
         const keymaxxerContext = yield* Layer.buildWithScope(

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -110,6 +110,7 @@ const defaultGithub: GitHubServiceShape = {
       "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
     ),
   ensureIssueCompletedWithSummary: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
   listReadyIssues: () => Effect.succeed([]),
 }
 

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -112,6 +112,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "Review model",
       "Wait for ready checks",
       "Merge Policy",
+      "CI Gate",
     ])
 
     const ui = uiSource()

--- a/apps/harness/test/repository-settings-ci-gate.test.ts
+++ b/apps/harness/test/repository-settings-ci-gate.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const indexSource = () =>
+  readFileSync(join(import.meta.dir, "../src/home-page-content.tsx"), "utf8")
+
+const repositoriesQuerySource = () =>
+  readFileSync(join(import.meta.dir, "../src/repositories-query.ts"), "utf8")
+
+describe("Repository settings CI Gate Definitions", () => {
+  test("loads the live catalog and covers selection states in settings", () => {
+    const source = indexSource()
+    expect(source).toContain("CI Gate")
+    expect(source).toContain("Loading CI Gate Definitions…")
+    expect(source).toContain("repo-sec-ci-gate-")
+    expect(source).toContain("ciGateCatalog")
+    expect(source).toContain("selectedCiGateDefinitionIdentities")
+    expect(source).toContain("(unavailable)")
+    expect(source).toContain(
+      "No CI Gate Definitions selected — Repository CI Gate is disabled.",
+    )
+    expect(source).toContain('role="alert"')
+    expect(source).toMatch(
+      /updateSettings\.mutate\(\{[\s\S]*selectedCiGateDefinitionIdentities: \[\.\.\.selectedCiGateIdentities\]/,
+    )
+    expect(source).toContain("setSelectedCiGateIdentities")
+    expect(source).toContain("repository.selectedCiGateDefinitions.map(")
+  })
+
+  test("shows persisted selections and empty default on the Repository card", () => {
+    const source = indexSource()
+    expect(source).toContain("<dt>CI Gate</dt>")
+    expect(source).toContain(
+      "repository.selectedCiGateDefinitions.length === 0",
+    )
+    expect(source).toContain('? "Disabled"')
+    expect(source).toContain("definition.displayLabel")
+  })
+
+  test("repositories query asks for selected CI Gate Definitions", () => {
+    const source = repositoriesQuerySource()
+    expect(source).toContain("selectedCiGateDefinitions")
+    expect(source).toContain("displayLabel: true")
+    expect(source).toContain("diagnosticMetadata: true")
+  })
+})

--- a/packages/db-schema/drizzle/20260907120000_repository_ci_gate_definitions/migration.sql
+++ b/packages/db-schema/drizzle/20260907120000_repository_ci_gate_definitions/migration.sql
@@ -1,0 +1,15 @@
+-- Repository-owned CI Gate Definition selections. Existing Repositories
+-- receive no rows: empty selection disables the Repository CI Gate.
+CREATE TABLE `ci_gate_definition` (
+	`id` text PRIMARY KEY NOT NULL,
+	`repository_id` text NOT NULL,
+	`identity` text NOT NULL,
+	`display_label` text NOT NULL,
+	`kind` text NOT NULL,
+	`diagnostic_metadata` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`repository_id`) REFERENCES `repository`(`id`) ON DELETE CASCADE
+);--> statement-breakpoint
+CREATE UNIQUE INDEX `ci_gate_definition_repository_id_identity_uidx` ON `ci_gate_definition` (`repository_id`,`identity`);--> statement-breakpoint
+CREATE INDEX `ci_gate_definition_repository_id_idx` ON `ci_gate_definition` (`repository_id`);

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -509,6 +509,40 @@ export const autonomousRetry = snakeCase.table(
 )
 
 /**
+ * Repository-owned CI Gate Definition selection. Empty means the Repository
+ * CI Gate is disabled. Identity is Forge-native and unique per Repository.
+ * See xplain: type ci gate definition "cgd"
+ */
+export const ciGateDefinition = snakeCase.table(
+  "ci_gate_definition",
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => `cgd-${ulid()}`),
+    repositoryId: text()
+      .notNull()
+      .references(() => repository.id, { onDelete: "cascade" }),
+    identity: text().notNull(),
+    displayLabel: text().notNull(),
+    kind: text().notNull(),
+    diagnosticMetadata: text(),
+    createdAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (t) => [
+    uniqueIndex("ci_gate_definition_repository_id_identity_uidx").on(
+      t.repositoryId,
+      t.identity,
+    ),
+    index("ci_gate_definition_repository_id_idx").on(t.repositoryId),
+  ],
+)
+
+/**
  * Durable autonomous whole-review workflow rerun permits for a Work Item.
  * Scoped by PR head SHA and workflow run identity; initial execution is free.
  * See xplain: type automated review rerun "arr"

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -20,6 +20,8 @@ import {
 import {
   type AddRepositoryInput,
   type BackendModelPrefs,
+  type CiGateDefinitionRecord,
+  CiGateDefinitionSqlRow,
   ConfigRecord,
   ConfigSqlRow,
   GuaranteedMinSumSqlRow,
@@ -270,6 +272,10 @@ const decodeRepositoryRows = (rows: ReadonlyArray<unknown>) =>
   Schema.decodeUnknownEffect(Schema.Array(RepositorySqlRow))(rows).pipe(
     Effect.mapError(toSchemaDatabaseError),
   )
+const decodeCiGateDefinitionRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(CiGateDefinitionSqlRow))(rows).pipe(
+    Effect.mapError(toSchemaDatabaseError),
+  )
 const decodeConfigRows = (rows: ReadonlyArray<unknown>) =>
   Schema.decodeUnknownEffect(Schema.Array(ConfigSqlRow))(rows).pipe(
     Effect.mapError(toSchemaDatabaseError),
@@ -451,6 +457,12 @@ export interface DbServiceShape {
     | RepositoryNotFoundError
     | GuaranteedMinAgentTurnsExceedsCapError
     | DatabaseError
+  >
+  readonly listCiGateDefinitions: (
+    repositoryId: string,
+  ) => Effect.Effect<
+    readonly CiGateDefinitionRecord[],
+    RepositoryNotFoundError | DatabaseError
   >
   readonly pauseRepository: (
     repositoryId: string,
@@ -1155,6 +1167,77 @@ export const DbServiceLive = Layer.effect(
       return repository
     })
 
+    const replaceCiGateDefinitions = Effect.fn(
+      "DbService.replaceCiGateDefinitions",
+    )(function* (input: {
+      readonly repositoryId: string
+      readonly definitions: readonly CiGateDefinitionRecord[]
+      readonly now: number
+    }) {
+      const normalized: CiGateDefinitionRecord[] = []
+      const seen = new Set<string>()
+      for (const definition of input.definitions) {
+        const identity = definition.identity.trim()
+        const displayLabel = definition.displayLabel.trim()
+        const kind = definition.kind.trim()
+        const diagnosticMetadata =
+          definition.diagnosticMetadata === null
+            ? null
+            : definition.diagnosticMetadata.trim() === ""
+              ? null
+              : definition.diagnosticMetadata.trim()
+        if (
+          identity.length === 0 ||
+          displayLabel.length === 0 ||
+          kind.length === 0
+        ) {
+          return yield* new InvalidRepositorySettingsError({
+            field: "selectedCiGateDefinitionIdentities",
+            message:
+              "Each CI Gate Definition needs a stable identity, display label, and kind",
+          })
+        }
+        if (seen.has(identity)) {
+          return yield* new InvalidRepositorySettingsError({
+            field: "selectedCiGateDefinitionIdentities",
+            message: `Duplicate CI Gate Definition identity: ${identity}`,
+          })
+        }
+        seen.add(identity)
+        normalized.push({
+          identity,
+          displayLabel,
+          kind,
+          diagnosticMetadata,
+        })
+      }
+      yield* sql
+        .unsafe(`DELETE FROM ci_gate_definition WHERE repository_id = ?`, [
+          input.repositoryId,
+        ])
+        .pipe(Effect.mapError(toDatabaseError))
+      for (const definition of normalized) {
+        yield* sql
+          .unsafe(
+            `INSERT INTO ci_gate_definition (
+               id, repository_id, identity, display_label, kind,
+               diagnostic_metadata, created_at, updated_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+            [
+              `cgd-${ulid()}`,
+              input.repositoryId,
+              definition.identity,
+              definition.displayLabel,
+              definition.kind,
+              definition.diagnosticMetadata,
+              input.now,
+              input.now,
+            ],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+      }
+    })
+
     const updateRepositorySettings = Effect.fn(
       "DbService.updateRepositorySettings",
     )(function* (input: UpdateRepositorySettingsInput) {
@@ -1352,7 +1435,7 @@ export const DbServiceLive = Layer.effect(
             // the (possibly empty) prefs for the new effective backend — which
             // we just wrote from this request's model fields.
             const backendModelPrefs = serializeBackendModelPrefsMap(prefsMap)
-            return yield* sql
+            const updatedRows = yield* sql
               .unsafe(
                 `UPDATE repository
              SET forge = ?,
@@ -1392,6 +1475,14 @@ export const DbServiceLive = Layer.effect(
                 ],
               )
               .pipe(Effect.mapError(toDatabaseError))
+            if (input.selectedCiGateDefinitions !== undefined) {
+              yield* replaceCiGateDefinitions({
+                repositoryId: input.repositoryId,
+                definitions: input.selectedCiGateDefinitions,
+                now,
+              })
+            }
+            return updatedRows
           }),
         )
         .pipe(
@@ -1498,6 +1589,25 @@ export const DbServiceLive = Layer.effect(
       const decoded = yield* decodeRepositoryRows(repositories)
       return decoded.map((row) => toRepositoryRecord(row))
     }).pipe(Effect.withSpan("DbService.listRepositories"))
+
+    const listCiGateDefinitions = Effect.fn("DbService.listCiGateDefinitions")(
+      function* (repositoryId: string) {
+        yield* ensureRepositoryExists(repositoryId)
+        const rows = yield* sql
+          .unsafe(
+            `SELECT identity,
+                    display_label,
+                    kind,
+                    diagnostic_metadata
+             FROM ci_gate_definition
+             WHERE repository_id = ?
+             ORDER BY display_label COLLATE NOCASE, identity`,
+            [repositoryId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+        return yield* decodeCiGateDefinitionRows(rows)
+      },
+    )
 
     const ensureRepositoryExists = Effect.fn(
       "DbService.ensureRepositoryExists",
@@ -1959,6 +2069,7 @@ export const DbServiceLive = Layer.effect(
       listSelectedOrInUseBackendIds,
       addRepository,
       updateRepositorySettings,
+      listCiGateDefinitions,
       pauseRepository,
       unpauseRepository,
       listRepositories,

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -112,6 +112,7 @@ export class InvalidRepositorySettingsError extends Schema.TaggedErrorClass<Inva
       "reviewModel",
       "reviewThinkingLevel",
       "guaranteedMinConcurrentAgentTurns",
+      "selectedCiGateDefinitionIdentities",
     ]),
     message: Schema.String,
   },

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -70,6 +70,7 @@ export const stubDbService = (
   listSelectedOrInUseBackendIds: Effect.succeed(["opencode"]),
   addRepository: unused,
   updateRepositorySettings: unused,
+  listCiGateDefinitions: () => Effect.succeed([]),
   pauseRepository: unused,
   unpauseRepository: unused,
   listRepositories: unused(),

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -65,6 +65,14 @@ export const RepositoryRecord = Schema.Struct({
 })
 export type RepositoryRecord = typeof RepositoryRecord.Type
 
+export const CiGateDefinitionRecord = Schema.Struct({
+  identity: Schema.String,
+  displayLabel: Schema.String,
+  kind: Schema.String,
+  diagnosticMetadata: Schema.NullOr(Schema.String),
+})
+export type CiGateDefinitionRecord = typeof CiGateDefinitionRecord.Type
+
 export const UpdateRepositorySettingsInput = Schema.Struct({
   repositoryId: Schema.String,
   /** Omitted identity fields leave the persisted Forge identity unchanged. */
@@ -93,6 +101,13 @@ export const UpdateRepositorySettingsInput = Schema.Struct({
   ),
   includeAllIssueAuthors: Schema.Boolean,
   waitForReadyForReviewChecks: Schema.Boolean,
+  /**
+   * Selected CI Gate Definitions. Omitted leaves stored selections unchanged.
+   * Empty array clears every selection and disables the Repository CI Gate.
+   */
+  selectedCiGateDefinitions: Schema.optionalKey(
+    Schema.Array(CiGateDefinitionRecord),
+  ),
 })
 export type UpdateRepositorySettingsInput =
   typeof UpdateRepositorySettingsInput.Type
@@ -231,6 +246,19 @@ export const RepositorySqlRow = Schema.Struct({
   }),
 )
 export type RepositorySqlRow = typeof RepositorySqlRow.Type
+
+export const CiGateDefinitionSqlRow = Schema.Struct({
+  identity: Schema.String,
+  displayLabel: Schema.String,
+  kind: Schema.String,
+  diagnosticMetadata: Schema.NullOr(Schema.String),
+}).pipe(
+  Schema.encodeKeys({
+    displayLabel: "display_label",
+    diagnosticMetadata: "diagnostic_metadata",
+  }),
+)
+export type CiGateDefinitionSqlRow = typeof CiGateDefinitionSqlRow.Type
 
 export const ConfigSqlRow = Schema.Struct({
   selectedAgentBackend: Schema.String,

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -1923,6 +1923,92 @@ describe("DbService", () => {
           expect(error).toBeInstanceOf(RepositoryNotFoundError)
         }),
       ))
+
+    it("starts new Repositories with no CI Gate Definitions", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          expect(yield* db.listCiGateDefinitions(repo.id)).toEqual([])
+        }),
+      ))
+
+    it("persists selected CI Gate Definitions and keeps last-known metadata when omitted", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          const settings = {
+            repositoryId: repo.id,
+            paused: true,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            mergePolicy: "off" as const,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          }
+          yield* db.updateRepositorySettings({
+            ...settings,
+            selectedCiGateDefinitions: [
+              {
+                identity: "161335",
+                displayLabel: "CI",
+                kind: "workflow",
+                diagnosticMetadata: ".github/workflows/ci.yml",
+              },
+              {
+                identity: "269289",
+                displayLabel: "Linter",
+                kind: "workflow",
+                diagnosticMetadata: ".github/workflows/linter.yml",
+              },
+            ],
+          })
+          expect(yield* db.listCiGateDefinitions(repo.id)).toEqual([
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+            {
+              identity: "269289",
+              displayLabel: "Linter",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/linter.yml",
+            },
+          ])
+
+          yield* db.updateRepositorySettings({
+            ...settings,
+            paused: false,
+          })
+          expect((yield* db.listRepositories)[0]?.paused).toBe(false)
+          expect(yield* db.listCiGateDefinitions(repo.id)).toEqual([
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+            {
+              identity: "269289",
+              displayLabel: "Linter",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/linter.yml",
+            },
+          ])
+
+          yield* db.updateRepositorySettings({
+            ...settings,
+            paused: false,
+            selectedCiGateDefinitions: [],
+          })
+          expect(yield* db.listCiGateDefinitions(repo.id)).toEqual([])
+        }),
+      ))
   })
 
   describe("pauseRepository and unpauseRepository", () => {

--- a/packages/db/test/ci-gate-definition-migration.spec.ts
+++ b/packages/db/test/ci-gate-definition-migration.spec.ts
@@ -1,0 +1,87 @@
+import { readFile, readdir } from "node:fs/promises"
+import { join } from "node:path"
+import { Effect } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { SqliteTest } from "../src/lib/database-test.js"
+import {
+  defaultMigrationsFolder,
+  runMigrationsFromSources,
+} from "../src/lib/run-migrations.js"
+import { describe, expect, it } from "bun:test"
+
+const NEW_MIGRATION = "20260907120000_repository_ci_gate_definitions"
+
+const loadMigrationSources = async () => {
+  const names = (
+    await readdir(defaultMigrationsFolder, { withFileTypes: true })
+  )
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((left, right) => left.localeCompare(right))
+  return Promise.all(
+    names.map(async (name) => ({
+      name,
+      sql: await readFile(
+        join(defaultMigrationsFolder, name, "migration.sql"),
+        "utf8",
+      ),
+    })),
+  )
+}
+
+describe("CI Gate Definition migration", () => {
+  it("leaves existing Repositories with no selections and unchanged settings", async () => {
+    const sources = await loadMigrationSources()
+    const prior = sources.filter((source) => source.name !== NEW_MIGRATION)
+    const latest = sources.find((source) => source.name === NEW_MIGRATION)
+    if (latest === undefined) {
+      throw new Error(`Missing migration ${NEW_MIGRATION}`)
+    }
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* runMigrationsFromSources(prior)
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `INSERT INTO repository (
+             id, forge, forge_host, project_path, local_path, is_bare, paused,
+             selected_agent_backend, default_model, default_thinking_level,
+             review_model, review_thinking_level, backend_model_prefs,
+             merge_policy, include_all_issue_authors,
+             wait_for_ready_for_review_checks, created_at, updated_at
+           ) VALUES (
+             'repo-01ARZ3NDEKTSV4RRFFQ69G5FAV', 'github', 'github.com',
+             'acme/widgets', '/repos/acme/widgets.git', 1, 1,
+             NULL, NULL, NULL, NULL, NULL, '{}',
+             'off', 0, 1, 1, 1
+           )`,
+        )
+
+        yield* runMigrationsFromSources([...prior, latest])
+
+        const definitions = (yield* sql.unsafe(
+          "SELECT identity FROM ci_gate_definition",
+        )) as readonly { readonly identity: string }[]
+        expect(definitions).toEqual([])
+
+        const repositories = (yield* sql.unsafe(
+          `SELECT paused, merge_policy AS mergePolicy,
+                  include_all_issue_authors AS includeAllIssueAuthors,
+                  wait_for_ready_for_review_checks AS waitForReadyForReviewChecks
+           FROM repository
+           WHERE id = 'repo-01ARZ3NDEKTSV4RRFFQ69G5FAV'`,
+        )) as readonly {
+          readonly paused: number | boolean
+          readonly mergePolicy: string
+          readonly includeAllIssueAuthors: number | boolean
+          readonly waitForReadyForReviewChecks: number | boolean
+        }[]
+        expect(repositories).toHaveLength(1)
+        expect(Number(repositories[0]?.paused)).toBe(1)
+        expect(repositories[0]?.mergePolicy).toBe("off")
+        expect(Number(repositories[0]?.includeAllIssueAuthors)).toBe(0)
+        expect(Number(repositories[0]?.waitForReadyForReviewChecks)).toBe(1)
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+})

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -378,6 +378,7 @@ describe("runMigrations", () => {
           { name: "20260815180000_autonomous_retry_budget" },
           { name: "20260818120000_repository_merge_policy" },
           { name: "20260819120000_repository_guaranteed_min_agent_turns" },
+          { name: "20260907120000_repository_ci_gate_definitions" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )

--- a/packages/github-service/src/bin/list-ci-gate-catalog.ts
+++ b/packages/github-service/src/bin/list-ci-gate-catalog.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { GitHubService } from "../lib/github-service.js"
+import {
+  decodeArgument,
+  githubRepository,
+  runGitHubCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const listCiGateCatalogProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = githubRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const github = yield* GitHubService
+    const catalog = yield* github.listCiGateCatalog(repository)
+    yield* writeStandardOutput(JSON.stringify(catalog))
+  })
+
+if (import.meta.main)
+  runGitHubCli(listCiGateCatalogProgram(process.argv.slice(2)))

--- a/packages/github-service/src/lib/github-helper-process.ts
+++ b/packages/github-service/src/lib/github-helper-process.ts
@@ -10,6 +10,7 @@ import { getOpenPullRequestNumberProgram } from "../bin/get-open-pr-number.js"
 import { getPrCheckStatusProgram } from "../bin/get-pr-check-status.js"
 import { getPrLifecycleStatusProgram } from "../bin/get-pr-lifecycle-status.js"
 import { getPrStatusCheckDiagnosticsProgram } from "../bin/get-pr-status-check-diagnostics.js"
+import { listCiGateCatalogProgram } from "../bin/list-ci-gate-catalog.js"
 import { listReadyIssuesProgram } from "../bin/list-ready-issues.js"
 import { markPrReadyForReviewProgram } from "../bin/mark-pr-ready-for-review.js"
 import { mergePullRequestProgram } from "../bin/merge-pull-request.js"
@@ -26,6 +27,7 @@ export const INTERNAL_GITHUB_HELPER_ARG =
 
 export const GITHUB_HELPER_OPERATIONS = [
   "list-ready-issues",
+  "list-ci-gate-catalog",
   "get-authenticated-user-login",
   "get-open-pr-number",
   "find-open-pr-number",
@@ -140,6 +142,7 @@ const programs: Record<
   (args: ReadonlyArray<string>) => Effect.Effect<void, unknown, GitHubService>
 > = {
   "list-ready-issues": listReadyIssuesProgram,
+  "list-ci-gate-catalog": listCiGateCatalogProgram,
   "get-authenticated-user-login": getAuthenticatedUserLoginProgram,
   "get-open-pr-number": getOpenPullRequestNumberProgram,
   "find-open-pr-number": findOpenPullRequestNumberProgram,

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -54,6 +54,8 @@ import {
   githubApiHost,
 } from "./tls-trust.js"
 import {
+  type CiGateCatalogEntry,
+  GITHUB_CI_GATE_KIND,
   type GitHubIssueReference,
   type GitHubIssueState,
   type GitHubPullRequestLifecycleState,
@@ -413,6 +415,12 @@ export type RerunWorkflowRun = (
   workflowRunId: number,
   signal?: AbortSignal,
 ) => Promise<void>
+
+/** List active GitHub Actions workflows as CI Gate catalog entries. */
+export type ListCiGateCatalog = (
+  repository: { owner: string; name: string },
+  signal?: AbortSignal,
+) => Promise<readonly CiGateCatalogEntry[]>
 
 /** Upload file bytes as a GitHub user attachment and return the CDN URL. */
 export type UploadUserAttachment = (
@@ -1246,6 +1254,7 @@ const makeGitHubApiService = (
   rerunWorkflowRunImpl?: RerunWorkflowRun,
   observeAutomatedReviewEvidenceImpl?: ObserveAutomatedReviewEvidence,
   uploadUserAttachmentImpl?: UploadUserAttachment,
+  listCiGateCatalogImpl?: ListCiGateCatalog,
 ): GitHubApiServiceShape => ({
   getAuthenticatedUserLogin: Effect.fn(
     "GitHubService.getAuthenticatedUserLogin",
@@ -2277,6 +2286,33 @@ const makeGitHubApiService = (
       )
     },
   ),
+  listCiGateCatalog: Effect.fn("GitHubService.listCiGateCatalog")(
+    function* (repository) {
+      if (listCiGateCatalogImpl === undefined) {
+        return yield* new GitHubRequestError({
+          message: `CI Gate catalog listing is not configured for ${repository.owner}/${repository.name}`,
+          retryable: false,
+        })
+      }
+      const listed = yield* githubRequest(
+        `Failed to list CI Gate Definitions for ${repository.owner}/${repository.name}`,
+        (signal) => listCiGateCatalogImpl(repository, signal),
+      ).pipe(Effect.result)
+      if (Result.isSuccess(listed)) {
+        return listed.success
+      }
+      const error = listed.failure
+      if (error._tag === "GitHubRequestError" && error.statusCode === 403) {
+        return yield* new GitHubRequestError({
+          message: `Failed to list CI Gate Definitions for ${repository.owner}/${repository.name}: Actions read required`,
+          statusCode: 403,
+          retryable: false,
+          cause: error,
+        })
+      }
+      return yield* error
+    },
+  ),
   ensureIssueCompletedWithSummary: Effect.fn(
     "GitHubService.ensureIssueCompletedWithSummary",
   )(function* (repository, issueNumber, workItemId, summaryMarkdown) {
@@ -2972,6 +3008,7 @@ export const makeGitHubService = (
   rerunWorkflowRunImpl?: RerunWorkflowRun,
   observeAutomatedReviewEvidenceImpl?: ObserveAutomatedReviewEvidence,
   uploadUserAttachmentImpl?: UploadUserAttachment,
+  listCiGateCatalogImpl?: ListCiGateCatalog,
 ): GitHubServiceShape => {
   const service = makeGitHubApiService(
     client,
@@ -2980,6 +3017,7 @@ export const makeGitHubService = (
     rerunWorkflowRunImpl,
     observeAutomatedReviewEvidenceImpl,
     uploadUserAttachmentImpl,
+    listCiGateCatalogImpl,
   )
   const adapt = adaptRepository(service)
   return {
@@ -3005,6 +3043,7 @@ export const makeGitHubService = (
     mergePullRequest: adapt(service.mergePullRequest),
     rerunWorkflowRun: adapt(service.rerunWorkflowRun),
     uploadUserAttachment: adapt(service.uploadUserAttachment),
+    listCiGateCatalog: adapt(service.listCiGateCatalog),
     ensureIssueCompletedWithSummary: adapt(
       service.ensureIssueCompletedWithSummary,
     ),
@@ -3184,6 +3223,84 @@ const makeRerunWorkflowRun =
           ? `Failed to rerun workflow run ${workflowRunId} for ${repository.owner}/${repository.name}: Actions write required`
           : `Failed to rerun workflow run ${workflowRunId} for ${repository.owner}/${repository.name}: ${response.statusText}: ${body}`,
     })
+  }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const mapActiveWorkflow = (value: unknown): CiGateCatalogEntry | null => {
+  if (!isRecord(value) || value.state !== "active") {
+    return null
+  }
+  const id = value.id
+  if (typeof id !== "number" || !Number.isSafeInteger(id) || id <= 0) {
+    return null
+  }
+  const name = typeof value.name === "string" ? value.name.trim() : ""
+  if (name.length === 0) {
+    return null
+  }
+  const path =
+    typeof value.path === "string" && value.path.trim() !== ""
+      ? value.path.trim()
+      : null
+  return {
+    identity: String(id),
+    displayLabel: name,
+    kind: GITHUB_CI_GATE_KIND,
+    diagnosticMetadata: path,
+  }
+}
+
+const makeListCiGateCatalog =
+  (token: string, fetchImpl: GitHubFetch): ListCiGateCatalog =>
+  async (repository, signal) => {
+    const entries: CiGateCatalogEntry[] = []
+    for (let page = 1; ; page += 1) {
+      const url = new URL(
+        `${GITHUB_API_URL}/repos/${repository.owner}/${repository.name}/actions/workflows`,
+      )
+      url.searchParams.set("per_page", String(PAGE_SIZE))
+      url.searchParams.set("page", String(page))
+      const response = await fetchImpl(url, {
+        headers: githubRestHeaders(token),
+        signal,
+      })
+      if (!response.ok) {
+        const body = await response.text()
+        const throttle = githubThrottleFromResponse({
+          statusCode: response.status,
+          headers: response.headers,
+          message: `${response.statusText}: ${body}`,
+        })
+        if (throttle !== undefined) {
+          throw throttle
+        }
+        throw new GitHubHttpError({
+          statusCode: response.status,
+          headers: response.headers,
+          message:
+            response.status === 403
+              ? `Failed to list CI Gate Definitions for ${repository.owner}/${repository.name}: Actions read required`
+              : `Failed to list CI Gate Definitions for ${repository.owner}/${repository.name}: ${response.statusText}: ${body}`,
+        })
+      }
+      const payload: unknown = await response.json()
+      const workflows =
+        isRecord(payload) && Array.isArray(payload.workflows)
+          ? payload.workflows
+          : []
+      for (const workflow of workflows) {
+        const mapped = mapActiveWorkflow(workflow)
+        if (mapped !== null) {
+          entries.push(mapped)
+        }
+      }
+      if (workflows.length < PAGE_SIZE) {
+        break
+      }
+    }
+    return entries
   }
 
 const makeUploadUserAttachment =
@@ -3897,6 +4014,7 @@ export const makeGitHubServiceFromToken = (
     makeRerunWorkflowRun(token, observingFetch),
     makeObserveAutomatedReviewEvidence(token, observingFetch),
     makeUploadUserAttachment(token, observingFetch),
+    makeListCiGateCatalog(token, observingFetch),
   )
 }
 

--- a/packages/github-service/src/lib/github-service-test.ts
+++ b/packages/github-service/src/lib/github-service-test.ts
@@ -75,6 +75,7 @@ export const makeGitHubServiceTest = (
       options.uploadUserAttachment ??
       (() => Effect.succeed(TEST_USER_ATTACHMENT_URL)),
     ensureIssueCompletedWithSummary: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
     listReadyIssues: (repository) => {
       const fixture = fixturesByRepository.get(repositoryKey(repository))
       if (fixture === undefined) {

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -5,6 +5,7 @@ import type {
 } from "./automated-review-evidence.js"
 import type { GitHubServiceError } from "./errors.js"
 import type {
+  CiGateCatalogEntry,
   GitHubRepository,
   MergePullRequestOptions,
   MergePullRequestResult,
@@ -46,6 +47,14 @@ export interface GitHubServiceShape {
     repository: GitHubRepository,
     options?: GitHubOperationOptions,
   ) => Effect.Effect<readonly ReadyLabeledIssue[], GitHubServiceError>
+  /**
+   * Live catalog of active GitHub Actions workflows as CI Gate Definitions.
+   * Disabled, deleted, and inactive workflows are omitted.
+   */
+  readonly listCiGateCatalog: (
+    repository: GitHubRepository,
+    options?: GitHubOperationOptions,
+  ) => Effect.Effect<readonly CiGateCatalogEntry[], GitHubServiceError>
   readonly getPullRequestCheckStatus: (
     repository: GitHubRepository,
     headRefName: string,

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -4,6 +4,19 @@ export interface GitHubRepository {
   readonly projectPath: string
 }
 
+/**
+ * Forge-neutral CI Gate catalog entry. GitHub maps an active Actions
+ * workflow to this shape; identity is the workflow id.
+ */
+export const GITHUB_CI_GATE_KIND = "workflow"
+
+export interface CiGateCatalogEntry {
+  readonly identity: string
+  readonly displayLabel: string
+  readonly kind: string
+  readonly diagnosticMetadata: string | null
+}
+
 /** Local file the harness uploads as a GitHub user attachment. */
 export interface UploadUserAttachmentInput {
   readonly name: string

--- a/packages/github-service/test/ci-gate-catalog.spec.ts
+++ b/packages/github-service/test/ci-gate-catalog.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+import {
+  GITHUB_CI_GATE_KIND,
+  GitHubRequestError,
+  GitHubThrottledError,
+  formatUserFacingError,
+  makeGitHubServiceFromToken,
+} from "../src/index.js"
+
+const repository = {
+  forge: "github",
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+}
+
+const workflowPayload = (input: {
+  readonly id: number
+  readonly name: string
+  readonly path: string
+  readonly state: string
+}) => ({
+  id: input.id,
+  node_id: `W_${String(input.id)}`,
+  name: input.name,
+  path: input.path,
+  state: input.state,
+  created_at: "2020-01-08T23:48:37.000-08:00",
+  updated_at: "2020-01-08T23:50:21.000-08:00",
+  url: `https://api.github.com/repos/acme/widgets/actions/workflows/${String(input.id)}`,
+  html_url: `https://github.com/acme/widgets/blob/master/${input.path}`,
+  badge_url: `https://github.com/acme/widgets/workflows/${input.name}/badge.svg`,
+})
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : "Forbidden",
+    headers: { "content-type": "application/json" },
+  })
+
+describe("GitHub CI Gate catalog", () => {
+  it("returns active workflows as catalog entries and omits inactive ones", async () => {
+    const service = makeGitHubServiceFromToken("token", async (input) => {
+      const url = String(input)
+      if (!url.includes("/actions/workflows")) {
+        return new Response("not found", { status: 404 })
+      }
+      return jsonResponse({
+        total_count: 4,
+        workflows: [
+          workflowPayload({
+            id: 161335,
+            name: "CI",
+            path: ".github/workflows/blank.yaml",
+            state: "active",
+          }),
+          workflowPayload({
+            id: 269289,
+            name: "Linter",
+            path: ".github/workflows/linter.yaml",
+            state: "disabled_manually",
+          }),
+          workflowPayload({
+            id: 314159,
+            name: "Nightly",
+            path: ".github/workflows/nightly.yml",
+            state: "disabled_inactivity",
+          }),
+          workflowPayload({
+            id: 271828,
+            name: "Retired",
+            path: ".github/workflows/retired.yml",
+            state: "deleted",
+          }),
+        ],
+      })
+    })
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([
+      {
+        identity: "161335",
+        displayLabel: "CI",
+        kind: GITHUB_CI_GATE_KIND,
+        diagnosticMetadata: ".github/workflows/blank.yaml",
+      },
+    ])
+  })
+
+  it("includes every active workflow across paginated official API pages", async () => {
+    const pageOne = Array.from({ length: 100 }, (_, index) =>
+      workflowPayload({
+        id: index + 1,
+        name: `Workflow ${String(index + 1)}`,
+        path: `.github/workflows/w${String(index + 1)}.yml`,
+        state: "active",
+      }),
+    )
+    const service = makeGitHubServiceFromToken("token", async (input) => {
+      const url = new URL(String(input))
+      if (!url.pathname.endsWith("/actions/workflows")) {
+        return new Response("not found", { status: 404 })
+      }
+      const page = url.searchParams.get("page") ?? "1"
+      if (page === "1") {
+        return jsonResponse({ total_count: 101, workflows: pageOne })
+      }
+      if (page === "2") {
+        return jsonResponse({
+          total_count: 101,
+          workflows: [
+            workflowPayload({
+              id: 9001,
+              name: "Release",
+              path: ".github/workflows/release.yml",
+              state: "active",
+            }),
+          ],
+        })
+      }
+      return jsonResponse({ total_count: 101, workflows: [] })
+    })
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toHaveLength(101)
+    expect(catalog[0]).toEqual({
+      identity: "1",
+      displayLabel: "Workflow 1",
+      kind: GITHUB_CI_GATE_KIND,
+      diagnosticMetadata: ".github/workflows/w1.yml",
+    })
+    expect(catalog[100]).toEqual({
+      identity: "9001",
+      displayLabel: "Release",
+      kind: GITHUB_CI_GATE_KIND,
+      diagnosticMetadata: ".github/workflows/release.yml",
+    })
+  })
+
+  it("skips workflows that lack a stable identity or display label", async () => {
+    const service = makeGitHubServiceFromToken("token", async () =>
+      jsonResponse({
+        total_count: 3,
+        workflows: [
+          {
+            id: "not-a-number",
+            name: "Broken",
+            path: ".github/workflows/broken.yml",
+            state: "active",
+          },
+          workflowPayload({
+            id: 12,
+            name: "   ",
+            path: ".github/workflows/blank.yml",
+            state: "active",
+          }),
+          workflowPayload({
+            id: 42,
+            name: "Build",
+            path: ".github/workflows/build.yml",
+            state: "active",
+          }),
+        ],
+      }),
+    )
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([
+      {
+        identity: "42",
+        displayLabel: "Build",
+        kind: GITHUB_CI_GATE_KIND,
+        diagnosticMetadata: ".github/workflows/build.yml",
+      },
+    ])
+  })
+
+  it.effect(
+    "maps a permission 403 to an actionable catalog error without GitHub body text",
+    () =>
+      Effect.gen(function* () {
+        const service = makeGitHubServiceFromToken(
+          "token",
+          async () =>
+            new Response(
+              JSON.stringify({
+                message: "Resource not accessible by personal access token",
+                documentation_url:
+                  "https://docs.github.com/rest/actions/workflows",
+              }),
+              {
+                status: 403,
+                statusText: "Forbidden",
+                headers: {
+                  "content-type": "application/json",
+                  "X-Accepted-GitHub-Permissions": "actions=read",
+                },
+              },
+            ),
+        )
+
+        const error = yield* service
+          .listCiGateCatalog(repository)
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(error.statusCode).toBe(403)
+        expect(error.retryable).toBe(false)
+        expect(error.message).toContain("Actions read required")
+        expect(error.message).not.toContain(
+          "Resource not accessible by personal access token",
+        )
+        expect(formatUserFacingError(error)).not.toContain(
+          "Resource not accessible by personal access token",
+        )
+      }),
+  )
+
+  it.effect("keeps a throttled 403 as GitHub throttling", () =>
+    Effect.gen(function* () {
+      const resetSeconds = Math.floor(Date.now() / 1_000) + 90
+      const service = makeGitHubServiceFromToken(
+        "token",
+        async () =>
+          new Response("API rate limit exceeded", {
+            status: 403,
+            headers: {
+              "x-ratelimit-remaining": "0",
+              "x-ratelimit-reset": String(resetSeconds),
+            },
+          }),
+      )
+
+      const error = yield* service
+        .listCiGateCatalog(repository)
+        .pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(GitHubThrottledError)
+      expect(error.retryAt).toBe(resetSeconds * 1_000)
+    }),
+  )
+})

--- a/packages/github-service/test/github-helper-process.spec.ts
+++ b/packages/github-service/test/github-helper-process.spec.ts
@@ -92,6 +92,16 @@ describe("internal GitHub helper mode", () => {
     )
   })
 
+  test("spawns the CI Gate catalog helper from source", () => {
+    const spawnPlan = resolveGitHubHelperChildSpawn({
+      operation: "list-ci-gate-catalog",
+      args: ["github", "github.com", "acme/widgets"],
+      execPath: "/usr/bin/bun",
+      argv: ["/usr/bin/bun", "/repo/apps/harness/server.ts"],
+    })
+    expect(spawnPlan.args[2]).toMatch(/list-ci-gate-catalog\.ts$/)
+  })
+
   test("shell formatting quotes every argv token", () => {
     const command = formatGitHubHelperShellCommand({
       command: "/opt/ready-for-agent",

--- a/packages/graphql-api/src/lib/ci-gate-definitions.ts
+++ b/packages/graphql-api/src/lib/ci-gate-definitions.ts
@@ -1,0 +1,117 @@
+import { Effect } from "effect"
+import {
+  type CiGateDefinitionRecord,
+  InvalidRepositorySettingsError,
+} from "@ready-for-agent/db-service"
+import {
+  type CiGateCatalogEntry,
+  formatUserFacingError,
+} from "@ready-for-agent/github-service"
+
+export type CiGateCatalogLoad =
+  | {
+      readonly kind: "loaded"
+      readonly definitions: readonly CiGateCatalogEntry[]
+    }
+  | { readonly kind: "unavailable"; readonly message: string }
+
+export const ciGateCatalogErrorMessage = (error: unknown): string => {
+  const formatted = formatUserFacingError(
+    error,
+    "The live CI Gate catalog could not be loaded",
+  )
+  return formatted.trim() === ""
+    ? "The live CI Gate catalog could not be loaded"
+    : formatted
+}
+
+export const resolveSelectedCiGateDefinitions = (input: {
+  readonly requestedIdentities: readonly string[]
+  readonly existing: readonly CiGateDefinitionRecord[]
+  readonly catalog: CiGateCatalogLoad
+}): Effect.Effect<
+  readonly CiGateDefinitionRecord[],
+  InvalidRepositorySettingsError
+> => {
+  const identities: string[] = []
+  const seen = new Set<string>()
+  for (const raw of input.requestedIdentities) {
+    const identity = raw.trim()
+    if (identity.length === 0) {
+      return Effect.fail(
+        new InvalidRepositorySettingsError({
+          field: "selectedCiGateDefinitionIdentities",
+          message: "CI Gate Definition identities cannot be empty",
+        }),
+      )
+    }
+    if (seen.has(identity)) {
+      return Effect.fail(
+        new InvalidRepositorySettingsError({
+          field: "selectedCiGateDefinitionIdentities",
+          message: `Duplicate CI Gate Definition identity: ${identity}`,
+        }),
+      )
+    }
+    seen.add(identity)
+    identities.push(identity)
+  }
+
+  const existingByIdentity = new Map(
+    input.existing.map((definition) => [definition.identity, definition]),
+  )
+  const catalogByIdentity = new Map(
+    input.catalog.kind === "loaded"
+      ? input.catalog.definitions.map((definition) => [
+          definition.identity,
+          definition,
+        ])
+      : [],
+  )
+  const added = identities.filter(
+    (identity) => !existingByIdentity.has(identity),
+  )
+  if (added.length > 0 && input.catalog.kind === "unavailable") {
+    return Effect.fail(
+      new InvalidRepositorySettingsError({
+        field: "selectedCiGateDefinitionIdentities",
+        message: `Cannot add CI Gate Definitions because the live catalog could not be loaded: ${input.catalog.message}`,
+      }),
+    )
+  }
+  for (const identity of added) {
+    if (!catalogByIdentity.has(identity)) {
+      return Effect.fail(
+        new InvalidRepositorySettingsError({
+          field: "selectedCiGateDefinitionIdentities",
+          message: `CI Gate Definition ${identity} is not in the current catalog. Select an active definition, or remove it from the selection.`,
+        }),
+      )
+    }
+  }
+
+  const resolved: CiGateDefinitionRecord[] = []
+  for (const identity of identities) {
+    const live = catalogByIdentity.get(identity)
+    if (live !== undefined) {
+      resolved.push({
+        identity: live.identity,
+        displayLabel: live.displayLabel,
+        kind: live.kind,
+        diagnosticMetadata: live.diagnosticMetadata,
+      })
+      continue
+    }
+    const existing = existingByIdentity.get(identity)
+    if (existing === undefined) {
+      return Effect.fail(
+        new InvalidRepositorySettingsError({
+          field: "selectedCiGateDefinitionIdentities",
+          message: `CI Gate Definition ${identity} is not in the current catalog. Select an active definition, or remove it from the selection.`,
+        }),
+      )
+    }
+    resolved.push(existing)
+  }
+  return Effect.succeed(resolved)
+}

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -64,6 +64,10 @@ import {
   resolveAddRepositoryCommand,
 } from "./add-repository-command.js"
 import {
+  ciGateCatalogErrorMessage,
+  resolveSelectedCiGateDefinitions,
+} from "./ci-gate-definitions.js"
+import {
   activateRepositoryPolling,
   enqueueRefreshRepositoryJob,
   suspendRepositoryPolling,
@@ -160,6 +164,7 @@ type UpdateRepositorySettingsArgs = {
     mergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
     includeAllIssueAuthors: boolean
     waitForReadyForReviewChecks: boolean
+    selectedCiGateDefinitionIdentities?: readonly string[] | null
   }
 }
 
@@ -455,6 +460,64 @@ const isSameOriginRequest = (request: Request): boolean => {
  * still passes through like the identity-defaulting posture below.
  * Ready Issue listing stays in `@ready-for-agent/issue-reconciler`.
  */
+const loadCiGateCatalog = Effect.fn("graphql-api.loadCiGateCatalog")(
+  function* (repository: {
+    readonly forge: string
+    readonly forgeHost: string
+    readonly projectPath: string
+  }) {
+    if (repository.forge !== "github") {
+      return { kind: "loaded" as const, definitions: [] }
+    }
+    const github = yield* GitHubService
+    return yield* github
+      .listCiGateCatalog(
+        {
+          forge: repository.forge,
+          forgeHost: repository.forgeHost,
+          projectPath: repository.projectPath,
+        },
+        { origin: "operator" },
+      )
+      .pipe(
+        Effect.map((definitions) => ({
+          kind: "loaded" as const,
+          definitions,
+        })),
+        Effect.catch((error) =>
+          Effect.succeed({
+            kind: "unavailable" as const,
+            message: ciGateCatalogErrorMessage(error),
+          }),
+        ),
+      )
+  },
+)
+
+const resolveRepositoryCiGateSelection = Effect.fn(
+  "graphql-api.resolveRepositoryCiGateSelection",
+)(function* (input: {
+  readonly repository: {
+    readonly id: string
+    readonly forge: string
+    readonly forgeHost: string
+    readonly projectPath: string
+  }
+  readonly identities: readonly string[]
+}) {
+  if (input.identities.length === 0) {
+    return []
+  }
+  const db = yield* DbService
+  const existing = yield* db.listCiGateDefinitions(input.repository.id)
+  const catalog = yield* loadCiGateCatalog(input.repository)
+  return yield* resolveSelectedCiGateDefinitions({
+    requestedIdentities: input.identities,
+    existing,
+    catalog,
+  })
+})
+
 const verifyRepositoryIdentity = Effect.fn(
   "graphql-api.verifyRepositoryIdentity",
 )(function* (identity: {
@@ -920,6 +983,30 @@ export const createGraphqlApi = <R>(
               }).pipe(Effect.withSpan("graphql-api.repositoryModelPrefs")),
               context,
             ),
+          ciGateCatalog: async (
+            _parent: unknown,
+            args: { repositoryId: string },
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const repositories = yield* db.listRepositories
+                const repository = repositories.find(
+                  ({ id }) => id === args.repositoryId,
+                )
+                if (repository === undefined) {
+                  return yield* new RepositoryNotFoundError({
+                    repositoryId: args.repositoryId,
+                  })
+                }
+                const catalog = yield* loadCiGateCatalog(repository)
+                return catalog.kind === "loaded"
+                  ? { definitions: catalog.definitions, error: null }
+                  : { definitions: [], error: catalog.message }
+              }).pipe(Effect.withSpan("graphql-api.ciGateCatalog")),
+              context,
+            ),
           models: async (
             _parent: unknown,
             _args: unknown,
@@ -1352,6 +1439,22 @@ export const createGraphqlApi = <R>(
               ),
               context,
             ),
+          selectedCiGateDefinitions: async (
+            repository: { id: string },
+            _args: unknown,
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.listCiGateDefinitions(repository.id)
+              }).pipe(
+                Effect.withSpan(
+                  "graphql-api.Repository.selectedCiGateDefinitions",
+                ),
+              ),
+              context,
+            ),
         },
         WorkItem: {
           agentBackend: (workItem: WorkItemRecord) =>
@@ -1756,6 +1859,18 @@ export const createGraphqlApi = <R>(
                       includeAllIssueAuthors: args.input.includeAllIssueAuthors,
                       waitForReadyForReviewChecks:
                         args.input.waitForReadyForReviewChecks,
+                      ...(args.input.selectedCiGateDefinitionIdentities ===
+                        undefined ||
+                      args.input.selectedCiGateDefinitionIdentities === null
+                        ? {}
+                        : {
+                            selectedCiGateDefinitions:
+                              yield* resolveRepositoryCiGateSelection({
+                                repository,
+                                identities:
+                                  args.input.selectedCiGateDefinitionIdentities,
+                              }),
+                          }),
                     })
                     // Sync Active set (activate missing, drop unused). Prefer
                     // setSelectedOrInUse over activate so repository Saves do

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -25,6 +25,7 @@ import {
 } from "@ready-for-agent/db-service/test"
 import {
   GitHubRepositoryUnavailableError,
+  GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
   GitHubThrottledError,
@@ -231,6 +232,7 @@ const defaultGithub: GitHubServiceShape = {
       "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
     ),
   ensureIssueCompletedWithSummary: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
   listReadyIssues: () => Effect.succeed([]),
 }
 
@@ -12914,5 +12916,346 @@ describe("GraphQL API", () => {
         }),
       ],
     })
+  })
+
+  test("ciGateCatalog returns live GitHub workflows without GitHub-specific types", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.succeed([
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+          ]),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          ciGateCatalog(repositoryId: "${repository.id}") {
+            error
+            definitions { identity displayLabel kind diagnosticMetadata }
+          }
+        }`,
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        ciGateCatalog: {
+          error: null,
+          definitions: [
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("ciGateCatalog returns an actionable error instead of failing the query", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.fail(
+            new GitHubRequestError({
+              message:
+                "Failed to list CI Gate Definitions for acme/widgets: Actions read required",
+              statusCode: 403,
+              retryable: false,
+            }),
+          ),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          ciGateCatalog(repositoryId: "${repository.id}") {
+            error
+            definitions { identity }
+          }
+        }`,
+      }),
+    )
+    const payload = (await response.json()) as {
+      data: {
+        ciGateCatalog: { error: string | null; definitions: unknown[] }
+      }
+    }
+    expect(payload.data.ciGateCatalog.definitions).toEqual([])
+    expect(payload.data.ciGateCatalog.error).toContain("Actions read required")
+  })
+
+  test("updateRepositorySettings saves catalog identities and rejects fabricated ones", async () => {
+    await runtime.dispose()
+    let persisted:
+      | ReadonlyArray<{
+          readonly identity: string
+          readonly displayLabel: string
+          readonly kind: string
+          readonly diagnosticMetadata: string | null
+        }>
+      | undefined
+    let stored: ReadonlyArray<{
+      readonly identity: string
+      readonly displayLabel: string
+      readonly kind: string
+      readonly diagnosticMetadata: string | null
+    }> = []
+    runtime = makeRuntime(
+      {
+        listCiGateDefinitions: () => Effect.succeed(stored),
+        updateRepositorySettings: (input) => {
+          if (input.selectedCiGateDefinitions !== undefined) {
+            persisted = input.selectedCiGateDefinitions
+            stored = [...input.selectedCiGateDefinitions]
+          }
+          return Effect.succeed({ ...repository, paused: input.paused })
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.succeed([
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+          ]),
+      },
+    )
+
+    const settingsInput = {
+      repositoryId: repository.id,
+      paused: true,
+      defaultModel: null,
+      defaultThinkingLevel: null,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+      mergePolicy: "OFF",
+      includeAllIssueAuthors: false,
+      waitForReadyForReviewChecks: true,
+    }
+
+    const saved = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) {
+            selectedCiGateDefinitions { identity displayLabel kind diagnosticMetadata }
+          }
+        }`,
+        variables: {
+          input: {
+            ...settingsInput,
+            selectedCiGateDefinitionIdentities: ["161335"],
+          },
+        },
+      }),
+    )
+    expect(await saved.json()).toEqual({
+      data: {
+        updateRepositorySettings: {
+          selectedCiGateDefinitions: [
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+          ],
+        },
+      },
+    })
+    expect(persisted).toEqual([
+      {
+        identity: "161335",
+        displayLabel: "CI",
+        kind: "workflow",
+        diagnosticMetadata: ".github/workflows/ci.yml",
+      },
+    ])
+
+    const rejected = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) { id }
+        }`,
+        variables: {
+          input: {
+            ...settingsInput,
+            selectedCiGateDefinitionIdentities: ["999"],
+          },
+        },
+      }),
+    )
+    expect(await rejected.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: expect.stringMatching(/not in the current catalog/),
+          extensions: {
+            code: "INVALID_REPOSITORY_SETTINGS",
+            field: "selectedCiGateDefinitionIdentities",
+          },
+        }),
+      ],
+    })
+  })
+
+  test("unavailable saved CI Gate Definitions do not block unrelated settings saves", async () => {
+    await runtime.dispose()
+    let persistedPaused: boolean | undefined
+    let persistedDefinitions:
+      | ReadonlyArray<{ readonly identity: string }>
+      | "unset" = "unset"
+    runtime = makeRuntime(
+      {
+        listCiGateDefinitions: () =>
+          Effect.succeed([
+            {
+              identity: "161335",
+              displayLabel: "CI",
+              kind: "workflow",
+              diagnosticMetadata: ".github/workflows/ci.yml",
+            },
+          ]),
+        updateRepositorySettings: (input) => {
+          persistedPaused = input.paused
+          persistedDefinitions =
+            input.selectedCiGateDefinitions === undefined
+              ? "unset"
+              : input.selectedCiGateDefinitions.map(({ identity }) => ({
+                  identity,
+                }))
+          return Effect.succeed({ ...repository, paused: input.paused })
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.fail(
+            new GitHubRequestError({
+              message:
+                "Failed to list CI Gate Definitions for acme/widgets: Actions read required",
+              statusCode: 403,
+              retryable: false,
+            }),
+          ),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) { paused }
+        }`,
+        variables: {
+          input: {
+            repositoryId: repository.id,
+            paused: false,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            mergePolicy: "OFF",
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+            selectedCiGateDefinitionIdentities: ["161335"],
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: { updateRepositorySettings: { paused: false } },
+    })
+    expect(persistedPaused).toBe(false)
+    expect(persistedDefinitions).toEqual([{ identity: "161335" }])
+  })
+
+  test("empty CI Gate selection disables the Repository CI Gate", async () => {
+    await runtime.dispose()
+    let persisted: ReadonlyArray<unknown> | undefined
+    let stored: ReadonlyArray<{
+      readonly identity: string
+      readonly displayLabel: string
+      readonly kind: string
+      readonly diagnosticMetadata: string | null
+    }> = [
+      {
+        identity: "161335",
+        displayLabel: "CI",
+        kind: "workflow",
+        diagnosticMetadata: ".github/workflows/ci.yml",
+      },
+    ]
+    runtime = makeRuntime({
+      listCiGateDefinitions: () => Effect.succeed(stored),
+      updateRepositorySettings: (input) => {
+        persisted = input.selectedCiGateDefinitions
+        if (input.selectedCiGateDefinitions !== undefined) {
+          stored = [...input.selectedCiGateDefinitions]
+        }
+        return Effect.succeed(repository)
+      },
+    })
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) {
+            selectedCiGateDefinitions { identity }
+          }
+        }`,
+        variables: {
+          input: {
+            repositoryId: repository.id,
+            paused: true,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            mergePolicy: "OFF",
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+            selectedCiGateDefinitionIdentities: [],
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        updateRepositorySettings: { selectedCiGateDefinitions: [] },
+      },
+    })
+    expect(persisted).toEqual([])
   })
 })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -53,6 +53,13 @@ type Query {
     backendId: String!
   ): BackendModelPrefs!
   """
+  Live Forge-neutral CI Gate Definition catalog for one Repository.
+  Discovery uses the Repository's configured Forge credential. Failures
+  return an actionable error and an empty definitions list rather than
+  failing the query.
+  """
+  ciGateCatalog(repositoryId: ID!): CiGateCatalog!
+  """
   Agent Models available from the Active Agent Backend, each with optional
   Thinking Levels. Empty thinkingLevels means the model has no Thinking Levels.
   Empty when the backend is unavailable.
@@ -507,6 +514,34 @@ type AgentModel {
   kind: String
 }
 
+"""
+Forge-neutral CI Gate Definition. Identity is the Forge-native stable id.
+Kind distinguishes catalog kinds without leaking provider-specific GraphQL types.
+"""
+type CiGateDefinition {
+  """
+  Stable Forge-native identity. Opaque to generic callers.
+  """
+  identity: String!
+  displayLabel: String!
+  kind: String!
+  """
+  Optional diagnostic metadata such as a workflow path. Opaque string.
+  """
+  diagnosticMetadata: String
+}
+
+"""
+Live catalog of selectable CI Gate Definitions for one Repository.
+"""
+type CiGateCatalog {
+  definitions: [CiGateDefinition!]!
+  """
+  Null when the catalog loaded. Actionable message when discovery failed.
+  """
+  error: String
+}
+
 type Repository {
   id: ID!
   forge: String!
@@ -570,6 +605,11 @@ type Repository {
   and draft PRs are excluded. Does not apply Issue relevance filters.
   """
   pullRequestCount: Int!
+  """
+  Persisted CI Gate Definitions for this Repository. Empty disables the
+  Repository CI Gate. Unavailable saved entries keep last-known display metadata.
+  """
+  selectedCiGateDefinitions: [CiGateDefinition!]!
 }
 
 type LocalRepositoryInspection {
@@ -1077,6 +1117,12 @@ input UpdateRepositorySettingsInput {
   Defaults to true. Disable only when the ready transition cannot start relevant workflows.
   """
   waitForReadyForReviewChecks: Boolean!
+  """
+  Selected CI Gate Definition identities. Empty list disables the Repository
+  CI Gate. Omitted leaves stored selections unchanged. Newly added identities
+  must exist in the current live catalog.
+  """
+  selectedCiGateDefinitionIdentities: [String!]
 }
 
 type Mutation {

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -50,6 +50,13 @@ type Query {
     backendId: String!
   ): BackendModelPrefs!
   """
+  Live Forge-neutral CI Gate Definition catalog for one Repository.
+  Discovery uses the Repository's configured Forge credential. Failures
+  return an actionable error and an empty definitions list rather than
+  failing the query.
+  """
+  ciGateCatalog(repositoryId: ID!): CiGateCatalog!
+  """
   Agent Models available from the Active Agent Backend, each with optional
   Thinking Levels. Empty thinkingLevels means the model has no Thinking Levels.
   Empty when the backend is unavailable.
@@ -504,6 +511,34 @@ type AgentModel {
   kind: String
 }
 
+"""
+Forge-neutral CI Gate Definition. Identity is the Forge-native stable id.
+Kind distinguishes catalog kinds without leaking provider-specific GraphQL types.
+"""
+type CiGateDefinition {
+  """
+  Stable Forge-native identity. Opaque to generic callers.
+  """
+  identity: String!
+  displayLabel: String!
+  kind: String!
+  """
+  Optional diagnostic metadata such as a workflow path. Opaque string.
+  """
+  diagnosticMetadata: String
+}
+
+"""
+Live catalog of selectable CI Gate Definitions for one Repository.
+"""
+type CiGateCatalog {
+  definitions: [CiGateDefinition!]!
+  """
+  Null when the catalog loaded. Actionable message when discovery failed.
+  """
+  error: String
+}
+
 type Repository {
   id: ID!
   forge: String!
@@ -567,6 +602,11 @@ type Repository {
   and draft PRs are excluded. Does not apply Issue relevance filters.
   """
   pullRequestCount: Int!
+  """
+  Persisted CI Gate Definitions for this Repository. Empty disables the
+  Repository CI Gate. Unavailable saved entries keep last-known display metadata.
+  """
+  selectedCiGateDefinitions: [CiGateDefinition!]!
 }
 
 type LocalRepositoryInspection {
@@ -1055,6 +1095,12 @@ input UpdateRepositorySettingsInput {
   Defaults to true. Disable only when the ready transition cannot start relevant workflows.
   """
   waitForReadyForReviewChecks: Boolean!
+  """
+  Selected CI Gate Definition identities. Empty list disables the Repository
+  CI Gate. Omitted leaves stored selections unchanged. Newly added identities
+  must exist in the current live catalog.
+  """
+  selectedCiGateDefinitionIdentities: [String!]
 }
 
 type Mutation {

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -214,6 +214,7 @@ const makeGitHubLayer = (
         "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
       ),
     ensureIssueCompletedWithSummary: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
     listReadyIssues: ({ projectPath }) => {
       actions.push(`github:${projectPath}`)
       return options.error ? Effect.fail(options.error) : Effect.succeed(issues)

--- a/packages/work-item-lifecycle/src/lib/github-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/github-service-test.ts
@@ -50,6 +50,7 @@ export const stubGitHubServiceLayer = (
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
       ...overrides,
     }),
   )

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -97,6 +97,7 @@ const unusedGithub = {
       "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
     ),
   ensureIssueCompletedWithSummary: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
 } satisfies GitHubServiceShape
 
 describe("closeIssue", () => {

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -135,6 +135,7 @@ const stubGitHub = (
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
       listReadyIssues: () => Effect.succeed([]),
       ...overrides,

--- a/packages/work-item-lifecycle/test/merge-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/merge-pr.spec.ts
@@ -89,6 +89,7 @@ describe("mergePr", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     await Effect.runPromise(
@@ -201,6 +202,7 @@ describe("mergePr", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const exit = await Effect.runPromise(
@@ -342,6 +344,7 @@ describe("mergePr", () => {
         return Effect.succeed({ _tag: "merged" as const })
       },
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } as AzureDevOpsServiceShape)
 
     await Effect.runPromise(
@@ -376,6 +379,7 @@ describe("mergePr", () => {
         return Effect.succeed({ _tag: "merged" as const })
       },
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } as AzureDevOpsServiceShape)
 
     await Effect.runPromise(

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -210,6 +210,7 @@ const githubWith = (
         "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
       ),
     ensureIssueCompletedWithSummary: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
     ...overrides,
   } satisfies GitHubServiceShape)
 
@@ -326,6 +327,7 @@ describe("PR status check steps", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const status = await Effect.runPromise(
@@ -509,6 +511,7 @@ describe("PR status check steps", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const result = await Effect.runPromise(
@@ -609,6 +612,7 @@ describe("PR status check steps", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const result = await Effect.runPromise(
@@ -772,6 +776,7 @@ describe("PR status check steps", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const result = await Effect.runPromise(
@@ -877,6 +882,7 @@ describe("PR status check steps", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const second = await Effect.runPromise(
@@ -941,6 +947,7 @@ describe("PR status check steps", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
     const result = await Effect.runPromise(

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -171,6 +171,7 @@ const stubGitHub = (
         "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
       ),
     ensureIssueCompletedWithSummary: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
     ...overrides,
   } satisfies GitHubServiceShape)
 

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -141,6 +141,7 @@ describe("syncNeedsHumanMergeHandoffs", () => {
           "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
         ),
       ensureIssueCompletedWithSummary: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
     } satisfies GitHubServiceShape)
 
   const makeLayer = (


### PR DESCRIPTION
Repository settings can now discover active GitHub Actions workflows and save one or more as CI Gate Definitions. This is the GitHub selection slice of #1249: it establishes the forge-neutral catalog and persistence used by later observation, without watching runs or holding work yet.

Existing and new Repositories stay opted out. An empty selection disables the Repository CI Gate. New identities must exist in the live catalog; fabricated or stale IDs are rejected. A saved workflow that is later disabled, deleted, or missing stays visible with last-known name and path until removed. Catalog load failures do not block unrelated settings saves.

Discovery uses the Repository credential and the official Actions workflows API (not `gh`). GraphQL exposes a forge-neutral catalog and selected definitions. GitLab and Azure DevOps currently return an empty catalog until their follow-on tickets.

Verification: GitHub adapter tests (active-only catalog, pagination, 403/throttle), GraphQL save/reject/unrelated-save/empty-selection tests, persistence plus a migration that leaves existing Repositories unselected, and settings UI coverage for loading, catalog error, selection, unavailable rows, and empty default. Pre-commit passed after staging the follow-up test and typecheck fixes.

Closes #1249