### PR TITLE
feat(azure-devops): watch selected build pipelines as Repository CI Gates

### DIFF
--- a/apps/harness/src/server/keymaxxer-azure-devops-layer.ts
+++ b/apps/harness/src/server/keymaxxer-azure-devops-layer.ts
@@ -17,6 +17,8 @@ import {
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { ambientAzureDevOpsLayer } from "./ambient-azure-devops-layer.js"
 import {
+  SerializedCiGateCatalog,
+  SerializedCiGateObservation,
   SerializedMergePullRequestResult,
   SerializedPrStatusCheckDiagnostics,
   SerializedPullRequestCheckStatus,
@@ -371,6 +373,53 @@ export const keymaxxerAzureDevOpsLayer = (options: {
                   decode: (stdout) => parseIssues(stdout, repository),
                 }),
               (ambientService) => ambientService.listReadyIssues(repository),
+            ),
+        ),
+        listCiGateCatalog: Effect.fn("KeymaxxerAzureDevOps.listCiGateCatalog")(
+          (repository) =>
+            withVaultOrAmbient(
+              repository,
+              (tokenName) =>
+                callHelper({
+                  operation: "list-ci-gate-catalog",
+                  repository,
+                  tokenName,
+                  describe: "list CI Gate Definitions",
+                  decode: decodeJson(
+                    SerializedCiGateCatalog,
+                    repository,
+                    "decode CI Gate catalog",
+                  ),
+                }),
+              (ambientService) => ambientService.listCiGateCatalog(repository),
+            ),
+        ),
+        observeCiGate: Effect.fn("KeymaxxerAzureDevOps.observeCiGate")(
+          (repository, input) =>
+            withVaultOrAmbient(
+              repository,
+              (tokenName) =>
+                callHelper({
+                  operation: "observe-ci-gate",
+                  repository,
+                  tokenName,
+                  describe: "observe CI Gate Definitions",
+                  args: [
+                    encodeArgument(
+                      JSON.stringify({
+                        definitionIdentities: input.definitionIdentities,
+                        lastRunIdentities: input.lastRunIdentities,
+                      }),
+                    ),
+                  ],
+                  decode: decodeJson(
+                    SerializedCiGateObservation,
+                    repository,
+                    "decode CI Gate observation",
+                  ),
+                }),
+              (ambientService) =>
+                ambientService.observeCiGate(repository, input),
             ),
         ),
         hasCredentials: Effect.fn("KeymaxxerAzureDevOps.hasCredentials")(

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -192,6 +192,9 @@ const defaultAzureDevOpsShape = {
   verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
   getOpenPullRequestNumber: () => Effect.succeed(1),

--- a/apps/harness/test/keymaxxer-azure-devops-layer.test.ts
+++ b/apps/harness/test/keymaxxer-azure-devops-layer.test.ts
@@ -20,6 +20,12 @@ const platformLayer = BunChildProcessSpawner.layer.pipe(
 )
 
 const azureLifecycleStub = {
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({
+      defaultBranch: "refs/heads/main",
+      observations: [],
+    }),
   getOpenPullRequestNumber: () => Effect.succeed(1),
   findOpenPullRequestNumber: () => Effect.succeed(null),
   createDraftPullRequest: () => Effect.succeed(1),

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -152,6 +152,9 @@ const defaultAzureDevOps: AzureDevOpsServiceShape = {
   verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
   getOpenPullRequestNumber: () => Effect.succeed(1),

--- a/docs/azure-devops.md
+++ b/docs/azure-devops.md
@@ -40,6 +40,21 @@ until you push an initial commit so `main` (or equivalent) exists.
 Add may still succeed today; later worktree and Implement steps fail.
 Push `main` first.
 
+## Repository CI Gate
+
+Azure Repos can opt into the same Repository CI Gate as GitHub. The
+catalog lists **enabled build pipelines associated with this Git
+repository**, not every definition in the Azure DevOps project. Select
+those pipelines in Repository settings. Default-branch builds are
+observed on the existing polling cadence; Pull Request validation
+builds stay local to the Work Item PR. A failed or partially succeeded
+build closes the gate until a newer succeeded run; missing Build read
+permission degrades observation without pretending the pipeline is
+healthy.
+
+PR Status Checks (branch policy / build validation on the pull request)
+remain a separate path. They are not CI Gate Definitions.
+
 ## Merge Policy
 
 New Repositories default to Merge Policy `off` — a human must merge.

--- a/packages/azure-devops-service/src/bin/list-ci-gate-catalog.ts
+++ b/packages/azure-devops-service/src/bin/list-ci-gate-catalog.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { AzureDevOpsService } from "../lib/azure-devops-service.js"
+import {
+  azureDevOpsRepository,
+  decodeArgument,
+  runAzureDevOpsCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const listCiGateCatalogProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = azureDevOpsRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const azureDevOps = yield* AzureDevOpsService
+    const catalog = yield* azureDevOps.listCiGateCatalog(repository)
+    yield* writeStandardOutput(JSON.stringify(catalog))
+  })
+
+if (import.meta.main)
+  runAzureDevOpsCli(listCiGateCatalogProgram(process.argv.slice(2)))

--- a/packages/azure-devops-service/src/bin/observe-ci-gate.ts
+++ b/packages/azure-devops-service/src/bin/observe-ci-gate.ts
@@ -1,0 +1,43 @@
+import { Effect, Schema } from "effect"
+import { AzureDevOpsService } from "../lib/azure-devops-service.js"
+import {
+  CliArgumentError,
+  azureDevOpsRepository,
+  decodeArgument,
+  runAzureDevOpsCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+const ObserveCiGateArguments = Schema.Struct({
+  definitionIdentities: Schema.Array(Schema.String),
+  lastRunIdentities: Schema.Record(Schema.String, Schema.String),
+})
+
+export const observeCiGateProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = azureDevOpsRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const encodedInput = yield* decodeArgument(
+      args[3],
+      "CI Gate observation input",
+    )
+    const input = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(ObserveCiGateArguments),
+    )(encodedInput).pipe(
+      Effect.mapError(
+        () =>
+          new CliArgumentError({
+            message: "Invalid CI Gate observation input argument",
+          }),
+      ),
+    )
+    const azureDevOps = yield* AzureDevOpsService
+    const observation = yield* azureDevOps.observeCiGate(repository, input)
+    yield* writeStandardOutput(JSON.stringify(observation))
+  })
+
+if (import.meta.main)
+  runAzureDevOpsCli(observeCiGateProgram(process.argv.slice(2)))

--- a/packages/azure-devops-service/src/lib/azure-devops-helper-process.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-helper-process.ts
@@ -12,9 +12,11 @@ import { getOpenPullRequestNumberProgram } from "../bin/get-open-pull-request-nu
 import { getPrCheckStatusProgram } from "../bin/get-pr-check-status.js"
 import { getPrLifecycleStatusProgram } from "../bin/get-pr-lifecycle-status.js"
 import { getPrStatusCheckDiagnosticsProgram } from "../bin/get-pr-status-check-diagnostics.js"
+import { listCiGateCatalogProgram } from "../bin/list-ci-gate-catalog.js"
 import { listReadyIssuesProgram } from "../bin/list-ready-issues.js"
 import { markPrReadyForReviewProgram } from "../bin/mark-pr-ready-for-review.js"
 import { mergePullRequestProgram } from "../bin/merge-pull-request.js"
+import { observeCiGateProgram } from "../bin/observe-ci-gate.js"
 import { updateOpenDraftPullRequestCopyProgram } from "../bin/update-open-draft-pull-request-copy.js"
 import { verifyProjectProgram } from "../bin/verify-project.js"
 import { azureDevOpsServiceBinScriptPath } from "../bin-script-path.js"
@@ -27,13 +29,16 @@ export const INTERNAL_AZURE_DEVOPS_HELPER_ARG =
 /**
  * CLI-backed operations. `hasCredentials`/`hasAmbientCredentials` are
  * synchronous local checks (no vault secret needed) and never need a
- * subprocess, matching GitLab's helper operation set.
- * `countOpenNonDraftPullRequests` still fails with
+ * subprocess, matching GitLab's helper operation set. CI Gate catalog
+ * and observation run through the same helper path as other REST
+ * operations. `countOpenNonDraftPullRequests` still fails with
  * `AzureDevOpsNotImplementedError` inside the helper the same way the
  * in-process Live layer does.
  */
 export const AZURE_DEVOPS_HELPER_OPERATIONS = [
   "list-ready-issues",
+  "list-ci-gate-catalog",
+  "observe-ci-gate",
   "get-authenticated-user-login",
   "verify-project",
   "get-open-pull-request-number",
@@ -146,6 +151,8 @@ const programs: Record<
   ) => Effect.Effect<void, unknown, AzureDevOpsService>
 > = {
   "list-ready-issues": listReadyIssuesProgram,
+  "list-ci-gate-catalog": listCiGateCatalogProgram,
+  "observe-ci-gate": observeCiGateProgram,
   "get-authenticated-user-login": getAuthenticatedUserLoginProgram,
   "verify-project": verifyProjectProgram,
   "get-open-pull-request-number": getOpenPullRequestNumberProgram,

--- a/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
@@ -11,7 +11,12 @@ import {
   Schema,
 } from "effect"
 import {
+  type CiGateCatalogEntry,
+  type CiGateDefinitionObservation,
+  type CiGateObservation,
+  type CiGateObservedRun,
   type MergePullRequestResult,
+  type ObserveCiGateInput,
   type PrStatusCheckDiagnostic,
   type PullRequestCheckStatus,
   type PullRequestLifecycleStatus,
@@ -30,6 +35,7 @@ import {
   AzureDevOpsRequestError,
 } from "./errors.js"
 import {
+  AZURE_DEVOPS_CI_GATE_KIND,
   AZURE_DEVOPS_FORGE_HOST,
   AZURE_DEVOPS_PAT_ENV_VAR,
   type AzureDevOpsProjectIdentity,
@@ -592,6 +598,201 @@ const decodeOrRequestError = <S extends { readonly Type: unknown }>(
 const organizationApiBase = (organization: string): string =>
   `https://${AZURE_DEVOPS_FORGE_HOST}/${encodeURIComponent(organization)}`
 
+const CI_GATE_PAGE_SIZE = 100
+const CI_GATE_CONTINUATION_HEADER = "x-ms-continuationtoken"
+const CI_GATE_PULL_REQUEST_REASON = "pullrequest"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const pageValues = (payload: unknown): readonly unknown[] => {
+  if (Array.isArray(payload)) {
+    return payload
+  }
+  if (isRecord(payload) && Array.isArray(payload.value)) {
+    return payload.value
+  }
+  return []
+}
+
+const parseAzureInstant = (value: unknown): Date | null => {
+  if (typeof value !== "string" || value.trim() === "") {
+    return null
+  }
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+const optionalNonEmptyString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed === "" ? null : trimmed
+}
+
+const positiveInt = (value: unknown): number | null => {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    return null
+  }
+  return value
+}
+
+const definitionWebUrl = (
+  identity: AzureDevOpsProjectIdentity,
+  definitionId: number,
+): string =>
+  `https://${AZURE_DEVOPS_FORGE_HOST}/${encodeURIComponent(identity.organization)}/${encodeURIComponent(identity.project)}/_build?definitionId=${String(definitionId)}`
+
+const catalogDiagnosticMetadata = (input: {
+  readonly path: string | null
+  readonly type: string | null
+  readonly queueStatus: string | null
+  readonly revision: number | null
+  readonly url: string
+}): string => {
+  const parts: string[] = []
+  if (input.path !== null) {
+    parts.push(input.path)
+  }
+  if (input.type !== null) {
+    parts.push(input.type)
+  }
+  if (input.queueStatus !== null) {
+    parts.push(input.queueStatus)
+  }
+  if (input.revision !== null) {
+    parts.push(`rev ${String(input.revision)}`)
+  }
+  parts.push(input.url)
+  return parts.join(" · ")
+}
+
+const repositoryIdOf = (value: unknown): string | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+  return optionalNonEmptyString(value.id)
+}
+
+const mapActiveBuildDefinition = (
+  value: unknown,
+  identity: AzureDevOpsProjectIdentity,
+  repositoryId: string,
+): CiGateCatalogEntry | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+  if (optionalNonEmptyString(value.queueStatus)?.toLowerCase() !== "enabled") {
+    return null
+  }
+  if (optionalNonEmptyString(value.quality)?.toLowerCase() === "draft") {
+    return null
+  }
+  const repository = value.repository
+  const definitionRepositoryId = repositoryIdOf(repository)
+  if (
+    definitionRepositoryId !== null &&
+    definitionRepositoryId.toLowerCase() !== repositoryId.toLowerCase()
+  ) {
+    return null
+  }
+  if (
+    isRecord(repository) &&
+    optionalNonEmptyString(repository.type) !== null &&
+    optionalNonEmptyString(repository.type)?.toLowerCase() !== "tfsgit"
+  ) {
+    return null
+  }
+  const id = positiveInt(value.id)
+  if (id === null) {
+    return null
+  }
+  const name = optionalNonEmptyString(value.name)
+  if (name === null) {
+    return null
+  }
+  const webHref =
+    isRecord(value._links) && isRecord(value._links.web)
+      ? optionalNonEmptyString(value._links.web.href)
+      : null
+  return {
+    identity: String(id),
+    displayLabel: name,
+    kind: AZURE_DEVOPS_CI_GATE_KIND,
+    diagnosticMetadata: catalogDiagnosticMetadata({
+      path: optionalNonEmptyString(value.path),
+      type: optionalNonEmptyString(value.type),
+      queueStatus: optionalNonEmptyString(value.queueStatus),
+      revision: positiveInt(value.revision),
+      url: webHref ?? definitionWebUrl(identity, id),
+    }),
+  }
+}
+
+const runIdFromIdentity = (runIdentity: string): string => {
+  const separator = runIdentity.indexOf(":")
+  return separator === -1 ? runIdentity : runIdentity.slice(0, separator)
+}
+
+const isSameObservedRun = (
+  runIdentity: string,
+  lastRunIdentity: string,
+): boolean =>
+  runIdentity === lastRunIdentity ||
+  runIdFromIdentity(runIdentity) === runIdFromIdentity(lastRunIdentity)
+
+const mapObservedBuild = (
+  value: unknown,
+  defaultBranch: string,
+  identity: AzureDevOpsProjectIdentity,
+): CiGateObservedRun | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+  const id = positiveInt(value.id)
+  if (id === null) {
+    return null
+  }
+  const reason = optionalNonEmptyString(value.reason)
+  if (reason === null || reason.toLowerCase() === CI_GATE_PULL_REQUEST_REASON) {
+    return null
+  }
+  const sourceBranch = optionalNonEmptyString(value.sourceBranch)
+  if (sourceBranch === null) {
+    return null
+  }
+  const normalizedSource = toFullRefName(sourceBranch)
+  if (normalizedSource !== defaultBranch) {
+    return null
+  }
+  const createdAt =
+    parseAzureInstant(value.queueTime) ?? parseAzureInstant(value.startTime)
+  if (createdAt === null) {
+    return null
+  }
+  const buildNumber = optionalNonEmptyString(value.buildNumber)
+  const webHref =
+    isRecord(value._links) && isRecord(value._links.web)
+      ? optionalNonEmptyString(value._links.web.href)
+      : null
+  return {
+    runIdentity:
+      buildNumber === null ? String(id) : `${String(id)}:${buildNumber}`,
+    htmlUrl: webHref ?? buildResultsUrl(identity, id),
+    headSha: optionalNonEmptyString(value.sourceVersion),
+    headRef: normalizedSource,
+    event: reason,
+    createdAt,
+    updatedAt:
+      parseAzureInstant(value.finishTime) ??
+      parseAzureInstant(value.lastChangedDate),
+    startedAt: parseAzureInstant(value.startTime),
+    rawStatus: optionalNonEmptyString(value.status),
+    rawConclusion: optionalNonEmptyString(value.result),
+  }
+}
+
 const REFS_HEADS_PREFIX = "refs/heads/"
 
 /** Azure DevOps requires fully-qualified refs on PR create/list bodies. */
@@ -802,6 +1003,57 @@ export const makeAzureDevOpsService = (options: {
         return await response.json()
       },
       catch: (cause) => requestError(message, cause),
+    }).pipe(
+      Effect.timeout(REQUEST_TIMEOUT),
+      Effect.catchTag("TimeoutError", (cause) =>
+        Effect.fail(requestError(`${message} timed out`, cause)),
+      ),
+    )
+
+  const requestJsonPage = (
+    organization: string,
+    path: string,
+    message: string,
+    permissionMessage: string,
+  ): Effect.Effect<
+    { readonly payload: unknown; readonly continuationToken: string | null },
+    AzureDevOpsRequestError
+  > =>
+    Effect.tryPromise({
+      try: async () => {
+        const separator = path.includes("?") ? "&" : "?"
+        const response = await fetchImpl(
+          `${organizationApiBase(organization)}${path}${separator}api-version=${API_VERSION}`,
+          { method: "GET", headers },
+        )
+        if (!response.ok) {
+          if (response.status === 403) {
+            await response.text()
+            throw new AzureDevOpsHttpError(403, permissionMessage)
+          }
+          throw new AzureDevOpsHttpError(
+            response.status,
+            `${message}: Azure DevOps returned HTTP ${response.status}`,
+          )
+        }
+        const payload: unknown = await response.json()
+        const continuationToken =
+          optionalNonEmptyString(
+            response.headers.get(CI_GATE_CONTINUATION_HEADER),
+          ) ??
+          optionalNonEmptyString(response.headers.get("X-MS-ContinuationToken"))
+        return { payload, continuationToken }
+      },
+      catch: (cause) => {
+        if (cause instanceof AzureDevOpsHttpError && cause.statusCode === 403) {
+          return new AzureDevOpsRequestError({
+            message: permissionMessage,
+            cause,
+            statusCode: 403,
+          })
+        }
+        return requestError(message, cause)
+      },
     }).pipe(
       Effect.timeout(REQUEST_TIMEOUT),
       Effect.catchTag("TimeoutError", (cause) =>
@@ -1167,6 +1419,254 @@ export const makeAzureDevOpsService = (options: {
       return yield* loadDefaultBranch(repository, identity)
     })
 
+  const loadGitRepository = (
+    repository: AzureDevOpsRepository,
+    identity: AzureDevOpsProjectIdentity,
+    permissionMessage: string,
+  ): Effect.Effect<
+    { readonly id: string; readonly defaultBranch: string },
+    AzureDevOpsServiceError
+  > =>
+    Effect.gen(function* () {
+      const page = yield* unavailableOn404(
+        repository,
+        requestJsonPage(
+          identity.organization,
+          repositoryMetaPath(identity),
+          `Failed to resolve the Git repository for ${repository.projectPath}`,
+          permissionMessage,
+        ),
+      )
+      const meta = yield* decodeOrRequestError(
+        RepositoryMetaSchema,
+        `Azure DevOps returned invalid repository metadata for ${repository.projectPath}`,
+        page.payload,
+      )
+      const id = meta.id?.trim() ?? ""
+      if (id === "") {
+        return yield* new AzureDevOpsRequestError({
+          message: `Azure DevOps did not identify the Git repository for ${repository.projectPath}`,
+        })
+      }
+      const defaultBranch = meta.defaultBranch?.trim() ?? ""
+      if (defaultBranch === "") {
+        return yield* new AzureDevOpsRequestError({
+          message: `Repository ${repository.projectPath} has no default branch; push an initial commit first`,
+        })
+      }
+      return { id, defaultBranch: toFullRefName(defaultBranch) }
+    })
+
+  const collectCiGatePages = (
+    organization: string,
+    path: string,
+    message: string,
+    permissionMessage: string,
+    onPage: (values: readonly unknown[]) => "continue" | "stop",
+  ): Effect.Effect<void, AzureDevOpsRequestError> =>
+    Effect.gen(function* () {
+      let continuationToken: string | null = null
+      for (;;) {
+        const pagePath: string =
+          continuationToken === null
+            ? path
+            : `${path}&continuationToken=${encodeURIComponent(continuationToken)}`
+        const page: {
+          readonly payload: unknown
+          readonly continuationToken: string | null
+        } = yield* requestJsonPage(
+          organization,
+          pagePath,
+          message,
+          permissionMessage,
+        )
+        const stop = onPage(pageValues(page.payload))
+        if (stop === "stop" || page.continuationToken === null) {
+          return
+        }
+        continuationToken = page.continuationToken
+      }
+    })
+
+  const listCiGateCatalog = (
+    repository: AzureDevOpsRepository,
+  ): Effect.Effect<readonly CiGateCatalogEntry[], AzureDevOpsServiceError> =>
+    Effect.gen(function* () {
+      const identity = splitAzureDevOpsProjectPath(repository.projectPath)
+      if (identity === null) {
+        return yield* invalidProjectPath(repository)
+      }
+      const permissionMessage = `Failed to list CI Gate Definitions for ${repository.projectPath}: Build read required`
+      const gitRepository = yield* loadGitRepository(
+        repository,
+        identity,
+        permissionMessage,
+      )
+      const entries: CiGateCatalogEntry[] = []
+      const listPath = `/${encodeURIComponent(identity.project)}/_apis/build/definitions?repositoryId=${encodeURIComponent(gitRepository.id)}&repositoryType=TfsGit&includeAllProperties=true&$top=${String(CI_GATE_PAGE_SIZE)}`
+      yield* collectCiGatePages(
+        identity.organization,
+        listPath,
+        `Failed to list CI Gate Definitions for ${repository.projectPath}`,
+        permissionMessage,
+        (values) => {
+          for (const value of values) {
+            const mapped = mapActiveBuildDefinition(
+              value,
+              identity,
+              gitRepository.id,
+            )
+            if (mapped !== null) {
+              entries.push(mapped)
+            }
+          }
+          return "continue"
+        },
+      )
+      return entries
+    })
+
+  const observeDefinition = (
+    repository: AzureDevOpsRepository,
+    identity: AzureDevOpsProjectIdentity,
+    gitRepository: { readonly id: string; readonly defaultBranch: string },
+    definitionIdentity: string,
+    lastRunIdentity: string | null,
+    permissionMessage: string,
+  ): Effect.Effect<CiGateDefinitionObservation, AzureDevOpsServiceError> =>
+    Effect.gen(function* () {
+      const trimmed = definitionIdentity.trim()
+      const definitionId = Number(trimmed)
+      if (
+        trimmed.length === 0 ||
+        !Number.isSafeInteger(definitionId) ||
+        definitionId <= 0
+      ) {
+        return {
+          identity: trimmed,
+          kind: "unavailable" as const,
+          reason: "not_found" as const,
+          message: `CI Gate Definition ${trimmed} could not be observed`,
+        }
+      }
+      const definitionPage = yield* requestJsonPage(
+        identity.organization,
+        `/${encodeURIComponent(identity.project)}/_apis/build/definitions/${String(definitionId)}`,
+        `Failed to observe CI Gate Definition ${trimmed} for ${repository.projectPath}`,
+        permissionMessage,
+      ).pipe(
+        Effect.catch((error) =>
+          error.statusCode === 404 ? Effect.succeed(null) : Effect.fail(error),
+        ),
+      )
+      if (definitionPage === null) {
+        return {
+          identity: trimmed,
+          kind: "unavailable" as const,
+          reason: "not_found" as const,
+          message: `CI Gate Definition ${trimmed} could not be observed`,
+        }
+      }
+      const definition = definitionPage.payload
+      const queueStatus = isRecord(definition)
+        ? optionalNonEmptyString(definition.queueStatus)?.toLowerCase()
+        : null
+      if (queueStatus === "disabled" || queueStatus === "paused") {
+        return {
+          identity: trimmed,
+          kind: "unavailable" as const,
+          reason: "error" as const,
+          message: `CI Gate Definition ${trimmed} is ${queueStatus}`,
+        }
+      }
+      const definitionRepositoryId = isRecord(definition)
+        ? repositoryIdOf(definition.repository)
+        : null
+      if (
+        definitionRepositoryId !== null &&
+        definitionRepositoryId.toLowerCase() !== gitRepository.id.toLowerCase()
+      ) {
+        return {
+          identity: trimmed,
+          kind: "unavailable" as const,
+          reason: "not_found" as const,
+          message: `CI Gate Definition ${trimmed} could not be observed`,
+        }
+      }
+      const runs: CiGateObservedRun[] = []
+      const buildsPath = `/${encodeURIComponent(identity.project)}/_apis/build/builds?definitions=${String(definitionId)}&branchName=${encodeURIComponent(gitRepository.defaultBranch)}&queryOrder=QueueTimeDescending&$top=${String(CI_GATE_PAGE_SIZE)}`
+      yield* collectCiGatePages(
+        identity.organization,
+        buildsPath,
+        `Failed to observe CI Gate Definition ${trimmed} for ${repository.projectPath}`,
+        permissionMessage,
+        (values) => {
+          for (const value of values) {
+            const mapped = mapObservedBuild(
+              value,
+              gitRepository.defaultBranch,
+              identity,
+            )
+            if (mapped === null) {
+              continue
+            }
+            runs.push(mapped)
+            if (
+              lastRunIdentity !== null &&
+              isSameObservedRun(mapped.runIdentity, lastRunIdentity)
+            ) {
+              return "stop"
+            }
+          }
+          return "continue"
+        },
+      )
+      return {
+        identity: trimmed,
+        kind: "observed" as const,
+        runs,
+      }
+    })
+
+  const observeCiGate = (
+    repository: AzureDevOpsRepository,
+    input: ObserveCiGateInput,
+  ): Effect.Effect<CiGateObservation, AzureDevOpsServiceError> =>
+    Effect.gen(function* () {
+      const identity = splitAzureDevOpsProjectPath(repository.projectPath)
+      if (identity === null) {
+        return yield* invalidProjectPath(repository)
+      }
+      const permissionMessage = `Failed to observe CI Gate Definitions for ${repository.projectPath}: Build read required`
+      const gitRepository = yield* loadGitRepository(
+        repository,
+        identity,
+        permissionMessage,
+      )
+      const observations: CiGateDefinitionObservation[] = []
+      for (const definitionIdentity of input.definitionIdentities) {
+        const lastSeenRaw = input.lastRunIdentities[definitionIdentity]
+        const lastSeen =
+          lastSeenRaw !== undefined && lastSeenRaw.trim() !== ""
+            ? lastSeenRaw
+            : null
+        observations.push(
+          yield* observeDefinition(
+            repository,
+            identity,
+            gitRepository,
+            definitionIdentity,
+            lastSeen,
+            permissionMessage,
+          ),
+        )
+      }
+      return {
+        defaultBranch: gitRepository.defaultBranch,
+        observations,
+      }
+    })
+
   return {
     verifyProject: Effect.fn("AzureDevOpsService.verifyProject")(
       function* (repository) {
@@ -1324,6 +1824,10 @@ export const makeAzureDevOpsService = (options: {
         })
       },
     ),
+    listCiGateCatalog: Effect.fn("AzureDevOpsService.listCiGateCatalog")(
+      listCiGateCatalog,
+    ),
+    observeCiGate: Effect.fn("AzureDevOpsService.observeCiGate")(observeCiGate),
     hasCredentials: () => Effect.succeed(options.token !== undefined),
     hasAmbientCredentials: () => Effect.succeed(options.token !== undefined),
     getOpenPullRequestNumber: Effect.fn(

--- a/packages/azure-devops-service/src/lib/azure-devops-service-test.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-test.ts
@@ -1,5 +1,7 @@
 import { Effect, Layer } from "effect"
 import type {
+  CiGateCatalogEntry,
+  CiGateObservation,
   MergePullRequestResult,
   PullRequestCheckStatus,
   PullRequestLifecycleStatus,
@@ -16,7 +18,7 @@ import type {
 } from "./types.js"
 
 /**
- * Hand-written fake for the Azure DevOps service surface: the 16 REST-backed
+ * Hand-written fake for the Azure DevOps service surface: the REST-backed
  * methods plus the two local credential checks (`hasCredentials`/
  * `hasAmbientCredentials`). Mirrors
  * `gitlab-service-test.ts`'s in-memory `Map`-keyed `Layer.succeed` pattern:
@@ -43,6 +45,8 @@ export interface AzureDevOpsServiceTestFixture {
   readonly pullRequestCheckStatus?: PullRequestCheckStatus
   readonly pullRequestLifecycleStatus?: PullRequestLifecycleStatus
   readonly mergePullRequestResult?: MergePullRequestResult
+  readonly ciGateCatalog?: readonly CiGateCatalogEntry[]
+  readonly ciGateObservation?: CiGateObservation
   readonly error?: AzureDevOpsRequestError
 }
 
@@ -116,6 +120,19 @@ export const makeAzureDevOpsServiceTest = (
           [...(state.fixture.issues ?? [])].sort(
             (left, right) => left.number - right.number,
           ),
+        ),
+      ),
+    listCiGateCatalog: (repository) =>
+      failOr(repository, (state) =>
+        Effect.succeed([...(state.fixture.ciGateCatalog ?? [])]),
+      ),
+    observeCiGate: (repository) =>
+      failOr(repository, (state) =>
+        Effect.succeed(
+          state.fixture.ciGateObservation ?? {
+            defaultBranch: "refs/heads/main",
+            observations: [],
+          },
         ),
       ),
     getOpenPullRequestNumber: (repository, headRefName) => {

--- a/packages/azure-devops-service/src/lib/azure-devops-service.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service.ts
@@ -1,7 +1,10 @@
 import { Context, type Effect } from "effect"
 import type {
+  CiGateCatalogEntry,
+  CiGateObservation,
   MergePullRequestOptions,
   MergePullRequestResult,
+  ObserveCiGateInput,
   PrStatusCheckDiagnostic,
   PrStatusCheckDiagnosticsOptions,
   PrStatusCheckDiagnosticsRequest,
@@ -24,13 +27,13 @@ export type AzureDevOpsServiceError =
   | AzureDevOpsNotImplementedError
 
 /**
- * GitLab's 18-method surface plus {@link AzureDevOpsServiceShape.ensurePullRequestLinkedToIssue}:
- * Azure Boards does not honor `Closes #N` as a PR association, so Create PR
- * must write an ArtifactLink. 16 methods perform live Azure DevOps REST
- * requests (and have matching Keymaxxer helper operations),
- * `hasCredentials`/`hasAmbientCredentials` are local credential checks, and
- * only `countOpenNonDraftPullRequests` still fails with
- * `AzureDevOpsNotImplementedError` (see method-level docs).
+ * GitLab's 18-method surface plus {@link AzureDevOpsServiceShape.ensurePullRequestLinkedToIssue}
+ * and Repository CI Gate catalog/observation. Azure Boards does not honor
+ * `Closes #N` as a PR association, so Create PR must write an ArtifactLink.
+ * 18 methods perform live Azure DevOps REST requests (and have matching
+ * Keymaxxer helper operations), `hasCredentials`/`hasAmbientCredentials`
+ * are local credential checks, and only `countOpenNonDraftPullRequests`
+ * still fails with `AzureDevOpsNotImplementedError` (see method-level docs).
  */
 export interface AzureDevOpsServiceShape {
   /**
@@ -63,6 +66,24 @@ export interface AzureDevOpsServiceShape {
     readonly AzureDevOpsReadyLabeledIssue[],
     AzureDevOpsServiceError
   >
+  /**
+   * Live catalog of enabled build pipelines associated with this Git
+   * Repository (`GET .../build/definitions?repositoryId=&repositoryType=TfsGit`).
+   * Paused, disabled, draft, and other-repository definitions are omitted.
+   */
+  readonly listCiGateCatalog: (
+    repository: AzureDevOpsRepository,
+  ) => Effect.Effect<readonly CiGateCatalogEntry[], AzureDevOpsServiceError>
+  /**
+   * Observe selected build pipelines on the Repository's current default
+   * branch in Azure DevOps ref form. Pull Request validation builds are
+   * omitted even when they target that branch. Raw status/result stay
+   * Azure-native.
+   */
+  readonly observeCiGate: (
+    repository: AzureDevOpsRepository,
+    input: ObserveCiGateInput,
+  ) => Effect.Effect<CiGateObservation, AzureDevOpsServiceError>
   /**
    * Whether credentials resolve for this Repository: a per-Repository vault
    * secret and/or the ambient `AZURE_DEVOPS_EXT_PAT` (layer-dependent).

--- a/packages/azure-devops-service/src/lib/types.ts
+++ b/packages/azure-devops-service/src/lib/types.ts
@@ -1,5 +1,11 @@
 import type { ReadyLabeledIssue } from "@ready-for-agent/github-service"
 
+/**
+ * Forge-neutral CI Gate catalog kind for an Azure DevOps build pipeline.
+ * Identity is the build definition id.
+ */
+export const AZURE_DEVOPS_CI_GATE_KIND = "build-pipeline"
+
 export interface AzureDevOpsRepository {
   readonly forge: string
   readonly forgeHost: string

--- a/packages/azure-devops-service/test/ci-gate-catalog.spec.ts
+++ b/packages/azure-devops-service/test/ci-gate-catalog.spec.ts
@@ -1,0 +1,300 @@
+import { Effect, Result } from "effect"
+import { formatUserFacingError } from "@ready-for-agent/github-service"
+import {
+  AZURE_DEVOPS_CI_GATE_KIND,
+  AzureDevOpsRequestError,
+  makeAzureDevOpsServiceFromToken,
+} from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const repository = {
+  forge: "azure-devops",
+  forgeHost: "dev.azure.com",
+  projectPath: "acme/widgets",
+}
+
+const REPOSITORY_ID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+const OTHER_REPOSITORY_ID = "cccccccc-4444-5555-6666-dddddddddddd"
+
+const json = (
+  value: unknown,
+  init: { readonly status?: number; readonly continuationToken?: string } = {},
+): Response => {
+  const headers = new Headers({ "content-type": "application/json" })
+  if (init.continuationToken !== undefined) {
+    headers.set("x-ms-continuationtoken", init.continuationToken)
+  }
+  return new Response(JSON.stringify(value), {
+    status: init.status ?? 200,
+    statusText: init.status === 403 ? "Forbidden" : "OK",
+    headers,
+  })
+}
+
+const definitionPayload = (input: {
+  readonly id: number
+  readonly name: string
+  readonly path?: string
+  readonly queueStatus?: string
+  readonly revision?: number
+  readonly quality?: string
+  readonly type?: string
+  readonly repositoryId?: string
+}) => ({
+  id: input.id,
+  name: input.name,
+  path: input.path ?? "\\",
+  type: input.type ?? "build",
+  queueStatus: input.queueStatus ?? "enabled",
+  revision: input.revision ?? 1,
+  quality: input.quality ?? "definition",
+  uri: `vstfs:///Build/Definition/${String(input.id)}`,
+  url: `https://dev.azure.com/acme/widgets/_apis/build/definitions/${String(input.id)}`,
+  _links: {
+    web: {
+      href: `https://dev.azure.com/acme/widgets/_build?definitionId=${String(input.id)}`,
+    },
+  },
+  repository: {
+    id: input.repositoryId ?? REPOSITORY_ID,
+    type: "TfsGit",
+    name: "widgets",
+  },
+})
+
+const isRepositoryMetaUrl = (url: URL): boolean =>
+  url.pathname === "/acme/widgets/_apis/git/repositories/widgets"
+
+const isDefinitionsListUrl = (url: URL): boolean =>
+  url.pathname === "/acme/widgets/_apis/build/definitions"
+
+describe("Azure DevOps CI Gate catalog", () => {
+  test("lists enabled build pipelines for the configured Git Repository only", async () => {
+    const requested: URL[] = []
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      requested.push(url)
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (!isDefinitionsListUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      expect(url.searchParams.get("repositoryId")).toBe(REPOSITORY_ID)
+      expect(url.searchParams.get("repositoryType")).toBe("TfsGit")
+      expect(url.searchParams.get("page")).toBeNull()
+      return json({
+        count: 5,
+        value: [
+          definitionPayload({
+            id: 12,
+            name: "CI",
+            path: "\\CI",
+            revision: 3,
+          }),
+          definitionPayload({
+            id: 13,
+            name: "Nightly",
+            path: "\\Nightly",
+            queueStatus: "paused",
+            revision: 8,
+          }),
+          definitionPayload({
+            id: 14,
+            name: "Retired",
+            path: "\\Archive",
+            queueStatus: "disabled",
+            revision: 2,
+          }),
+          definitionPayload({
+            id: 15,
+            name: "Other repo",
+            path: "\\Shared",
+            repositoryId: OTHER_REPOSITORY_ID,
+          }),
+          definitionPayload({
+            id: 16,
+            name: "Draft pipeline",
+            quality: "draft",
+          }),
+        ],
+      })
+    }) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([
+      {
+        identity: "12",
+        displayLabel: "CI",
+        kind: AZURE_DEVOPS_CI_GATE_KIND,
+        diagnosticMetadata:
+          "\\CI · build · enabled · rev 3 · https://dev.azure.com/acme/widgets/_build?definitionId=12",
+      },
+    ])
+    expect(requested.some((url) => isDefinitionsListUrl(url))).toBe(true)
+  })
+
+  test("follows continuation-token pages instead of GitHub-style page numbers", async () => {
+    const continuationTokens: Array<string | null> = []
+    const pageOne = Array.from({ length: 100 }, (_, index) =>
+      definitionPayload({
+        id: index + 1,
+        name: `Pipeline ${String(index + 1)}`,
+        path: `\\Batch\\${String(index + 1)}`,
+      }),
+    )
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (!isDefinitionsListUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      expect(url.searchParams.get("page")).toBeNull()
+      continuationTokens.push(url.searchParams.get("continuationToken"))
+      if (url.searchParams.get("continuationToken") === null) {
+        return json({ value: pageOne }, { continuationToken: "page-2" })
+      }
+      if (url.searchParams.get("continuationToken") === "page-2") {
+        return json({
+          value: [
+            definitionPayload({
+              id: 9001,
+              name: "Release",
+              path: "\\Release",
+              revision: 11,
+            }),
+          ],
+        })
+      }
+      throw new Error(`unexpected continuation ${url.search}`)
+    }) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(continuationTokens).toEqual([null, "page-2"])
+    expect(catalog).toHaveLength(101)
+    expect(catalog[0]).toEqual({
+      identity: "1",
+      displayLabel: "Pipeline 1",
+      kind: AZURE_DEVOPS_CI_GATE_KIND,
+      diagnosticMetadata:
+        "\\Batch\\1 · build · enabled · rev 1 · https://dev.azure.com/acme/widgets/_build?definitionId=1",
+    })
+    expect(catalog[100]).toEqual({
+      identity: "9001",
+      displayLabel: "Release",
+      kind: AZURE_DEVOPS_CI_GATE_KIND,
+      diagnosticMetadata:
+        "\\Release · build · enabled · rev 11 · https://dev.azure.com/acme/widgets/_build?definitionId=9001",
+    })
+  })
+
+  test("skips definitions that lack a stable identity or display name", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      return json({
+        value: [
+          {
+            id: "not-a-number",
+            name: "Broken",
+            path: "\\Broken",
+            queueStatus: "enabled",
+            repository: { id: REPOSITORY_ID, type: "TfsGit" },
+          },
+          definitionPayload({
+            id: 12,
+            name: "   ",
+            path: "\\Blank",
+          }),
+          definitionPayload({
+            id: 42,
+            name: "Build",
+            path: "\\Build",
+            revision: 4,
+            type: "xaml",
+          }),
+        ],
+      })
+    }) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([
+      {
+        identity: "42",
+        displayLabel: "Build",
+        kind: AZURE_DEVOPS_CI_GATE_KIND,
+        diagnosticMetadata:
+          "\\Build · xaml · enabled · rev 4 · https://dev.azure.com/acme/widgets/_build?definitionId=42",
+      },
+    ])
+  })
+
+  test("maps a permission 403 to Build-read guidance without Azure body text", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      return new Response(
+        JSON.stringify({
+          message: "TF401444: The user lacks permission to read builds.",
+        }),
+        {
+          status: 403,
+          statusText: "Forbidden",
+          headers: { "content-type": "application/json" },
+        },
+      )
+    }) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service.listCiGateCatalog(repository).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(AzureDevOpsRequestError)
+    expect(error.statusCode).toBe(403)
+    expect(error.message).toContain("Build read required")
+    expect(error.message).not.toContain("TF401444")
+    expect(formatUserFacingError(error)).not.toContain("TF401444")
+  })
+
+  test("fails closed when the Git repository metadata cannot be resolved", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({ defaultBranch: "refs/heads/main" })
+      }
+      throw new Error("must not list definitions without a repository id")
+    }) as typeof fetch)
+
+    const result = await Effect.runPromise(
+      service.listCiGateCatalog(repository).pipe(Effect.result),
+    )
+    expect(Result.isFailure(result)).toBe(true)
+  })
+})

--- a/packages/azure-devops-service/test/ci-gate-observation.spec.ts
+++ b/packages/azure-devops-service/test/ci-gate-observation.spec.ts
@@ -1,0 +1,529 @@
+import { Effect } from "effect"
+import { formatUserFacingError } from "@ready-for-agent/github-service"
+import {
+  AzureDevOpsRequestError,
+  makeAzureDevOpsServiceFromToken,
+} from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const repository = {
+  forge: "azure-devops",
+  forgeHost: "dev.azure.com",
+  projectPath: "acme/widgets",
+}
+
+const REPOSITORY_ID = "aaaaaaaa-1111-2222-3333-bbbbbbbbbbbb"
+
+const json = (
+  value: unknown,
+  init: { readonly status?: number; readonly continuationToken?: string } = {},
+): Response => {
+  const headers = new Headers({ "content-type": "application/json" })
+  if (init.continuationToken !== undefined) {
+    headers.set("x-ms-continuationtoken", init.continuationToken)
+  }
+  return new Response(JSON.stringify(value), {
+    status: init.status ?? 200,
+    statusText:
+      init.status === 403
+        ? "Forbidden"
+        : init.status === 404
+          ? "Not Found"
+          : "OK",
+    headers,
+  })
+}
+
+const definitionPayload = (input: {
+  readonly id?: number
+  readonly queueStatus?: string
+  readonly name?: string
+}) => ({
+  id: input.id ?? 12,
+  name: input.name ?? "CI",
+  path: "\\CI",
+  type: "build",
+  queueStatus: input.queueStatus ?? "enabled",
+  revision: 3,
+  repository: { id: REPOSITORY_ID, type: "TfsGit", name: "widgets" },
+  _links: {
+    web: { href: "https://dev.azure.com/acme/widgets/_build?definitionId=12" },
+  },
+})
+
+const buildPayload = (input: {
+  readonly id: number
+  readonly reason: string
+  readonly status: string
+  readonly result: string | null
+  readonly sourceBranch?: string
+  readonly sourceVersion?: string
+  readonly buildNumber?: string
+  readonly queueTime?: string
+  readonly startTime?: string
+  readonly finishTime?: string
+}) => ({
+  id: input.id,
+  buildNumber: input.buildNumber ?? `20260907.${String(input.id)}`,
+  status: input.status,
+  result: input.result,
+  queueTime: input.queueTime ?? "2026-09-07T12:00:00Z",
+  startTime: input.startTime ?? "2026-09-07T12:00:01Z",
+  finishTime: input.finishTime ?? "2026-09-07T12:05:00Z",
+  reason: input.reason,
+  sourceBranch: input.sourceBranch ?? "refs/heads/main",
+  sourceVersion: input.sourceVersion ?? `sha-${String(input.id)}`,
+  _links: {
+    web: {
+      href: `https://dev.azure.com/acme/widgets/_build/results?buildId=${String(input.id)}`,
+    },
+  },
+})
+
+const isRepositoryMetaUrl = (url: URL): boolean =>
+  url.pathname === "/acme/widgets/_apis/git/repositories/widgets"
+
+const isDefinitionUrl = (url: URL, definitionId = "12"): boolean =>
+  url.pathname === `/acme/widgets/_apis/build/definitions/${definitionId}`
+
+const isBuildsUrl = (url: URL): boolean =>
+  url.pathname === "/acme/widgets/_apis/build/builds"
+
+describe("Azure DevOps CI Gate observation", () => {
+  test("returns default-branch CI builds in provider order and excludes PR validation", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (isDefinitionUrl(url)) {
+        return json(definitionPayload({}))
+      }
+      if (!isBuildsUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      expect(url.searchParams.get("definitions")).toBe("12")
+      expect(url.searchParams.get("branchName")).toBe("refs/heads/main")
+      expect(url.searchParams.get("queryOrder")).toBe("QueueTimeDescending")
+      expect(url.searchParams.get("page")).toBeNull()
+      return json({
+        value: [
+          buildPayload({
+            id: 600,
+            reason: "manual",
+            status: "completed",
+            result: "succeeded",
+            queueTime: "2026-09-07T12:00:00Z",
+          }),
+          buildPayload({
+            id: 500,
+            reason: "individualCI",
+            status: "inProgress",
+            result: null,
+            queueTime: "2026-09-07T11:30:00Z",
+            finishTime: undefined,
+          }),
+          buildPayload({
+            id: 400,
+            reason: "schedule",
+            status: "completed",
+            result: "failed",
+            queueTime: "2026-09-07T11:00:00Z",
+          }),
+          buildPayload({
+            id: 350,
+            reason: "pullRequest",
+            status: "completed",
+            result: "failed",
+            queueTime: "2026-09-07T10:50:00Z",
+          }),
+          buildPayload({
+            id: 300,
+            reason: "individualCI",
+            status: "completed",
+            result: "failed",
+            sourceBranch: "refs/heads/feature",
+            queueTime: "2026-09-07T10:30:00Z",
+          }),
+          buildPayload({
+            id: 200,
+            reason: "userCreated",
+            status: "completed",
+            result: "partiallySucceeded",
+            queueTime: "2026-09-07T10:00:00Z",
+          }),
+        ],
+      })
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["12"],
+        lastRunIdentities: {},
+      }),
+    )
+
+    expect(observation.defaultBranch).toBe("refs/heads/main")
+    expect(observation.observations).toHaveLength(1)
+    const definition = observation.observations[0]
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(definition.runs.map((run) => run.runIdentity)).toEqual([
+      "600:20260907.600",
+      "500:20260907.500",
+      "400:20260907.400",
+      "200:20260907.200",
+    ])
+    expect(definition.runs[0]).toEqual({
+      runIdentity: "600:20260907.600",
+      htmlUrl: "https://dev.azure.com/acme/widgets/_build/results?buildId=600",
+      headSha: "sha-600",
+      headRef: "refs/heads/main",
+      event: "manual",
+      createdAt: new Date("2026-09-07T12:00:00Z"),
+      updatedAt: new Date("2026-09-07T12:05:00Z"),
+      startedAt: new Date("2026-09-07T12:00:01Z"),
+      rawStatus: "completed",
+      rawConclusion: "succeeded",
+    })
+    expect(definition.runs[1]?.rawStatus).toBe("inProgress")
+    expect(definition.runs[1]?.rawConclusion).toBeNull()
+    expect(definition.runs[2]?.rawConclusion).toBe("failed")
+    expect(definition.runs[3]?.rawConclusion).toBe("partiallySucceeded")
+  })
+
+  test("preserves canceled, notStarted, postponed, cancelling, and none raw outcomes", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (isDefinitionUrl(url)) {
+        return json(definitionPayload({}))
+      }
+      if (!isBuildsUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      return json({
+        value: [
+          buildPayload({
+            id: 80,
+            reason: "manual",
+            status: "completed",
+            result: "canceled",
+            queueTime: "2026-09-07T12:00:00Z",
+          }),
+          buildPayload({
+            id: 70,
+            reason: "individualCI",
+            status: "notStarted",
+            result: "none",
+            queueTime: "2026-09-07T11:50:00Z",
+          }),
+          buildPayload({
+            id: 60,
+            reason: "schedule",
+            status: "postponed",
+            result: null,
+            queueTime: "2026-09-07T11:40:00Z",
+          }),
+          buildPayload({
+            id: 50,
+            reason: "manual",
+            status: "cancelling",
+            result: null,
+            queueTime: "2026-09-07T11:30:00Z",
+          }),
+          buildPayload({
+            id: 40,
+            reason: "individualCI",
+            status: "none",
+            result: "none",
+            queueTime: "2026-09-07T11:20:00Z",
+          }),
+        ],
+      })
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["12"],
+        lastRunIdentities: {},
+      }),
+    )
+    const definition = observation.observations[0]
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(
+      definition.runs.map((run) => ({
+        runIdentity: run.runIdentity,
+        rawStatus: run.rawStatus,
+        rawConclusion: run.rawConclusion,
+      })),
+    ).toEqual([
+      {
+        runIdentity: "80:20260907.80",
+        rawStatus: "completed",
+        rawConclusion: "canceled",
+      },
+      {
+        runIdentity: "70:20260907.70",
+        rawStatus: "notStarted",
+        rawConclusion: "none",
+      },
+      {
+        runIdentity: "60:20260907.60",
+        rawStatus: "postponed",
+        rawConclusion: null,
+      },
+      {
+        runIdentity: "50:20260907.50",
+        rawStatus: "cancelling",
+        rawConclusion: null,
+      },
+      {
+        runIdentity: "40:20260907.40",
+        rawStatus: "none",
+        rawConclusion: "none",
+      },
+    ])
+  })
+
+  test("includes every relevant build across continuation-token pages", async () => {
+    const pageOne = Array.from({ length: 100 }, (_, index) =>
+      buildPayload({
+        id: 1000 - index,
+        reason: "individualCI",
+        status: "completed",
+        result: "succeeded",
+        queueTime: `2026-09-07T${String(10 + Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}:00Z`,
+      }),
+    )
+    const continuationTokens: Array<string | null> = []
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (isDefinitionUrl(url)) {
+        return json(definitionPayload({}))
+      }
+      if (!isBuildsUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      expect(url.searchParams.get("page")).toBeNull()
+      continuationTokens.push(url.searchParams.get("continuationToken"))
+      if (url.searchParams.get("continuationToken") === null) {
+        return json({ value: pageOne }, { continuationToken: "builds-2" })
+      }
+      if (url.searchParams.get("continuationToken") === "builds-2") {
+        return json({
+          value: [
+            buildPayload({
+              id: 1,
+              reason: "individualCI",
+              status: "completed",
+              result: "failed",
+              queueTime: "2026-09-06T09:00:00Z",
+            }),
+          ],
+        })
+      }
+      throw new Error(`unexpected continuation ${url.search}`)
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["12"],
+        lastRunIdentities: {},
+      }),
+    )
+    const definition = observation.observations[0]
+    expect(continuationTokens).toEqual([null, "builds-2"])
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(definition.runs).toHaveLength(101)
+    expect(definition.runs[0]?.runIdentity).toBe("1000:20260907.1000")
+    expect(definition.runs[100]?.runIdentity).toBe("1:20260907.1")
+    expect(definition.runs[100]?.rawConclusion).toBe("failed")
+  })
+
+  test("stops paging once the last-seen build identity is included", async () => {
+    const requestedTokens: Array<string | null> = []
+    const pageOne = Array.from({ length: 100 }, (_, index) =>
+      buildPayload({
+        id: 2000 - index,
+        reason: "individualCI",
+        status: "completed",
+        result: "succeeded",
+      }),
+    )
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (isDefinitionUrl(url)) {
+        return json(definitionPayload({}))
+      }
+      if (!isBuildsUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      requestedTokens.push(url.searchParams.get("continuationToken"))
+      if (url.searchParams.get("continuationToken") === null) {
+        return json(
+          { value: pageOne },
+          { continuationToken: "should-not-fetch" },
+        )
+      }
+      throw new Error(`unexpected extra page ${url.search}`)
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["12"],
+        lastRunIdentities: { "12": "1950:20260907.1950" },
+      }),
+    )
+    const definition = observation.observations[0]
+    expect(requestedTokens).toEqual([null])
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(definition.runs[0]?.runIdentity).toBe("2000:20260907.2000")
+    expect(definition.runs.at(-1)?.runIdentity).toBe("1950:20260907.1950")
+    expect(definition.runs).toHaveLength(51)
+  })
+
+  test("marks deleted, disabled, and paused definitions unavailable without dropping others", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      if (isDefinitionUrl(url, "12")) {
+        return json(definitionPayload({ id: 12, queueStatus: "enabled" }))
+      }
+      if (isDefinitionUrl(url, "13")) {
+        return json(definitionPayload({ id: 13, queueStatus: "disabled" }))
+      }
+      if (isDefinitionUrl(url, "14")) {
+        return json(definitionPayload({ id: 14, queueStatus: "paused" }))
+      }
+      if (isDefinitionUrl(url, "99")) {
+        return json({ message: "Not found" }, { status: 404 })
+      }
+      if (isBuildsUrl(url) && url.searchParams.get("definitions") === "12") {
+        return json({
+          value: [
+            buildPayload({
+              id: 42,
+              reason: "individualCI",
+              status: "completed",
+              result: "succeeded",
+            }),
+          ],
+        })
+      }
+      return new Response("not found", { status: 404 })
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["12", "13", "14", "99"],
+        lastRunIdentities: {},
+      }),
+    )
+
+    expect(observation.observations).toEqual([
+      expect.objectContaining({
+        identity: "12",
+        kind: "observed",
+      }),
+      {
+        identity: "13",
+        kind: "unavailable",
+        reason: "error",
+        message: expect.stringContaining("disabled"),
+      },
+      {
+        identity: "14",
+        kind: "unavailable",
+        reason: "error",
+        message: expect.stringContaining("paused"),
+      },
+      {
+        identity: "99",
+        kind: "unavailable",
+        reason: "not_found",
+        message: expect.stringContaining("could not be observed"),
+      },
+    ])
+    const live = observation.observations[0]
+    expect(live?.kind).toBe("observed")
+    if (live?.kind === "observed") {
+      expect(live.runs[0]?.htmlUrl).toBe(
+        "https://dev.azure.com/acme/widgets/_build/results?buildId=42",
+      )
+    }
+  })
+
+  test("maps a permission 403 to Build-read guidance without Azure body text", async () => {
+    const service = makeAzureDevOpsServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isRepositoryMetaUrl(url)) {
+        return json({
+          id: REPOSITORY_ID,
+          defaultBranch: "refs/heads/main",
+        })
+      }
+      return new Response(
+        JSON.stringify({
+          message: "TF401444: The user lacks permission to read builds.",
+        }),
+        {
+          status: 403,
+          statusText: "Forbidden",
+          headers: { "content-type": "application/json" },
+        },
+      )
+    }) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service
+        .observeCiGate(repository, {
+          definitionIdentities: ["12"],
+          lastRunIdentities: {},
+        })
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(AzureDevOpsRequestError)
+    expect(error.statusCode).toBe(403)
+    expect(error.message).toContain("Build read required")
+    expect(error.message).not.toContain("TF401444")
+    expect(formatUserFacingError(error)).not.toContain("TF401444")
+  })
+})

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -6,7 +6,9 @@ export interface GitHubRepository {
 
 /**
  * Forge-neutral CI Gate catalog entry. GitHub maps an active Actions
- * workflow to this shape; identity is the workflow id.
+ * workflow (identity is the workflow id); Azure DevOps maps an enabled
+ * build pipeline associated with the Git Repository (identity is the
+ * build definition id).
  */
 export const GITHUB_CI_GATE_KIND = "workflow"
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -468,6 +468,27 @@ const loadCiGateCatalog = Effect.fn("graphql-api.loadCiGateCatalog")(
     readonly forgeHost: string
     readonly projectPath: string
   }) {
+    if (repository.forge === "azure-devops") {
+      const azureDevOps = yield* AzureDevOpsService
+      return yield* azureDevOps
+        .listCiGateCatalog({
+          forge: repository.forge,
+          forgeHost: repository.forgeHost,
+          projectPath: repository.projectPath,
+        })
+        .pipe(
+          Effect.map((definitions) => ({
+            kind: "loaded" as const,
+            definitions,
+          })),
+          Effect.catch((error) =>
+            Effect.succeed({
+              kind: "unavailable" as const,
+              message: ciGateCatalogErrorMessage(error),
+            }),
+          ),
+        )
+    }
     if (repository.forge !== "github") {
       return { kind: "loaded" as const, definitions: [] }
     }

--- a/packages/graphql-api/src/lib/observe-repository-ci-gate.ts
+++ b/packages/graphql-api/src/lib/observe-repository-ci-gate.ts
@@ -1,5 +1,6 @@
 import { Clock, Effect, Result } from "effect"
 import { ulid } from "ulidx"
+import { AzureDevOpsService } from "@ready-for-agent/azure-devops-service"
 import {
   type CiFailureIncidentRecord,
   type CiGateDefinitionObservationRecord,
@@ -11,15 +12,25 @@ import {
 } from "@ready-for-agent/db-service"
 import {
   type CiGateDefinitionObservation,
+  type CiGateObservation,
   type CiGateObservedRun,
   type GitHubOperationOrigin,
   GitHubService,
+  type ObserveCiGateInput,
   formatUserFacingError,
 } from "@ready-for-agent/github-service"
 
 export type RepositoryCiGateStatus = "disabled" | "open" | "closed" | "degraded"
 
-const FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "action_required"])
+const FAILURE_CONCLUSIONS = new Set([
+  "failure",
+  "timed_out",
+  "action_required",
+  "failed",
+  "partiallySucceeded",
+])
+
+const SUCCESS_CONCLUSIONS = new Set(["success", "succeeded"])
 
 export const ciGateObservationErrorMessage = (error: unknown): string => {
   const formatted = formatUserFacingError(error, "CI Gate observation failed")
@@ -39,7 +50,8 @@ const isPermissionError = (error: unknown): boolean => {
   }
   return (
     typeof record.message === "string" &&
-    record.message.includes("Actions read required")
+    (record.message.includes("Actions read required") ||
+      record.message.includes("Build read required"))
   )
 }
 
@@ -54,7 +66,7 @@ const classifyRun = (
   if (conclusion !== null && FAILURE_CONCLUSIONS.has(conclusion)) {
     return "failure"
   }
-  if (conclusion === "success") {
+  if (conclusion !== null && SUCCESS_CONCLUSIONS.has(conclusion)) {
     return "success"
   }
   return "non_decisive"
@@ -337,7 +349,10 @@ export const observeRepositoryCiGate = Effect.fn("observeRepositoryCiGate")(
           !definitions.some((definition) => definition.identity === identity),
       )
 
-    if (input.repository.forge !== "github") {
+    if (
+      input.repository.forge !== "github" &&
+      input.repository.forge !== "azure-devops"
+    ) {
       const observations = definitions.map((definition) =>
         unavailableObservation({
           previous: previousByIdentity.get(definition.identity),
@@ -371,23 +386,31 @@ export const observeRepositoryCiGate = Effect.fn("observeRepositoryCiGate")(
       }
     }
 
-    const github = yield* GitHubService
-    const adapterResult = yield* github
-      .observeCiGate(
-        {
-          forge: input.repository.forge,
-          forgeHost: input.repository.forgeHost,
-          projectPath: input.repository.projectPath,
-        },
-        {
-          definitionIdentities: definitions.map(
-            (definition) => definition.identity,
-          ),
-          lastRunIdentities,
-        },
-        { origin: input.origin },
-      )
-      .pipe(Effect.result)
+    const forgeRepository = {
+      forge: input.repository.forge,
+      forgeHost: input.repository.forgeHost,
+      projectPath: input.repository.projectPath,
+    }
+    const observationInput: ObserveCiGateInput = {
+      definitionIdentities: definitions.map(
+        (definition) => definition.identity,
+      ),
+      lastRunIdentities,
+    }
+    let adapterResult: Result.Result<CiGateObservation, unknown>
+    if (input.repository.forge === "azure-devops") {
+      const azureDevOps = yield* AzureDevOpsService
+      adapterResult = yield* azureDevOps
+        .observeCiGate(forgeRepository, observationInput)
+        .pipe(Effect.result)
+    } else {
+      const github = yield* GitHubService
+      adapterResult = yield* github
+        .observeCiGate(forgeRepository, observationInput, {
+          origin: input.origin,
+        })
+        .pipe(Effect.result)
+    }
 
     if (Result.isFailure(adapterResult)) {
       const message = ciGateObservationErrorMessage(adapterResult.failure)

--- a/packages/graphql-api/test/ci-gate-azure-devops.test.ts
+++ b/packages/graphql-api/test/ci-gate-azure-devops.test.ts
@@ -6,12 +6,15 @@ import {
   missingSessionTelemetry,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
-import { AzureDevOpsService } from "@ready-for-agent/azure-devops-service"
+import {
+  AzureDevOpsRequestError,
+  AzureDevOpsService,
+  type AzureDevOpsServiceShape,
+} from "@ready-for-agent/azure-devops-service"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import {
   type CiGateObservation,
-  GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
@@ -28,16 +31,18 @@ const unused = () => Effect.die("not used")
 
 const catalog = [
   {
-    identity: "161335",
+    identity: "12",
     displayLabel: "CI",
-    kind: "workflow",
-    diagnosticMetadata: ".github/workflows/ci.yml",
+    kind: "build-pipeline",
+    diagnosticMetadata:
+      "\\CI · build · enabled · rev 3 · https://dev.azure.com/acme/widgets/_build?definitionId=12",
   },
   {
-    identity: "269289",
+    identity: "13",
     displayLabel: "Nightly",
-    kind: "workflow",
-    diagnosticMetadata: ".github/workflows/nightly.yml",
+    kind: "build-pipeline",
+    diagnosticMetadata:
+      "\\Nightly · build · enabled · rev 1 · https://dev.azure.com/acme/widgets/_build?definitionId=13",
   },
 ] as const
 
@@ -53,10 +58,10 @@ const observedRun = (input: {
     : never
   : never => ({
   runIdentity: input.runIdentity,
-  htmlUrl: `https://github.com/acme/widgets/actions/runs/${input.runIdentity.split(":")[0] ?? input.runIdentity}`,
+  htmlUrl: `https://dev.azure.com/acme/widgets/_build/results?buildId=${input.runIdentity.split(":")[0] ?? input.runIdentity}`,
   headSha: `sha-${input.runIdentity}`,
-  headRef: "main",
-  event: input.event ?? "push",
+  headRef: "refs/heads/main",
+  event: input.event ?? "individualCI",
   createdAt: new Date(input.createdAt ?? "2026-09-07T12:00:00.000Z"),
   updatedAt: new Date("2026-09-07T12:05:00.000Z"),
   startedAt: new Date("2026-09-07T12:00:01.000Z"),
@@ -98,7 +103,7 @@ const settingsInput = (
   selectedCiGateDefinitionIdentities: [...identities],
 })
 
-const ciGateQuery = (repositoryId: string) => ({
+const ciGateQuery = {
   query: `query {
     repositories {
       id
@@ -137,8 +142,7 @@ const ciGateQuery = (repositoryId: string) => ({
       }
     }
   }`,
-  variables: { repositoryId },
-})
+}
 
 const graphqlRequest = (body: unknown) =>
   new Request("http://127.0.0.1:6056/graphql", {
@@ -147,11 +151,10 @@ const graphqlRequest = (body: unknown) =>
     body: JSON.stringify(body),
   })
 
-describe("Repository CI Gate observation", () => {
-  let observe: GitHubServiceShape["observeCiGate"] = () =>
-    Effect.succeed({ defaultBranch: "main", observations: [] })
-  let listReadyIssues: GitHubServiceShape["listReadyIssues"] = () =>
-    Effect.succeed([])
+describe("Azure DevOps Repository CI Gate", () => {
+  let observe: AzureDevOpsServiceShape["observeCiGate"] = () =>
+    Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] })
+  let pullRequestCheckCalls = 0
 
   const githubLayer = Layer.succeed(GitHubService, {
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
@@ -187,11 +190,10 @@ describe("Repository CI Gate observation", () => {
         "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
       ),
     ensureIssueCompletedWithSummary: () => Effect.void,
-    listCiGateCatalog: () => Effect.succeed([...catalog]),
-    observeCiGate: (repository, input, options) =>
-      observe(repository, input, options),
-    listReadyIssues: (repository, options) =>
-      listReadyIssues(repository, options),
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "main", observations: [] }),
+    listReadyIssues: () => Effect.succeed([]),
   } satisfies GitHubServiceShape)
 
   const runtimeLayer = Layer.mergeAll(
@@ -222,12 +224,8 @@ describe("Repository CI Gate observation", () => {
       verifyProject: (repository) => Effect.succeed(repository),
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
       listReadyIssues: () => Effect.succeed([]),
-      listCiGateCatalog: () => Effect.succeed([]),
-      observeCiGate: () =>
-        Effect.succeed({
-          defaultBranch: "refs/heads/main",
-          observations: [],
-        }),
+      listCiGateCatalog: () => Effect.succeed([...catalog]),
+      observeCiGate: (repository, input) => observe(repository, input),
       hasCredentials: () => Effect.succeed(true),
       hasAmbientCredentials: () => Effect.succeed(true),
       getOpenPullRequestNumber: () => Effect.succeed(1),
@@ -236,7 +234,25 @@ describe("Repository CI Gate observation", () => {
       ensurePullRequestLinkedToIssue: () => Effect.void,
       updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
       countOpenNonDraftPullRequests: () => Effect.succeed(0),
-      getPullRequestCheckStatus: unused,
+      getPullRequestCheckStatus: () => {
+        pullRequestCheckCalls += 1
+        return Effect.succeed({
+          _tag: "succeeded" as const,
+          terminalChecks: [
+            {
+              externalId: "azure-policy:eval-1",
+              name: "Build validation",
+              outcome: "green" as const,
+            },
+          ],
+          mergeability: "mergeable" as const,
+          baseRefName: "main",
+          headPushedAt: null,
+          headSha: null,
+          createdAt: null,
+          isDraft: null,
+        })
+      },
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       markPullRequestReadyForReview: () => Effect.void,
       getPullRequestLifecycleStatus: () =>
@@ -348,8 +364,8 @@ describe("Repository CI Gate observation", () => {
     Layer.succeed(LocalGit, {
       inspect: (path) =>
         Effect.succeed({
-          forge: "github",
-          forgeHost: "github.com",
+          forge: "azure-devops",
+          forgeHost: "dev.azure.com",
           projectPath: "acme/widgets",
           localPath: path,
           isBare: true,
@@ -366,8 +382,9 @@ describe("Repository CI Gate observation", () => {
 
   afterEach(async () => {
     await runtime.dispose()
-    observe = () => Effect.succeed({ defaultBranch: "main", observations: [] })
-    listReadyIssues = () => Effect.succeed([])
+    observe = () =>
+      Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] })
+    pullRequestCheckCalls = 0
     runtime = ManagedRuntime.make(runtimeLayer)
   })
 
@@ -376,8 +393,8 @@ describe("Repository CI Gate observation", () => {
       Effect.gen(function* () {
         const db = yield* DbService
         return yield* db.addRepository({
-          forge: "github",
-          forgeHost: "github.com",
+          forge: "azure-devops",
+          forgeHost: "dev.azure.com",
           projectPath: "acme/widgets",
           localPath: `/repos/acme/widgets-${String(Date.now())}.git`,
           isBare: true,
@@ -387,7 +404,7 @@ describe("Repository CI Gate observation", () => {
 
   const fetchCiGate = async (repositoryId: string) => {
     const response = await createGraphqlApi(runtime).fetch(
-      graphqlRequest(ciGateQuery(repositoryId)),
+      graphqlRequest(ciGateQuery),
     )
     const payload = (await response.json()) as {
       data: {
@@ -453,7 +470,7 @@ describe("Repository CI Gate observation", () => {
         query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
           updateRepositorySettings(input: $input) {
             id
-            selectedCiGateDefinitions { identity }
+            selectedCiGateDefinitions { identity kind }
             ciGate { status enabled }
           }
         }`,
@@ -464,7 +481,10 @@ describe("Repository CI Gate observation", () => {
       data: {
         updateRepositorySettings: {
           id: string
-          selectedCiGateDefinitions: ReadonlyArray<{ identity: string }>
+          selectedCiGateDefinitions: ReadonlyArray<{
+            identity: string
+            kind: string
+          }>
           ciGate: { status: string; enabled: boolean }
         }
       }
@@ -490,7 +510,7 @@ describe("Repository CI Gate observation", () => {
       }),
     )
 
-  test("empty selection disables the gate and save of a successful definition is Open", async () => {
+  test("selecting an Azure pipeline observes Open, then failed and partiallySucceeded close the gate until a newer success", async () => {
     const repository = await addRepository()
     expect(await fetchCiGate(repository.id)).toMatchObject({
       enabled: false,
@@ -500,93 +520,76 @@ describe("Repository CI Gate observation", () => {
 
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "100:1",
+              runIdentity: "100:20260907.100",
               rawStatus: "completed",
-              rawConclusion: "success",
+              rawConclusion: "succeeded",
             }),
           ]),
         ],
       })
-
-    const saved = await saveSelection(repository.id, ["161335"])
+    const saved = await saveSelection(repository.id, ["12"])
     expect(saved.errors).toBeUndefined()
+    expect(
+      saved.data.updateRepositorySettings.selectedCiGateDefinitions,
+    ).toEqual([{ identity: "12", kind: "build-pipeline" }])
     expect(saved.data.updateRepositorySettings.ciGate).toEqual({
       status: "OPEN",
       enabled: true,
     })
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.defaultBranch).toBe("main")
-    expect(gate.definitions[0]?.latestRun?.rawConclusion).toBe("success")
-    expect(gate.definitions[0]?.latestRun?.htmlUrl).toContain("/actions/runs/")
-    expect(gate.activeIncident).toBeNull()
-  })
+    expect((await fetchCiGate(repository.id)).defaultBranch).toBe(
+      "refs/heads/main",
+    )
 
-  test("failure latches Closed, pending does not clear it, and a newer success resolves the incident", async () => {
-    const repository = await addRepository()
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "200:1",
+              runIdentity: "101:20260907.101",
               rawStatus: "completed",
-              rawConclusion: "failure",
+              rawConclusion: "failed",
             }),
           ]),
         ],
       })
-    await saveSelection(repository.id, ["161335"])
+    await refresh(repository.id)
     let gate = await fetchCiGate(repository.id)
     expect(gate.status).toBe("CLOSED")
     expect(gate.definitions[0]?.failureLatched).toBe(true)
-    expect(gate.activeIncident?.status).toBe("OPEN")
     expect(gate.activeIncident?.failedDefinitions).toEqual([
-      { identity: "161335", displayLabel: "CI" },
+      { identity: "12", displayLabel: "CI" },
     ])
 
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "201:1",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-            observedRun({
-              runIdentity: "200:1",
+              runIdentity: "102:20260907.102",
               rawStatus: "completed",
-              rawConclusion: "failure",
+              rawConclusion: "partiallySucceeded",
             }),
           ]),
         ],
       })
     await refresh(repository.id)
-    gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("CLOSED")
-    expect(gate.activeIncident?.status).toBe("OPEN")
+    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
 
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "202:1",
+              runIdentity: "103:20260907.103",
               rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-            observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
+              rawConclusion: "succeeded",
             }),
           ]),
         ],
@@ -595,50 +598,155 @@ describe("Repository CI Gate observation", () => {
     gate = await fetchCiGate(repository.id)
     expect(gate.status).toBe("OPEN")
     expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.status).toBe("RESOLVED")
     expect(gate.latestResolvedIncident?.recoveryReason).toBe("NEWER_SUCCESS")
   })
 
-  test("a run first seen as pending latches Closed when that same run later fails", async () => {
+  test("canceled, notStarted, postponed, and inProgress do not close an otherwise Open gate", async () => {
     const repository = await addRepository()
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "500:1",
-              rawStatus: "in_progress",
+              runIdentity: "200:20260907.200",
+              rawStatus: "completed",
+              rawConclusion: "canceled",
+            }),
+            observedRun({
+              runIdentity: "199:20260907.199",
+              rawStatus: "notStarted",
+              rawConclusion: "none",
+            }),
+            observedRun({
+              runIdentity: "198:20260907.198",
+              rawStatus: "postponed",
+              rawConclusion: null,
+            }),
+            observedRun({
+              runIdentity: "197:20260907.197",
+              rawStatus: "inProgress",
+              rawConclusion: null,
+            }),
+            observedRun({
+              runIdentity: "196:20260907.196",
+              rawStatus: "cancelling",
               rawConclusion: null,
             }),
           ]),
         ],
       })
-    await saveSelection(repository.id, ["161335"])
+    await saveSelection(repository.id, ["12"])
+    const gate = await fetchCiGate(repository.id)
+    expect(gate.status).toBe("OPEN")
+    expect(gate.definitions[0]?.failureLatched).toBe(false)
+    expect(gate.activeIncident).toBeNull()
+  })
+
+  test("a saved pipeline that later becomes unavailable stays listed as Degraded", async () => {
+    const repository = await addRepository()
+    observe = () =>
+      Effect.succeed({
+        defaultBranch: "refs/heads/main",
+        observations: [
+          observedDefinition("12", [
+            observedRun({
+              runIdentity: "250:20260907.250",
+              rawStatus: "completed",
+              rawConclusion: "succeeded",
+            }),
+          ]),
+        ],
+      })
+    await saveSelection(repository.id, ["12"])
     expect((await fetchCiGate(repository.id)).status).toBe("OPEN")
 
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          {
+            identity: "12",
+            kind: "unavailable",
+            reason: "not_found",
+            message: "CI Gate Definition 12 could not be observed",
+          },
+        ],
+      })
+    await refresh(repository.id)
+    const gate = await fetchCiGate(repository.id)
+    expect(gate.status).toBe("DEGRADED")
+    expect(gate.enabled).toBe(true)
+    expect(gate.definitions).toEqual([
+      expect.objectContaining({
+        identity: "12",
+        displayLabel: "CI",
+        failureLatched: false,
+        diagnostic: "CI Gate Definition 12 could not be observed",
+      }),
+    ])
+    expect(gate.activeIncident).toBeNull()
+  })
+
+  test("a permission failure degrades Open and cannot clear an existing Closed latch", async () => {
+    const repository = await addRepository()
+    observe = () =>
+      Effect.succeed({
+        defaultBranch: "refs/heads/main",
+        observations: [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "500:1",
+              runIdentity: "300:20260907.300",
               rawStatus: "completed",
-              rawConclusion: "failure",
+              rawConclusion: "succeeded",
+            }),
+          ]),
+        ],
+      })
+    await saveSelection(repository.id, ["12"])
+    observe = () =>
+      Effect.fail(
+        new AzureDevOpsRequestError({
+          message:
+            "Failed to observe CI Gate Definitions for acme/widgets: Build read required",
+          statusCode: 403,
+        }),
+      )
+    await refresh(repository.id)
+    let gate = await fetchCiGate(repository.id)
+    expect(gate.status).toBe("DEGRADED")
+    expect(gate.diagnostic).toContain("Build read required")
+    expect(gate.activeIncident).toBeNull()
+
+    observe = () =>
+      Effect.succeed({
+        defaultBranch: "refs/heads/main",
+        observations: [
+          observedDefinition("12", [
+            observedRun({
+              runIdentity: "301:20260907.301",
+              rawStatus: "completed",
+              rawConclusion: "failed",
             }),
           ]),
         ],
       })
     await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
+    observe = () =>
+      Effect.fail(
+        new AzureDevOpsRequestError({
+          message:
+            "Failed to observe CI Gate Definitions for acme/widgets: Build read required",
+          statusCode: 403,
+        }),
+      )
+    await refresh(repository.id)
+    gate = await fetchCiGate(repository.id)
     expect(gate.status).toBe("CLOSED")
-    expect(gate.definitions[0]?.failureLatched).toBe(true)
-    expect(gate.definitions[0]?.latestRun?.rawConclusion).toBe("failure")
     expect(gate.activeIncident?.status).toBe("OPEN")
   })
 
-  test("later observation tells GitHub the last-seen run identity", async () => {
+  test("later observation tells Azure the last-seen build identity", async () => {
     const repository = await addRepository()
     const seenLastRunIdentities: Array<{
       readonly [identity: string]: string
@@ -646,383 +754,61 @@ describe("Repository CI Gate observation", () => {
     observe = (_repo, input) => {
       seenLastRunIdentities.push(input.lastRunIdentities)
       return Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "100:1",
+              runIdentity: "400:20260907.400",
               rawStatus: "completed",
-              rawConclusion: "success",
+              rawConclusion: "succeeded",
             }),
           ]),
         ],
       })
     }
-    await saveSelection(repository.id, ["161335"])
+    await saveSelection(repository.id, ["12"])
     expect(seenLastRunIdentities[0]).toEqual({})
     await refresh(repository.id)
-    expect(seenLastRunIdentities[1]).toEqual({ "161335": "100:1" })
+    expect(seenLastRunIdentities[1]).toEqual({ "12": "400:20260907.400" })
   })
 
-  test("a pending rerun that later succeeds clears the failure latch", async () => {
+  test("PR Status Check aggregation stays on the Azure policy path and is not used as the CI Gate", async () => {
     const repository = await addRepository()
     observe = () =>
       Effect.succeed({
-        defaultBranch: "main",
+        defaultBranch: "refs/heads/main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("12", [
             observedRun({
-              runIdentity: "200:1",
+              runIdentity: "500:20260907.500",
               rawStatus: "completed",
-              rawConclusion: "failure",
+              rawConclusion: "failed",
             }),
           ]),
         ],
       })
-    await saveSelection(repository.id, ["161335"])
+    await saveSelection(repository.id, ["12"])
     expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
+    expect(pullRequestCheckCalls).toBe(0)
 
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:2",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:2",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe("NEWER_SUCCESS")
-  })
-
-  test("a pending rerun of a failed run stays Closed even when older success remains in history", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-            observedRun({
-              runIdentity: "199:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:2",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-            observedRun({
-              runIdentity: "199:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("CLOSED")
-    expect(gate.activeIncident?.status).toBe("OPEN")
-    expect(gate.definitions[0]?.latestRun?.runIdentity).toBe("200:2")
-  })
-
-  test("timeout and action-required conclusions latch Closed while canceled does not", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "900:1",
-              rawStatus: "completed",
-              rawConclusion: "timed_out",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "901:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("OPEN")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "902:1",
-              rawStatus: "completed",
-              rawConclusion: "action_required",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "903:1",
-              rawStatus: "completed",
-              rawConclusion: "cancelled",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["269289"])
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.definitions[0]?.failureLatched).toBe(false)
-  })
-
-  test("a failure and later success first seen together become a resolved incident without leaving Closed", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "301:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-              createdAt: "2026-09-07T13:00:00.000Z",
-            }),
-            observedRun({
-              runIdentity: "300:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-              createdAt: "2026-09-07T12:00:00.000Z",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.status).toBe("RESOLVED")
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe("NEWER_SUCCESS")
-  })
-
-  test("Closed outranks a later permission error, which otherwise degrades an Open gate", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "400:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    observe = () =>
-      Effect.fail(
-        new GitHubRequestError({
-          message:
-            "Failed to observe CI Gate Definitions for acme/widgets: Actions read required",
-          statusCode: 403,
-          retryable: false,
-        }),
-      )
-    await refresh(repository.id)
-    let gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("DEGRADED")
-    expect(gate.diagnostic).toContain("Actions read required")
-    expect(gate.activeIncident).toBeNull()
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "401:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    observe = () =>
-      Effect.fail(
-        new GitHubRequestError({
-          message:
-            "Failed to observe CI Gate Definitions for acme/widgets: Actions read required",
-          statusCode: 403,
-          retryable: false,
-        }),
-      )
-    await refresh(repository.id)
-    gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("CLOSED")
-    expect(gate.activeIncident?.status).toBe("OPEN")
-  })
-
-  test("removing a failed definition or clearing the selection resolves with an attributable reason", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "500:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "600:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335", "269289"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "600:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["269289"])
-    let gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe(
-      "DEFINITION_REMOVED",
+    const status = await runtime.runPromise(
+      Effect.gen(function* () {
+        const azureDevOps = yield* AzureDevOpsService
+        return yield* azureDevOps.getPullRequestCheckStatus(
+          repository,
+          "feature",
+        )
+      }),
     )
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "601:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
+    expect(status._tag).toBe("succeeded")
+    expect(status.terminalChecks).toEqual([
+      {
+        externalId: "azure-policy:eval-1",
+        name: "Build validation",
+        outcome: "green",
+      },
+    ])
+    expect(pullRequestCheckCalls).toBe(1)
     expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-    await saveSelection(repository.id, [])
-    gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("DISABLED")
-    expect(gate.enabled).toBe(false)
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe("EMPTY_SELECTION")
-  })
-
-  test("a default-branch change clears old latches and starts an optimistic baseline", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "700:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "develop",
-        observations: [observedDefinition("161335", [])],
-      })
-    await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.defaultBranch).toBe("develop")
-    expect(gate.status).toBe("OPEN")
-    expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe(
-      "DEFAULT_BRANCH_CHANGED",
-    )
-    expect(gate.definitions[0]?.diagnostic).toBe("Not observed yet")
   })
 })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -274,6 +274,9 @@ const defaultAzureDevOps: AzureDevOpsServiceShape = {
   verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
   getOpenPullRequestNumber: () => Effect.succeed(1),
@@ -13006,6 +13009,115 @@ describe("GraphQL API", () => {
     }
     expect(payload.data.ciGateCatalog.definitions).toEqual([])
     expect(payload.data.ciGateCatalog.error).toContain("Actions read required")
+  })
+
+  test("ciGateCatalog returns live Azure DevOps build pipelines without Azure-specific types", async () => {
+    await runtime.dispose()
+    const azureRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/acme/widgets.git",
+      paused: true,
+    })
+    runtime = makeRuntime(
+      { listRepositories: Effect.succeed([azureRepository]) },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.succeed([
+            {
+              identity: "12",
+              displayLabel: "CI",
+              kind: "build-pipeline",
+              diagnosticMetadata:
+                "\\CI · build · enabled · rev 3 · https://dev.azure.com/acme/widgets/_build?definitionId=12",
+            },
+          ]),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          ciGateCatalog(repositoryId: "${azureRepository.id}") {
+            error
+            definitions { identity displayLabel kind diagnosticMetadata }
+          }
+        }`,
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        ciGateCatalog: {
+          error: null,
+          definitions: [
+            {
+              identity: "12",
+              displayLabel: "CI",
+              kind: "build-pipeline",
+              diagnosticMetadata:
+                "\\CI · build · enabled · rev 3 · https://dev.azure.com/acme/widgets/_build?definitionId=12",
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("ciGateCatalog returns Azure Build-read guidance instead of failing the query", async () => {
+    await runtime.dispose()
+    const azureRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/acme/widgets.git",
+      paused: true,
+    })
+    runtime = makeRuntime(
+      { listRepositories: Effect.succeed([azureRepository]) },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.fail(
+            new AzureDevOpsRequestError({
+              message:
+                "Failed to list CI Gate Definitions for acme/widgets: Build read required",
+              statusCode: 403,
+            }),
+          ),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          ciGateCatalog(repositoryId: "${azureRepository.id}") {
+            error
+            definitions { identity }
+          }
+        }`,
+      }),
+    )
+    const payload = (await response.json()) as {
+      data: {
+        ciGateCatalog: { error: string | null; definitions: unknown[] }
+      }
+    }
+    expect(payload.data.ciGateCatalog.definitions).toEqual([])
+    expect(payload.data.ciGateCatalog.error).toContain("Build read required")
   })
 
   test("updateRepositorySettings saves catalog identities and rejects fabricated ones", async () => {

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -261,6 +261,9 @@ const defaultAzureDevOpsShape = {
   verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("operator"),
   listReadyIssues: () => Effect.succeed([]),
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
   getOpenPullRequestNumber: () => Effect.succeed(1),

--- a/packages/work-item-lifecycle/src/lib/azure-devops-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/azure-devops-service-test.ts
@@ -19,6 +19,12 @@ export const stubAzureDevOpsServiceLayer = (
       verifyProject: (repository) => Effect.succeed(repository),
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
       listReadyIssues: () => Effect.succeed([]),
+      listCiGateCatalog: () => Effect.succeed([]),
+      observeCiGate: () =>
+        Effect.succeed({
+          defaultBranch: "refs/heads/main",
+          observations: [],
+        }),
       hasCredentials: () => Effect.succeed(true),
       hasAmbientCredentials: () => Effect.succeed(true),
       getOpenPullRequestNumber: () => Effect.succeed(1),

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -187,6 +187,9 @@ const stubAzureDevOps = (
     verifyProject: (repository) => Effect.succeed(repository),
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     listReadyIssues: () => Effect.succeed([]),
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
     hasCredentials: () => Effect.succeed(true),
     hasAmbientCredentials: () => Effect.succeed(true),
     getOpenPullRequestNumber: () => Effect.succeed(321),

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -251,6 +251,9 @@ const azureDevOpsWith = (
     verifyProject: (repository) => Effect.succeed(repository),
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     listReadyIssues: () => Effect.succeed([]),
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
     hasCredentials: () => Effect.succeed(true),
     hasAmbientCredentials: () => Effect.succeed(true),
     getOpenPullRequestNumber: () => Effect.succeed(1),

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -103,6 +103,9 @@ const stubAzureDevOps = (
     verifyProject: (repository) => Effect.succeed(repository),
     getAuthenticatedUserLogin: () => Effect.succeed("operator"),
     listReadyIssues: () => Effect.succeed([]),
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "refs/heads/main", observations: [] }),
     hasCredentials: () => Effect.succeed(true),
     hasAmbientCredentials: () => Effect.succeed(true),
     getOpenPullRequestNumber: () => Effect.succeed(1),


### PR DESCRIPTION
## Why

The Repository CI Gate already lets operators opt a GitHub Repository into default-branch health. Azure DevOps operators needed the same opt-in without offering every build definition in the Azure project, and without treating Pull Request validation as repository-wide CI. This is #1255.

## What changed

Azure Repos now discover **enabled build pipelines associated with this Git repository** and observe their default-branch builds through the existing gate model.

- Catalog identity stays native (definition id, name, folder, kind, queue state, revision, browser URL).
- Observation uses the current default branch in Azure ref form (`refs/heads/…`).
- Pull Request validation builds are ignored even when they target that branch.
- **Failed** and **partially succeeded** close the gate; **succeeded** clears it. Canceled, not started, postponed, in progress, cancelling, and none do not close an otherwise Open gate.
- A saved pipeline that later disappears or is disabled stays listed as Degraded. Missing Build read permission is Degraded and cannot clear an existing Closed latch.
- Selection save, Refresh, polling, incidents, recovery, and Repository/CLI status use the generic modules. There is no Azure-only lifecycle fork.
- Existing PR Status Checks (branch policy / build validation) and queued merge behavior are unchanged. Discovery uses the Repository PAT and official REST APIs; `az` is not required.

## Verification

Adapter tests cover repository-filtered discovery, continuation-token pagination, PR exclusion, ordering, status/result mapping (including partial success and non-closing outcomes), URLs, disabled/deleted definitions, and permission failures.

Application-level Azure GraphQL scenarios cover select → failed/partially succeeded Closed → newer success, saved-unavailable Degraded, permission that cannot clear a Closed latch, and PR Status Checks remaining a separate path. GitHub CI Gate tests still pass.

## Limitations

Ordinary hold, CI Repair authorization, and merge revalidation after a Closed gate still belong to later tickets in this epic (#1251–#1253). Azure is already on the shared gate path, so those behaviors do not need an Azure-specific branch once they land.

Closes #1255