### PR TITLE
feat: observe GitLab Project pipelines as a Repository CI Gate (#1254)

### DIFF
--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -175,6 +175,18 @@ export const ambientGitLabLayer = (options: {
               service.listReadyIssues(repository),
             ),
         ),
+        listCiGateCatalog: Effect.fn("AmbientGitLab.listCiGateCatalog")(
+          (repository) =>
+            authenticated(repository.forgeHost, (service) =>
+              service.listCiGateCatalog(repository),
+            ),
+        ),
+        observeCiGate: Effect.fn("AmbientGitLab.observeCiGate")(
+          (repository, input) =>
+            authenticated(repository.forgeHost, (service) =>
+              service.observeCiGate(repository, input),
+            ),
+        ),
         hasCredentials: Effect.fn("AmbientGitLab.hasCredentials")(
           (repository) =>
             acquireToken(repository.forgeHost).pipe(

--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -16,6 +16,8 @@ import {
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { ambientGitLabLayer } from "./ambient-gitlab-layer.js"
 import {
+  SerializedCiGateCatalog,
+  SerializedCiGateObservation,
   SerializedMergePullRequestResult,
   SerializedPrStatusCheckDiagnostics,
   SerializedPullRequestCheckStatus,
@@ -391,6 +393,53 @@ export const keymaxxerGitLabLayer = (options: {
                   decode: (stdout) => parseIssues(stdout, repository),
                 }),
               (ambientService) => ambientService.listReadyIssues(repository),
+            ),
+        ),
+        listCiGateCatalog: Effect.fn("KeymaxxerGitLab.listCiGateCatalog")(
+          (repository) =>
+            withVaultOrAmbient(
+              repository,
+              (tokenName) =>
+                callHelper({
+                  operation: "list-ci-gate-catalog",
+                  repository,
+                  tokenName,
+                  describe: "list CI Gate Definitions",
+                  decode: decodeJson(
+                    SerializedCiGateCatalog,
+                    repository,
+                    "decode CI Gate catalog",
+                  ),
+                }),
+              (ambientService) => ambientService.listCiGateCatalog(repository),
+            ),
+        ),
+        observeCiGate: Effect.fn("KeymaxxerGitLab.observeCiGate")(
+          (repository, input) =>
+            withVaultOrAmbient(
+              repository,
+              (tokenName) =>
+                callHelper({
+                  operation: "observe-ci-gate",
+                  repository,
+                  tokenName,
+                  describe: "observe CI Gate Definitions",
+                  args: [
+                    encodeArgument(
+                      JSON.stringify({
+                        definitionIdentities: input.definitionIdentities,
+                        lastRunIdentities: input.lastRunIdentities,
+                      }),
+                    ),
+                  ],
+                  decode: decodeJson(
+                    SerializedCiGateObservation,
+                    repository,
+                    "decode CI Gate observation",
+                  ),
+                }),
+              (ambientService) =>
+                ambientService.observeCiGate(repository, input),
             ),
         ),
         hasCredentials: Effect.fn("KeymaxxerGitLab.hasCredentials")(

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -53,6 +53,9 @@ const service = (
   ensureIssueCompletedWithSummary: () => Effect.void,
   closeOpenPullRequestsForBranch: () => Effect.void,
   deleteBranch: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "main", observations: [] }),
   ...overrides,
 })
 

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -186,6 +186,9 @@ const defaultGitlabLayer = Layer.succeed(GitLabService, {
   ensureIssueCompletedWithSummary: () => Effect.void,
   closeOpenPullRequestsForBranch: () => Effect.void,
   deleteBranch: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "main", observations: [] }),
 } satisfies GitLabServiceShape)
 
 const defaultAzureDevOpsShape = {

--- a/apps/harness/test/keymaxxer-gitlab-layer.test.ts
+++ b/apps/harness/test/keymaxxer-gitlab-layer.test.ts
@@ -44,6 +44,9 @@ const gitlabLifecycleStub = {
   ensureIssueCompletedWithSummary: () => Effect.void,
   closeOpenPullRequestsForBranch: () => Effect.void,
   deleteBranch: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "main", observations: [] }),
 } as const
 
 const repository = {
@@ -880,5 +883,50 @@ describe("Keymaxxer-backed GitLab layer", () => {
         expect(runs[0]?.command).toContain("get-pr-lifecycle-status")
         expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
       }),
+  )
+
+  it.effect("forwards CI Gate observation input to the observe helper", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify({
+              defaultBranch: "main",
+              observations: [{ identity: "42", kind: "observed", runs: [] }],
+            }),
+            stderr: "",
+          })
+        },
+      })
+      const layer = keymaxxerGitLabLayer({
+        workspaceRoot: "/workspace",
+      }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+      const observation = yield* Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        return yield* gitlab.observeCiGate(repository, {
+          definitionIdentities: ["42"],
+          lastRunIdentities: { "42": "47:12" },
+        })
+      }).pipe(Effect.provide(layer))
+      expect(observation.defaultBranch).toBe("main")
+      expect(runs[0]?.command).toContain("observe-ci-gate")
+      expect(runs[0]?.command).toContain(
+        Buffer.from(
+          JSON.stringify({
+            definitionIdentities: ["42"],
+            lastRunIdentities: { "42": "47:12" },
+          }),
+          "utf8",
+        ).toString("base64url"),
+      )
+    }),
   )
 })

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -146,6 +146,9 @@ const defaultGitlab: GitLabServiceShape = {
   ensureIssueCompletedWithSummary: () => Effect.void,
   closeOpenPullRequestsForBranch: () => Effect.void,
   deleteBranch: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "main", observations: [] }),
 }
 
 const defaultAzureDevOps: AzureDevOpsServiceShape = {

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -4,14 +4,15 @@ export interface GitHubRepository {
   readonly projectPath: string
 }
 
-/**
- * Forge-neutral CI Gate catalog entry. GitHub maps an active Actions
- * workflow (identity is the workflow id); Azure DevOps maps an enabled
- * build pipeline associated with the Git Repository (identity is the
- * build definition id).
- */
 export const GITHUB_CI_GATE_KIND = "workflow"
 
+/**
+ * Forge-neutral CI Gate catalog entry. GitHub maps an active Actions
+ * workflow (identity is the workflow id). GitLab maps one synthesized
+ * Project pipeline (identity is the numeric project id). Azure DevOps
+ * maps an enabled build pipeline associated with the Git Repository
+ * (identity is the build definition id).
+ */
 export interface CiGateCatalogEntry {
   readonly identity: string
   readonly displayLabel: string

--- a/packages/gitlab-service/src/bin/list-ci-gate-catalog.ts
+++ b/packages/gitlab-service/src/bin/list-ci-gate-catalog.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const listCiGateCatalogProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const gitlab = yield* GitLabService
+    const catalog = yield* gitlab.listCiGateCatalog(repository)
+    yield* writeStandardOutput(JSON.stringify(catalog))
+  })
+
+if (import.meta.main)
+  runGitLabCli(listCiGateCatalogProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/observe-ci-gate.ts
+++ b/packages/gitlab-service/src/bin/observe-ci-gate.ts
@@ -1,0 +1,42 @@
+import { Effect, Schema } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  CliArgumentError,
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+const ObserveCiGateArguments = Schema.Struct({
+  definitionIdentities: Schema.Array(Schema.String),
+  lastRunIdentities: Schema.Record(Schema.String, Schema.String),
+})
+
+export const observeCiGateProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const encodedInput = yield* decodeArgument(
+      args[3],
+      "CI Gate observation input",
+    )
+    const input = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(ObserveCiGateArguments),
+    )(encodedInput).pipe(
+      Effect.mapError(
+        () =>
+          new CliArgumentError({
+            message: "Invalid CI Gate observation input argument",
+          }),
+      ),
+    )
+    const gitlab = yield* GitLabService
+    const observation = yield* gitlab.observeCiGate(repository, input)
+    yield* writeStandardOutput(JSON.stringify(observation))
+  })
+
+if (import.meta.main) runGitLabCli(observeCiGateProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/lib/gitlab-helper-process.ts
+++ b/packages/gitlab-service/src/lib/gitlab-helper-process.ts
@@ -11,9 +11,11 @@ import { getOpenPullRequestNumberProgram } from "../bin/get-open-pull-request-nu
 import { getPrCheckStatusProgram } from "../bin/get-pr-check-status.js"
 import { getPrLifecycleStatusProgram } from "../bin/get-pr-lifecycle-status.js"
 import { getPrStatusCheckDiagnosticsProgram } from "../bin/get-pr-status-check-diagnostics.js"
+import { listCiGateCatalogProgram } from "../bin/list-ci-gate-catalog.js"
 import { listReadyIssuesProgram } from "../bin/list-ready-issues.js"
 import { markPrReadyForReviewProgram } from "../bin/mark-pr-ready-for-review.js"
 import { mergePullRequestProgram } from "../bin/merge-pull-request.js"
+import { observeCiGateProgram } from "../bin/observe-ci-gate.js"
 import { updateOpenDraftPullRequestCopyProgram } from "../bin/update-open-draft-pull-request-copy.js"
 import { verifyProjectProgram } from "../bin/verify-project.js"
 import { gitlabServiceBinScriptPath } from "../bin-script-path.js"
@@ -25,6 +27,8 @@ export const INTERNAL_GITLAB_HELPER_ARG =
 
 export const GITLAB_HELPER_OPERATIONS = [
   "list-ready-issues",
+  "list-ci-gate-catalog",
+  "observe-ci-gate",
   "get-authenticated-user-login",
   "verify-project",
   "get-open-pull-request-number",
@@ -133,6 +137,8 @@ const programs: Record<
   (args: ReadonlyArray<string>) => Effect.Effect<void, unknown, GitLabService>
 > = {
   "list-ready-issues": listReadyIssuesProgram,
+  "list-ci-gate-catalog": listCiGateCatalogProgram,
+  "observe-ci-gate": observeCiGateProgram,
   "get-authenticated-user-login": getAuthenticatedUserLoginProgram,
   "verify-project": verifyProjectProgram,
   "get-open-pull-request-number": getOpenPullRequestNumberProgram,

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -10,6 +10,9 @@ import {
   Schema,
 } from "effect"
 import {
+  type CiGateCatalogEntry,
+  type CiGateDefinitionObservation,
+  type CiGateObservedRun,
   type MergePullRequestResult,
   type PrStatusCheckDiagnostic,
   type PullRequestCheckStatus,
@@ -24,7 +27,11 @@ import {
   type GitLabServiceError,
   type GitLabServiceShape,
 } from "./gitlab-service.js"
-import type { GitLabReadyLabeledIssue, GitLabRepository } from "./types.js"
+import {
+  GITLAB_CI_GATE_KIND,
+  type GitLabReadyLabeledIssue,
+  type GitLabRepository,
+} from "./types.js"
 
 const REQUEST_TIMEOUT = Duration.seconds(30)
 const READY_LABEL = "ready-for-agent"
@@ -57,7 +64,11 @@ const ProjectSchema = Schema.Struct({
   default_branch: Schema.optional(Schema.NullOr(Schema.String)),
   /** Canonical web/API host lives here; SSH remotes may use a different host. */
   web_url: Schema.optional(Schema.NullOr(Schema.String)),
+  ci_config_path: Schema.optional(Schema.NullOr(Schema.String)),
+  jobs_enabled: Schema.optional(Schema.NullOr(Schema.Boolean)),
+  builds_access_level: Schema.optional(Schema.NullOr(Schema.String)),
 })
+type GitLabProject = typeof ProjectSchema.Type
 
 /**
  * Normalize a Forge Host string (hostname or hostname:port).
@@ -493,6 +504,136 @@ const apiBase = (repository: GitLabRepository): string =>
 const projectApiPath = (repository: GitLabRepository): string =>
   `/projects/${encodeURIComponent(repository.projectPath)}`
 
+const DEFAULT_CI_CONFIG_PATH = ".gitlab-ci.yml"
+const PROJECT_PIPELINE_LABEL = "Project pipeline"
+const CI_GATE_INCLUDED_SOURCES = new Set([
+  "push",
+  "schedule",
+  "web",
+  "trigger",
+  "api",
+])
+const CI_GATE_EXCLUDED_SOURCES = new Set([
+  "merge_request_event",
+  "external_pull_request_event",
+  "parent_pipeline",
+])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isProjectCiAvailable = (project: GitLabProject): boolean => {
+  const access = (project.builds_access_level ?? "").trim().toLowerCase()
+  if (access === "disabled") return false
+  if (project.jobs_enabled === false) return false
+  return true
+}
+
+const configurationPath = (project: GitLabProject): string => {
+  const path = project.ci_config_path?.trim() ?? ""
+  return path === "" ? DEFAULT_CI_CONFIG_PATH : path
+}
+
+const toProjectPipelineCatalogEntry = (
+  projectId: number,
+  project: GitLabProject,
+): CiGateCatalogEntry => ({
+  identity: String(projectId),
+  displayLabel: PROJECT_PIPELINE_LABEL,
+  kind: GITLAB_CI_GATE_KIND,
+  diagnosticMetadata: configurationPath(project),
+})
+
+const mapCiGatePermissionError = (
+  error: GitLabRequestError,
+  message: string,
+): GitLabRequestError =>
+  error.statusCode === 403
+    ? new GitLabRequestError({
+        message,
+        statusCode: 403,
+        cause: error,
+      })
+    : error
+
+const pipelineIdFromIdentity = (runIdentity: string): string => {
+  const separator = runIdentity.indexOf(":")
+  return separator === -1 ? runIdentity : runIdentity.slice(0, separator)
+}
+
+const isSameObservedPipeline = (
+  runIdentity: string,
+  lastRunIdentity: string,
+): boolean =>
+  runIdentity === lastRunIdentity ||
+  pipelineIdFromIdentity(runIdentity) ===
+    pipelineIdFromIdentity(lastRunIdentity)
+
+const mapObservedPipeline = (
+  value: unknown,
+  defaultBranch: string,
+): CiGateObservedRun | null => {
+  if (!isRecord(value)) {
+    return null
+  }
+  const id = value.id
+  if (typeof id !== "number" || !Number.isSafeInteger(id) || id <= 0) {
+    return null
+  }
+  const source = typeof value.source === "string" ? value.source.trim() : ""
+  if (
+    source === "" ||
+    CI_GATE_EXCLUDED_SOURCES.has(source) ||
+    !CI_GATE_INCLUDED_SOURCES.has(source)
+  ) {
+    return null
+  }
+  const headRef = typeof value.ref === "string" ? value.ref.trim() : ""
+  if (headRef !== defaultBranch) {
+    return null
+  }
+  const createdAt = parseInstant(
+    typeof value.created_at === "string" ? value.created_at : null,
+  )
+  if (createdAt === null) {
+    return null
+  }
+  const iid =
+    typeof value.iid === "number" &&
+    Number.isSafeInteger(value.iid) &&
+    value.iid > 0
+      ? value.iid
+      : null
+  const htmlUrl =
+    typeof value.web_url === "string" && value.web_url.trim() !== ""
+      ? value.web_url.trim()
+      : null
+  const headSha =
+    typeof value.sha === "string" && value.sha.trim() !== ""
+      ? value.sha.trim()
+      : null
+  const rawStatus =
+    typeof value.status === "string" && value.status.trim() !== ""
+      ? value.status.trim()
+      : null
+  return {
+    runIdentity: iid === null ? String(id) : `${String(id)}:${String(iid)}`,
+    htmlUrl,
+    headSha,
+    headRef,
+    event: source,
+    createdAt,
+    updatedAt: parseInstant(
+      typeof value.updated_at === "string" ? value.updated_at : null,
+    ),
+    startedAt: parseInstant(
+      typeof value.started_at === "string" ? value.started_at : null,
+    ),
+    rawStatus,
+    rawConclusion: null,
+  }
+}
+
 const requestError = (message: string, cause: unknown): GitLabRequestError => {
   const code = extractErrorCode(cause)
   return new GitLabRequestError({
@@ -756,6 +897,71 @@ export const makeGitLabService = (options: {
       ),
     )
 
+  const listObservedPipelines = (
+    repository: GitLabRepository,
+    defaultBranch: string,
+    lastSeen: string | null,
+  ): Effect.Effect<readonly CiGateObservedRun[], GitLabRequestError> => {
+    const message = `Failed to observe CI Gate Definitions for ${repository.projectPath}`
+    return Effect.tryPromise({
+      try: async () => {
+        const runs: CiGateObservedRun[] = []
+        let page = 1
+        const path = `${projectApiPath(repository)}/pipelines?ref=${encodeURIComponent(defaultBranch)}&order_by=id&sort=desc`
+        while (true) {
+          const response = await fetchImpl(
+            `${apiBase(repository)}${path}&per_page=${PAGE_SIZE}&page=${page}`,
+            { headers },
+          )
+          if (!response.ok) {
+            throw new GitLabHttpError(
+              response.status,
+              `${message}: GitLab returned HTTP ${response.status}`,
+            )
+          }
+          const decoded: unknown = await response.json()
+          if (!Array.isArray(decoded)) {
+            throw new Error(`${message}: GitLab returned a non-array page`)
+          }
+          let reachedLastSeen = false
+          for (const value of decoded) {
+            const mapped = mapObservedPipeline(value, defaultBranch)
+            if (mapped === null) {
+              continue
+            }
+            runs.push(mapped)
+            if (
+              lastSeen !== null &&
+              isSameObservedPipeline(mapped.runIdentity, lastSeen)
+            ) {
+              reachedLastSeen = true
+              break
+            }
+          }
+          if (reachedLastSeen) {
+            break
+          }
+          const nextPage = response.headers.get("x-next-page")?.trim() ?? ""
+          if (nextPage === "") {
+            break
+          }
+          const parsed = Number(nextPage)
+          if (!Number.isSafeInteger(parsed) || parsed <= page) {
+            throw new Error(`${message}: invalid GitLab x-next-page header`)
+          }
+          page = parsed
+        }
+        return runs
+      },
+      catch: (cause) => requestError(message, cause),
+    }).pipe(
+      Effect.timeout(REQUEST_TIMEOUT),
+      Effect.catchTag("TimeoutError", (cause) =>
+        Effect.fail(requestError(`${message} timed out`, cause)),
+      ),
+    )
+  }
+
   const unavailableOn404 = <A>(
     repository: GitLabRepository,
     effect: Effect.Effect<A, GitLabRequestError>,
@@ -771,6 +977,29 @@ export const makeGitLabService = (options: {
           error.statusCode === 404
             ? Effect.fail(new GitLabProjectUnavailableError(repository))
             : Effect.fail(error),
+      ),
+    )
+
+  const loadCiGateProject = (
+    repository: GitLabRepository,
+    message: string,
+  ): Effect.Effect<GitLabProject, GitLabServiceError> =>
+    unavailableOn404(
+      repository,
+      requestUnknown(repository, projectApiPath(repository), message).pipe(
+        Effect.mapError((error) =>
+          mapCiGatePermissionError(
+            error,
+            `${message}: API/pipeline read required`,
+          ),
+        ),
+        Effect.flatMap((value) =>
+          decodeEffect(
+            ProjectSchema,
+            value,
+            `GitLab returned invalid project data for ${repository.projectPath}`,
+          ),
+        ),
       ),
     )
 
@@ -1083,6 +1312,100 @@ export const makeGitLabService = (options: {
           ),
         ),
       ),
+    ),
+    listCiGateCatalog: Effect.fn("GitLabService.listCiGateCatalog")(
+      (repository) =>
+        loadCiGateProject(
+          repository,
+          `Failed to list CI Gate Definitions for ${repository.projectPath}`,
+        ).pipe(
+          Effect.flatMap((project) => {
+            if (!isProjectCiAvailable(project)) {
+              return Effect.succeed([])
+            }
+            if (project.id === undefined) {
+              return Effect.fail(
+                new GitLabRequestError({
+                  message: `GitLab returned no project id for ${repository.projectPath}`,
+                }),
+              )
+            }
+            return Effect.succeed([
+              toProjectPipelineCatalogEntry(project.id, project),
+            ])
+          }),
+        ),
+    ),
+    observeCiGate: Effect.fn("GitLabService.observeCiGate")(
+      function* (repository, input) {
+        const project = yield* loadCiGateProject(
+          repository,
+          `Failed to observe CI Gate Definitions for ${repository.projectPath}`,
+        )
+        const defaultBranch = project.default_branch?.trim() ?? ""
+        if (defaultBranch === "") {
+          return yield* new GitLabRequestError({
+            message: `GitLab returned no default branch for ${repository.projectPath}`,
+          })
+        }
+        const ciAvailable = isProjectCiAvailable(project)
+        if (ciAvailable && project.id === undefined) {
+          return yield* new GitLabRequestError({
+            message: `GitLab returned no project id for ${repository.projectPath}`,
+          })
+        }
+        const projectIdentity =
+          project.id === undefined ? null : String(project.id)
+        const observations: CiGateDefinitionObservation[] = []
+        for (const rawIdentity of input.definitionIdentities) {
+          const identity = rawIdentity.trim()
+          if (
+            identity.length === 0 ||
+            projectIdentity === null ||
+            identity !== projectIdentity
+          ) {
+            observations.push({
+              identity,
+              kind: "unavailable",
+              reason: "not_found",
+              message: `CI Gate Definition ${identity} could not be observed`,
+            })
+            continue
+          }
+          if (!ciAvailable) {
+            observations.push({
+              identity,
+              kind: "unavailable",
+              reason: "not_found",
+              message: `Project CI is disabled for ${repository.projectPath}`,
+            })
+            continue
+          }
+          const lastSeenRaw = input.lastRunIdentities[identity]
+          const lastSeen =
+            lastSeenRaw !== undefined && lastSeenRaw.trim() !== ""
+              ? lastSeenRaw
+              : null
+          const runs = yield* listObservedPipelines(
+            repository,
+            defaultBranch,
+            lastSeen,
+          ).pipe(
+            Effect.mapError((error) =>
+              mapCiGatePermissionError(
+                error,
+                `Failed to observe CI Gate Definitions for ${repository.projectPath}: API/pipeline read required`,
+              ),
+            ),
+          )
+          observations.push({
+            identity,
+            kind: "observed",
+            runs,
+          })
+        }
+        return { defaultBranch, observations }
+      },
     ),
     getPullRequestCheckStatus: Effect.fn(
       "GitLabService.getPullRequestCheckStatus",

--- a/packages/gitlab-service/src/lib/gitlab-service-test.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-test.ts
@@ -131,5 +131,11 @@ export const makeGitLabServiceTest = (
     closeOpenPullRequestsForBranch: (repository) =>
       failOr(repository, () => Effect.void),
     deleteBranch: (repository) => failOr(repository, () => Effect.void),
+    listCiGateCatalog: (repository) =>
+      failOr(repository, () => Effect.succeed([])),
+    observeCiGate: (repository) =>
+      failOr(repository, () =>
+        Effect.succeed({ defaultBranch: "main", observations: [] }),
+      ),
   })
 }

--- a/packages/gitlab-service/src/lib/gitlab-service.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service.ts
@@ -1,7 +1,10 @@
 import { Context, type Effect } from "effect"
 import type {
+  CiGateCatalogEntry,
+  CiGateObservation,
   MergePullRequestOptions,
   MergePullRequestResult,
+  ObserveCiGateInput,
   PrStatusCheckDiagnostic,
   PrStatusCheckDiagnosticsOptions,
   PrStatusCheckDiagnosticsRequest,
@@ -101,6 +104,22 @@ export interface GitLabServiceShape {
   readonly countOpenNonDraftPullRequests: (
     repository: GitLabRepository,
   ) => Effect.Effect<number, GitLabServiceError>
+  /**
+   * Live catalog of the synthesized GitLab Project pipeline as a CI Gate
+   * Definition. Empty when project CI is disabled or unavailable.
+   */
+  readonly listCiGateCatalog: (
+    repository: GitLabRepository,
+  ) => Effect.Effect<readonly CiGateCatalogEntry[], GitLabServiceError>
+  /**
+   * Observe the selected Project pipeline on the Repository's current default
+   * branch. Merge-request and child pipelines are omitted. Provider order is
+   * GitLab's pipeline id descending.
+   */
+  readonly observeCiGate: (
+    repository: GitLabRepository,
+    input: ObserveCiGateInput,
+  ) => Effect.Effect<CiGateObservation, GitLabServiceError>
   /**
    * Observe the open MR's head pipeline at job granularity as PR Status Checks.
    * Each job is one check; `allow_failure` failures and manual/canceled/skipped

--- a/packages/gitlab-service/src/lib/types.ts
+++ b/packages/gitlab-service/src/lib/types.ts
@@ -1,5 +1,11 @@
 import type { ReadyLabeledIssue } from "@ready-for-agent/github-service"
 
+/**
+ * Forge-neutral CI Gate kind for the synthesized GitLab Project pipeline.
+ * Identity is the numeric project id, not a pipeline name or job id.
+ */
+export const GITLAB_CI_GATE_KIND = "project-pipeline"
+
 export interface GitLabRepository {
   readonly forge: string
   readonly forgeHost: string

--- a/packages/gitlab-service/test/ci-gate-catalog.spec.ts
+++ b/packages/gitlab-service/test/ci-gate-catalog.spec.ts
@@ -1,0 +1,159 @@
+import { Effect } from "effect"
+import { formatUserFacingError } from "@ready-for-agent/github-service"
+import {
+  GITLAB_CI_GATE_KIND,
+  GitLabRequestError,
+  makeGitLabServiceFromToken,
+} from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const repository = {
+  forge: "gitlab",
+  forgeHost: "git.drupalcode.org",
+  projectPath: "project/oauth_client",
+}
+
+const projectPayload = (input: {
+  readonly id?: number
+  readonly ciConfigPath?: string | null
+  readonly buildsAccessLevel?: string
+  readonly jobsEnabled?: boolean
+}) => ({
+  id: input.id ?? 42,
+  path_with_namespace: "project/oauth_client",
+  default_branch: "main",
+  web_url: "https://git.drupalcode.org/project/oauth_client",
+  ci_config_path: input.ciConfigPath,
+  builds_access_level: input.buildsAccessLevel ?? "enabled",
+  jobs_enabled: input.jobsEnabled ?? true,
+})
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : status === 403 ? "Forbidden" : "Error",
+    headers: { "content-type": "application/json" },
+  })
+
+const isProjectUrl = (url: URL) =>
+  url.pathname === "/api/v4/projects/project%2Foauth_client"
+
+describe("GitLab CI Gate catalog", () => {
+  test("returns exactly one synthesized Project pipeline when project CI is available", async () => {
+    const requested: string[] = []
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      requested.push(`${url.pathname}${url.search}`)
+      if (!isProjectUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      return jsonResponse(
+        projectPayload({ ciConfigPath: null, buildsAccessLevel: "private" }),
+      )
+    }) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([
+      {
+        identity: "42",
+        displayLabel: "Project pipeline",
+        kind: GITLAB_CI_GATE_KIND,
+        diagnosticMetadata: ".gitlab-ci.yml",
+      },
+    ])
+    expect(requested.every((path) => !path.includes("/pipelines"))).toBe(true)
+    expect(requested.every((path) => !path.includes("/jobs"))).toBe(true)
+  })
+
+  test("uses the last-known custom CI configuration path as display metadata", async () => {
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (!isProjectUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      return jsonResponse(
+        projectPayload({
+          ciConfigPath: "ci/custom.yml@group/ci-templates",
+        }),
+      )
+    }) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([
+      {
+        identity: "42",
+        displayLabel: "Project pipeline",
+        kind: GITLAB_CI_GATE_KIND,
+        diagnosticMetadata: "ci/custom.yml@group/ci-templates",
+      },
+    ])
+  })
+
+  test("omits the synthesized definition when project CI is disabled", async () => {
+    const service = makeGitLabServiceFromToken("token", (async () =>
+      jsonResponse(
+        projectPayload({ buildsAccessLevel: "disabled" }),
+      )) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([])
+  })
+
+  test("fails when project CI is available but GitLab omits a project id", async () => {
+    const service = makeGitLabServiceFromToken("token", (async () =>
+      jsonResponse({
+        path_with_namespace: "project/oauth_client",
+        default_branch: "main",
+        web_url: "https://git.drupalcode.org/project/oauth_client",
+        builds_access_level: "enabled",
+        jobs_enabled: true,
+      })) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service.listCiGateCatalog(repository).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitLabRequestError)
+    expect(error.message).toContain("no project id")
+  })
+
+  test("omits the synthesized definition when jobs are disabled", async () => {
+    const service = makeGitLabServiceFromToken("token", (async () =>
+      jsonResponse(
+        projectPayload({ jobsEnabled: false, buildsAccessLevel: "enabled" }),
+      )) as typeof fetch)
+
+    const catalog = await Effect.runPromise(
+      service.listCiGateCatalog(repository),
+    )
+
+    expect(catalog).toEqual([])
+  })
+
+  test("maps a permission 403 to an actionable catalog error without GitLab body text", async () => {
+    const service = makeGitLabServiceFromToken("token", (async () =>
+      jsonResponse(
+        { message: "403 Forbidden — insufficient_scope" },
+        403,
+      )) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service.listCiGateCatalog(repository).pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitLabRequestError)
+    expect(error.statusCode).toBe(403)
+    expect(error.message).toContain("API/pipeline read required")
+    expect(error.message).not.toContain("insufficient_scope")
+    expect(formatUserFacingError(error)).not.toContain("insufficient_scope")
+  })
+})

--- a/packages/gitlab-service/test/ci-gate-observation.spec.ts
+++ b/packages/gitlab-service/test/ci-gate-observation.spec.ts
@@ -1,0 +1,440 @@
+import { Effect } from "effect"
+import { formatUserFacingError } from "@ready-for-agent/github-service"
+import { GitLabRequestError, makeGitLabServiceFromToken } from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const repository = {
+  forge: "gitlab",
+  forgeHost: "git.drupalcode.org",
+  projectPath: "project/oauth_client",
+}
+
+const projectPayload = {
+  id: 42,
+  path_with_namespace: "project/oauth_client",
+  default_branch: "main",
+  web_url: "https://git.drupalcode.org/project/oauth_client",
+  ci_config_path: ".gitlab-ci.yml",
+  builds_access_level: "enabled",
+  jobs_enabled: true,
+}
+
+const pipelinePayload = (input: {
+  readonly id: number
+  readonly iid?: number
+  readonly source: string
+  readonly status: string
+  readonly ref?: string
+  readonly sha?: string
+  readonly name?: string
+  readonly createdAt?: string
+  readonly updatedAt?: string
+  readonly startedAt?: string
+  readonly webUrl?: string
+}) => ({
+  id: input.id,
+  iid: input.iid ?? input.id,
+  project_id: 42,
+  status: input.status,
+  source: input.source,
+  ref: input.ref ?? "main",
+  sha: input.sha ?? `sha-${String(input.id)}`,
+  name: input.name ?? "Build pipeline",
+  web_url:
+    input.webUrl ??
+    `https://git.drupalcode.org/project/oauth_client/-/pipelines/${String(input.id)}`,
+  created_at: input.createdAt ?? "2026-09-07T10:00:00.085Z",
+  updated_at: input.updatedAt ?? "2026-09-07T10:05:00.169Z",
+  started_at: input.startedAt ?? "2026-09-07T10:00:01.000Z",
+})
+
+const jsonResponse = (
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText: status === 200 ? "OK" : status === 403 ? "Forbidden" : "Error",
+    headers: { "content-type": "application/json", ...headers },
+  })
+
+const isProjectUrl = (url: URL) =>
+  url.pathname === "/api/v4/projects/project%2Foauth_client"
+
+const isPipelinesUrl = (url: URL) =>
+  url.pathname === "/api/v4/projects/project%2Foauth_client/pipelines"
+
+describe("GitLab CI Gate observation", () => {
+  test("returns default-branch push, schedule, web, trigger, and api pipelines in provider order", async () => {
+    const requested: string[] = []
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      requested.push(url.pathname)
+      if (isProjectUrl(url)) {
+        return jsonResponse(projectPayload)
+      }
+      if (!isPipelinesUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      expect(url.searchParams.get("ref")).toBe("main")
+      expect(url.searchParams.get("order_by")).toBe("id")
+      expect(url.searchParams.get("sort")).toBe("desc")
+      expect(url.searchParams.get("source")).not.toBe("parent_pipeline")
+      return jsonResponse([
+        pipelinePayload({
+          id: 600,
+          iid: 60,
+          source: "web",
+          status: "success",
+          createdAt: "2026-09-07T12:00:00.000Z",
+        }),
+        pipelinePayload({
+          id: 500,
+          iid: 50,
+          source: "api",
+          status: "running",
+          createdAt: "2026-09-07T11:30:00.000Z",
+        }),
+        pipelinePayload({
+          id: 400,
+          iid: 40,
+          source: "trigger",
+          status: "failed",
+          createdAt: "2026-09-07T11:00:00.000Z",
+        }),
+        pipelinePayload({
+          id: 350,
+          iid: 35,
+          source: "schedule",
+          status: "success",
+          createdAt: "2026-09-07T10:45:00.000Z",
+        }),
+        pipelinePayload({
+          id: 300,
+          iid: 30,
+          source: "merge_request_event",
+          status: "failed",
+          createdAt: "2026-09-07T10:40:00.000Z",
+        }),
+        pipelinePayload({
+          id: 250,
+          iid: 25,
+          source: "push",
+          status: "failed",
+          ref: "feature",
+          createdAt: "2026-09-07T10:30:00.000Z",
+        }),
+        pipelinePayload({
+          id: 200,
+          iid: 20,
+          source: "parent_pipeline",
+          status: "failed",
+          createdAt: "2026-09-07T10:20:00.000Z",
+        }),
+        pipelinePayload({
+          id: 100,
+          iid: 10,
+          source: "push",
+          status: "failed",
+          createdAt: "2026-09-07T10:00:00.000Z",
+        }),
+      ])
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["42"],
+        lastRunIdentities: {},
+      }),
+    )
+
+    expect(observation.defaultBranch).toBe("main")
+    expect(observation.observations).toHaveLength(1)
+    const definition = observation.observations[0]
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(definition.identity).toBe("42")
+    expect(definition.runs.map((run) => run.runIdentity)).toEqual([
+      "600:60",
+      "500:50",
+      "400:40",
+      "350:35",
+      "100:10",
+    ])
+    expect(definition.runs[0]).toEqual({
+      runIdentity: "600:60",
+      htmlUrl:
+        "https://git.drupalcode.org/project/oauth_client/-/pipelines/600",
+      headSha: "sha-600",
+      headRef: "main",
+      event: "web",
+      createdAt: new Date("2026-09-07T12:00:00.000Z"),
+      updatedAt: new Date("2026-09-07T10:05:00.169Z"),
+      startedAt: new Date("2026-09-07T10:00:01.000Z"),
+      rawStatus: "success",
+      rawConclusion: null,
+    })
+    expect(definition.runs[1]?.rawStatus).toBe("running")
+    expect(definition.runs[2]?.rawStatus).toBe("failed")
+    expect(definition.runs[2]?.event).toBe("trigger")
+    expect(requested.some((path) => path.includes("/jobs"))).toBe(false)
+    expect(requested.some((path) => path.includes("/bridges"))).toBe(false)
+  })
+
+  test("includes every relevant pipeline across paginated official API pages", async () => {
+    const pageOne = Array.from({ length: 100 }, (_, index) =>
+      pipelinePayload({
+        id: 1000 - index,
+        iid: 1000 - index,
+        source: "push",
+        status: "success",
+        createdAt: `2026-09-07T${String(10 + Math.floor(index / 60)).padStart(2, "0")}:${String(index % 60).padStart(2, "0")}:00.000Z`,
+      }),
+    )
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isProjectUrl(url)) {
+        return jsonResponse(projectPayload)
+      }
+      if (!isPipelinesUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      const page = url.searchParams.get("page") ?? "1"
+      if (page === "1") {
+        return jsonResponse(pageOne, 200, { "x-next-page": "2" })
+      }
+      if (page === "2") {
+        return jsonResponse([
+          pipelinePayload({
+            id: 1,
+            iid: 1,
+            source: "push",
+            status: "failed",
+            createdAt: "2026-09-06T09:00:00.000Z",
+          }),
+        ])
+      }
+      return jsonResponse([])
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["42"],
+        lastRunIdentities: {},
+      }),
+    )
+    const definition = observation.observations[0]
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(definition.runs).toHaveLength(101)
+    expect(definition.runs[0]?.runIdentity).toBe("1000:1000")
+    expect(definition.runs[100]?.runIdentity).toBe("1:1")
+    expect(definition.runs[100]?.rawStatus).toBe("failed")
+  })
+
+  test("stops paging once the last-seen pipeline identity is included", async () => {
+    const requestedPages: string[] = []
+    const pageOne = Array.from({ length: 100 }, (_, index) =>
+      pipelinePayload({
+        id: 2000 - index,
+        iid: 2000 - index,
+        source: "push",
+        status: "success",
+      }),
+    )
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isProjectUrl(url)) {
+        return jsonResponse(projectPayload)
+      }
+      if (!isPipelinesUrl(url)) {
+        return new Response("not found", { status: 404 })
+      }
+      const page = url.searchParams.get("page") ?? "1"
+      requestedPages.push(page)
+      if (page === "1") {
+        return jsonResponse(pageOne, 200, { "x-next-page": "2" })
+      }
+      throw new Error(`unexpected extra page ${page}`)
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["42"],
+        lastRunIdentities: { "42": "1950:1950" },
+      }),
+    )
+    const definition = observation.observations[0]
+    expect(requestedPages).toEqual(["1"])
+    expect(definition?.kind).toBe("observed")
+    if (definition?.kind !== "observed") {
+      throw new Error("expected observed definition")
+    }
+    expect(definition.runs[0]?.runIdentity).toBe("2000:2000")
+    expect(definition.runs.at(-1)?.runIdentity).toBe("1950:1950")
+    expect(definition.runs).toHaveLength(51)
+  })
+
+  test("marks disabled project CI unavailable without listing pipeline history", async () => {
+    const requested: string[] = []
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      requested.push(url.pathname)
+      if (isProjectUrl(url)) {
+        return jsonResponse({
+          ...projectPayload,
+          builds_access_level: "disabled",
+        })
+      }
+      throw new Error(`unexpected request ${url.pathname}`)
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["42"],
+        lastRunIdentities: {},
+      }),
+    )
+
+    expect(observation.observations).toEqual([
+      {
+        identity: "42",
+        kind: "unavailable",
+        reason: "not_found",
+        message: expect.stringContaining("disabled"),
+      },
+    ])
+    expect(requested.some((path) => path.includes("/pipelines"))).toBe(false)
+  })
+
+  test("fails when project CI is available but GitLab omits a project id", async () => {
+    const requested: string[] = []
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      requested.push(url.pathname)
+      if (isProjectUrl(url)) {
+        const { id: _id, ...withoutId } = projectPayload
+        return jsonResponse(withoutId)
+      }
+      throw new Error(`unexpected request ${url.pathname}`)
+    }) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service
+        .observeCiGate(repository, {
+          definitionIdentities: ["42"],
+          lastRunIdentities: {},
+        })
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitLabRequestError)
+    expect(error.message).toContain("no project id")
+    expect(requested.some((path) => path.includes("/pipelines"))).toBe(false)
+  })
+
+  test("marks a stale identity unavailable and still observes the live Project pipeline", async () => {
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isProjectUrl(url)) {
+        return jsonResponse(projectPayload)
+      }
+      if (isPipelinesUrl(url)) {
+        return jsonResponse([
+          pipelinePayload({
+            id: 47,
+            iid: 12,
+            source: "push",
+            status: "success",
+          }),
+        ])
+      }
+      return new Response("not found", { status: 404 })
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["42", "999"],
+        lastRunIdentities: {},
+      }),
+    )
+
+    expect(observation.observations).toEqual([
+      expect.objectContaining({
+        identity: "42",
+        kind: "observed",
+      }),
+      {
+        identity: "999",
+        kind: "unavailable",
+        reason: "not_found",
+        message: expect.stringContaining("could not be observed"),
+      },
+    ])
+    const live = observation.observations[0]
+    expect(live?.kind).toBe("observed")
+    if (live?.kind === "observed") {
+      expect(live.runs[0]?.runIdentity).toBe("47:12")
+      expect(live.runs[0]?.htmlUrl).toBe(
+        "https://git.drupalcode.org/project/oauth_client/-/pipelines/47",
+      )
+    }
+  })
+
+  test("treats deleted pipeline history as an empty observation rather than a failure", async () => {
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isProjectUrl(url)) {
+        return jsonResponse(projectPayload)
+      }
+      if (isPipelinesUrl(url)) {
+        return jsonResponse([])
+      }
+      return new Response("not found", { status: 404 })
+    }) as typeof fetch)
+
+    const observation = await Effect.runPromise(
+      service.observeCiGate(repository, {
+        definitionIdentities: ["42"],
+        lastRunIdentities: {},
+      }),
+    )
+
+    expect(observation.observations).toEqual([
+      { identity: "42", kind: "observed", runs: [] },
+    ])
+  })
+
+  test("maps a permission 403 to an actionable observation error without GitLab body text", async () => {
+    const service = makeGitLabServiceFromToken("token", (async (input) => {
+      const url = new URL(String(input))
+      if (isProjectUrl(url)) {
+        return jsonResponse(projectPayload)
+      }
+      return jsonResponse(
+        { message: "403 Forbidden — read_api is required" },
+        403,
+      )
+    }) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service
+        .observeCiGate(repository, {
+          definitionIdentities: ["42"],
+          lastRunIdentities: {},
+        })
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitLabRequestError)
+    expect(error.statusCode).toBe(403)
+    expect(error.message).toContain("API/pipeline read required")
+    expect(error.message).not.toContain("read_api is required")
+    expect(formatUserFacingError(error)).not.toContain("read_api is required")
+  })
+})

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -468,14 +468,15 @@ const loadCiGateCatalog = Effect.fn("graphql-api.loadCiGateCatalog")(
     readonly forgeHost: string
     readonly projectPath: string
   }) {
-    if (repository.forge === "azure-devops") {
-      const azureDevOps = yield* AzureDevOpsService
-      return yield* azureDevOps
-        .listCiGateCatalog({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-        })
+    const identity = {
+      forge: repository.forge,
+      forgeHost: repository.forgeHost,
+      projectPath: repository.projectPath,
+    }
+    if (repository.forge === "github") {
+      const github = yield* GitHubService
+      return yield* github
+        .listCiGateCatalog(identity, { origin: "operator" })
         .pipe(
           Effect.map((definitions) => ({
             kind: "loaded" as const,
@@ -489,20 +490,9 @@ const loadCiGateCatalog = Effect.fn("graphql-api.loadCiGateCatalog")(
           ),
         )
     }
-    if (repository.forge !== "github") {
-      return { kind: "loaded" as const, definitions: [] }
-    }
-    const github = yield* GitHubService
-    return yield* github
-      .listCiGateCatalog(
-        {
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-        },
-        { origin: "operator" },
-      )
-      .pipe(
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      return yield* gitlab.listCiGateCatalog(identity).pipe(
         Effect.map((definitions) => ({
           kind: "loaded" as const,
           definitions,
@@ -514,6 +504,23 @@ const loadCiGateCatalog = Effect.fn("graphql-api.loadCiGateCatalog")(
           }),
         ),
       )
+    }
+    if (repository.forge === "azure-devops") {
+      const azureDevOps = yield* AzureDevOpsService
+      return yield* azureDevOps.listCiGateCatalog(identity).pipe(
+        Effect.map((definitions) => ({
+          kind: "loaded" as const,
+          definitions,
+        })),
+        Effect.catch((error) =>
+          Effect.succeed({
+            kind: "unavailable" as const,
+            message: ciGateCatalogErrorMessage(error),
+          }),
+        ),
+      )
+    }
+    return { kind: "loaded" as const, definitions: [] }
   },
 )
 

--- a/packages/graphql-api/src/lib/observe-repository-ci-gate.ts
+++ b/packages/graphql-api/src/lib/observe-repository-ci-gate.ts
@@ -19,6 +19,7 @@ import {
   type ObserveCiGateInput,
   formatUserFacingError,
 } from "@ready-for-agent/github-service"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 
 export type RepositoryCiGateStatus = "disabled" | "open" | "closed" | "degraded"
 
@@ -27,7 +28,7 @@ const FAILURE_CONCLUSIONS = new Set([
   "timed_out",
   "action_required",
   "failed",
-  "partiallySucceeded",
+  "partiallysucceeded",
 ])
 
 const SUCCESS_CONCLUSIONS = new Set(["success", "succeeded"])
@@ -51,25 +52,42 @@ const isPermissionError = (error: unknown): boolean => {
   return (
     typeof record.message === "string" &&
     (record.message.includes("Actions read required") ||
+      record.message.includes("API/pipeline read required") ||
       record.message.includes("Build read required"))
   )
 }
 
+const NON_DECISIVE_STATUSES = new Set([
+  "canceled",
+  "cancelled",
+  "skipped",
+  "manual",
+])
+
 const classifyRun = (
   run: CiGateObservedRun,
 ): "failure" | "success" | "pending" | "non_decisive" => {
-  const status = run.rawStatus
-  if (status !== "completed") {
-    return "pending"
+  const status = (run.rawStatus ?? "").trim().toLowerCase()
+  const conclusion = (run.rawConclusion ?? "").trim().toLowerCase()
+  if (status === "completed") {
+    if (conclusion !== "" && FAILURE_CONCLUSIONS.has(conclusion)) {
+      return "failure"
+    }
+    if (conclusion !== "" && SUCCESS_CONCLUSIONS.has(conclusion)) {
+      return "success"
+    }
+    return "non_decisive"
   }
-  const conclusion = run.rawConclusion
-  if (conclusion !== null && FAILURE_CONCLUSIONS.has(conclusion)) {
+  if (status === "failed" || status === "failure") {
     return "failure"
   }
-  if (conclusion !== null && SUCCESS_CONCLUSIONS.has(conclusion)) {
+  if (status === "success" || SUCCESS_CONCLUSIONS.has(conclusion)) {
     return "success"
   }
-  return "non_decisive"
+  if (NON_DECISIVE_STATUSES.has(status)) {
+    return "non_decisive"
+  }
+  return "pending"
 }
 
 const runIdFromIdentity = (runIdentity: string): string => {
@@ -351,6 +369,7 @@ export const observeRepositoryCiGate = Effect.fn("observeRepositoryCiGate")(
 
     if (
       input.repository.forge !== "github" &&
+      input.repository.forge !== "gitlab" &&
       input.repository.forge !== "azure-devops"
     ) {
       const observations = definitions.map((definition) =>
@@ -401,6 +420,11 @@ export const observeRepositoryCiGate = Effect.fn("observeRepositoryCiGate")(
     if (input.repository.forge === "azure-devops") {
       const azureDevOps = yield* AzureDevOpsService
       adapterResult = yield* azureDevOps
+        .observeCiGate(forgeRepository, observationInput)
+        .pipe(Effect.result)
+    } else if (input.repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      adapterResult = yield* gitlab
         .observeCiGate(forgeRepository, observationInput)
         .pipe(Effect.result)
     } else {

--- a/packages/graphql-api/test/ci-gate-gitlab.test.ts
+++ b/packages/graphql-api/test/ci-gate-gitlab.test.ts
@@ -10,12 +10,16 @@ import { AzureDevOpsService } from "@ready-for-agent/azure-devops-service"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import {
+  type CiGateCatalogEntry,
   type CiGateObservation,
-  GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
-import { GitLabService } from "@ready-for-agent/gitlab-service"
+import {
+  GitLabRequestError,
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { DirectoryPicker, LocalGit } from "@ready-for-agent/local-git"
 import { QueueService, makeJobId } from "@ready-for-agent/queue-service"
@@ -26,25 +30,18 @@ import { afterEach, describe, expect, test } from "bun:test"
 
 const unused = () => Effect.die("not used")
 
-const catalog = [
+const catalog: CiGateCatalogEntry[] = [
   {
-    identity: "161335",
-    displayLabel: "CI",
-    kind: "workflow",
-    diagnosticMetadata: ".github/workflows/ci.yml",
+    identity: "42",
+    displayLabel: "Project pipeline",
+    kind: "project-pipeline",
+    diagnosticMetadata: ".gitlab-ci.yml",
   },
-  {
-    identity: "269289",
-    displayLabel: "Nightly",
-    kind: "workflow",
-    diagnosticMetadata: ".github/workflows/nightly.yml",
-  },
-] as const
+]
 
 const observedRun = (input: {
   readonly runIdentity: string
   readonly rawStatus: string
-  readonly rawConclusion: string | null
   readonly event?: string
   readonly createdAt?: string
 }): CiGateObservation["observations"][number] extends infer Observation
@@ -53,7 +50,7 @@ const observedRun = (input: {
     : never
   : never => ({
   runIdentity: input.runIdentity,
-  htmlUrl: `https://github.com/acme/widgets/actions/runs/${input.runIdentity.split(":")[0] ?? input.runIdentity}`,
+  htmlUrl: `https://git.drupalcode.org/project/oauth_client/-/pipelines/${input.runIdentity.split(":")[0] ?? input.runIdentity}`,
   headSha: `sha-${input.runIdentity}`,
   headRef: "main",
   event: input.event ?? "push",
@@ -61,7 +58,7 @@ const observedRun = (input: {
   updatedAt: new Date("2026-09-07T12:05:00.000Z"),
   startedAt: new Date("2026-09-07T12:00:01.000Z"),
   rawStatus: input.rawStatus,
-  rawConclusion: input.rawConclusion,
+  rawConclusion: null,
 })
 
 const observedDefinition = (
@@ -98,7 +95,7 @@ const settingsInput = (
   selectedCiGateDefinitionIdentities: [...identities],
 })
 
-const ciGateQuery = (repositoryId: string) => ({
+const ciGateQuery = {
   query: `query {
     repositories {
       id
@@ -137,8 +134,7 @@ const ciGateQuery = (repositoryId: string) => ({
       }
     }
   }`,
-  variables: { repositoryId },
-})
+}
 
 const graphqlRequest = (body: unknown) =>
   new Request("http://127.0.0.1:6056/graphql", {
@@ -147,11 +143,11 @@ const graphqlRequest = (body: unknown) =>
     body: JSON.stringify(body),
   })
 
-describe("Repository CI Gate observation", () => {
-  let observe: GitHubServiceShape["observeCiGate"] = () =>
+describe("GitLab Repository CI Gate", () => {
+  let observe: GitLabServiceShape["observeCiGate"] = () =>
     Effect.succeed({ defaultBranch: "main", observations: [] })
-  let listReadyIssues: GitHubServiceShape["listReadyIssues"] = () =>
-    Effect.succeed([])
+  let pullRequestCheckStatusCalls = 0
+  let githubObserveCalls = 0
 
   const githubLayer = Layer.succeed(GitHubService, {
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
@@ -187,11 +183,12 @@ describe("Repository CI Gate observation", () => {
         "https://github.com/user-attachments/assets/00000000-0000-0000-0000-000000000001",
       ),
     ensureIssueCompletedWithSummary: () => Effect.void,
-    listCiGateCatalog: () => Effect.succeed([...catalog]),
-    observeCiGate: (repository, input, options) =>
-      observe(repository, input, options),
-    listReadyIssues: (repository, options) =>
-      listReadyIssues(repository, options),
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () => {
+      githubObserveCalls += 1
+      return Effect.die("GitHub CI Gate must not observe a GitLab Repository")
+    },
+    listReadyIssues: () => Effect.succeed([]),
   } satisfies GitHubServiceShape)
 
   const runtimeLayer = Layer.mergeAll(
@@ -208,7 +205,27 @@ describe("Repository CI Gate observation", () => {
       createDraftPullRequest: () => Effect.succeed(1),
       updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
       countOpenNonDraftPullRequests: () => Effect.succeed(0),
-      getPullRequestCheckStatus: unused,
+      listCiGateCatalog: () => Effect.succeed([...catalog]),
+      observeCiGate: (repository, input) => observe(repository, input),
+      getPullRequestCheckStatus: () => {
+        pullRequestCheckStatusCalls += 1
+        return Effect.succeed({
+          _tag: "succeeded" as const,
+          terminalChecks: [
+            {
+              externalId: "gitlab-job:1",
+              name: "test",
+              outcome: "green" as const,
+            },
+          ],
+          mergeability: "mergeable" as const,
+          baseRefName: "main",
+          headPushedAt: null,
+          headSha: null,
+          createdAt: null,
+          isDraft: null,
+        })
+      },
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       markPullRequestReadyForReview: () => Effect.void,
       getPullRequestLifecycleStatus: () =>
@@ -217,9 +234,6 @@ describe("Repository CI Gate observation", () => {
       ensureIssueCompletedWithSummary: () => Effect.void,
       closeOpenPullRequestsForBranch: () => Effect.void,
       deleteBranch: () => Effect.void,
-      listCiGateCatalog: () => Effect.succeed([]),
-      observeCiGate: () =>
-        Effect.succeed({ defaultBranch: "main", observations: [] }),
     }),
     Layer.succeed(AzureDevOpsService, {
       verifyProject: (repository) => Effect.succeed(repository),
@@ -351,9 +365,9 @@ describe("Repository CI Gate observation", () => {
     Layer.succeed(LocalGit, {
       inspect: (path) =>
         Effect.succeed({
-          forge: "github",
-          forgeHost: "github.com",
-          projectPath: "acme/widgets",
+          forge: "gitlab",
+          forgeHost: "git.drupalcode.org",
+          projectPath: "project/oauth_client",
           localPath: path,
           isBare: true,
           paused: true as const,
@@ -370,7 +384,8 @@ describe("Repository CI Gate observation", () => {
   afterEach(async () => {
     await runtime.dispose()
     observe = () => Effect.succeed({ defaultBranch: "main", observations: [] })
-    listReadyIssues = () => Effect.succeed([])
+    pullRequestCheckStatusCalls = 0
+    githubObserveCalls = 0
     runtime = ManagedRuntime.make(runtimeLayer)
   })
 
@@ -379,10 +394,10 @@ describe("Repository CI Gate observation", () => {
       Effect.gen(function* () {
         const db = yield* DbService
         return yield* db.addRepository({
-          forge: "github",
-          forgeHost: "github.com",
-          projectPath: "acme/widgets",
-          localPath: `/repos/acme/widgets-${String(Date.now())}.git`,
+          forge: "gitlab",
+          forgeHost: "git.drupalcode.org",
+          projectPath: "project/oauth_client",
+          localPath: `/repos/project/oauth_client-${String(Date.now())}.git`,
           isBare: true,
         })
       }),
@@ -390,7 +405,7 @@ describe("Repository CI Gate observation", () => {
 
   const fetchCiGate = async (repositoryId: string) => {
     const response = await createGraphqlApi(runtime).fetch(
-      graphqlRequest(ciGateQuery(repositoryId)),
+      graphqlRequest(ciGateQuery),
     )
     const payload = (await response.json()) as {
       data: {
@@ -399,27 +414,22 @@ describe("Repository CI Gate observation", () => {
           ciGate: {
             enabled: boolean
             status: string
-            observedAt: string | null
-            defaultBranch: string | null
             diagnostic: string | null
+            defaultBranch: string | null
             definitions: ReadonlyArray<{
               identity: string
               displayLabel: string
               failureLatched: boolean
-              diagnostic: string | null
               latestRun: {
                 runIdentity: string
                 htmlUrl: string | null
                 rawStatus: string | null
                 rawConclusion: string | null
                 event: string | null
-                headSha: string | null
-                headRef: string | null
               } | null
             }>
             activeIncident: {
               status: string
-              summary: string
               failedDefinitions: ReadonlyArray<{
                 identity: string
                 displayLabel: string
@@ -427,12 +437,7 @@ describe("Repository CI Gate observation", () => {
             } | null
             latestResolvedIncident: {
               status: string
-              summary: string
               recoveryReason: string | null
-              failedDefinitions: ReadonlyArray<{
-                identity: string
-                displayLabel: string
-              }>
             } | null
           }
         }>
@@ -456,7 +461,7 @@ describe("Repository CI Gate observation", () => {
         query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
           updateRepositorySettings(input: $input) {
             id
-            selectedCiGateDefinitions { identity }
+            selectedCiGateDefinitions { identity displayLabel kind diagnosticMetadata }
             ciGate { status enabled }
           }
         }`,
@@ -467,7 +472,12 @@ describe("Repository CI Gate observation", () => {
       data: {
         updateRepositorySettings: {
           id: string
-          selectedCiGateDefinitions: ReadonlyArray<{ identity: string }>
+          selectedCiGateDefinitions: ReadonlyArray<{
+            identity: string
+            displayLabel: string
+            kind: string
+            diagnosticMetadata: string | null
+          }>
           ciGate: { status: string; enabled: boolean }
         }
       }
@@ -493,104 +503,83 @@ describe("Repository CI Gate observation", () => {
       }),
     )
 
-  test("empty selection disables the gate and save of a successful definition is Open", async () => {
+  test("selects the synthesized Project pipeline, latches Closed on failed, and recovers on newer success", async () => {
     const repository = await addRepository()
-    expect(await fetchCiGate(repository.id)).toMatchObject({
-      enabled: false,
-      status: "DISABLED",
-      activeIncident: null,
-    })
-
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "100:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
+          observedDefinition("42", [
+            observedRun({ runIdentity: "47:12", rawStatus: "success" }),
           ]),
         ],
       })
 
-    const saved = await saveSelection(repository.id, ["161335"])
+    const saved = await saveSelection(repository.id, ["42"])
     expect(saved.errors).toBeUndefined()
+    expect(
+      saved.data.updateRepositorySettings.selectedCiGateDefinitions,
+    ).toEqual([
+      {
+        identity: "42",
+        displayLabel: "Project pipeline",
+        kind: "project-pipeline",
+        diagnosticMetadata: ".gitlab-ci.yml",
+      },
+    ])
     expect(saved.data.updateRepositorySettings.ciGate).toEqual({
       status: "OPEN",
       enabled: true,
     })
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.defaultBranch).toBe("main")
-    expect(gate.definitions[0]?.latestRun?.rawConclusion).toBe("success")
-    expect(gate.definitions[0]?.latestRun?.htmlUrl).toContain("/actions/runs/")
-    expect(gate.activeIncident).toBeNull()
-  })
 
-  test("failure latches Closed, pending does not clear it, and a newer success resolves the incident", async () => {
-    const repository = await addRepository()
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("42", [
             observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
+              runIdentity: "48:13",
+              rawStatus: "failed",
+              event: "push",
             }),
           ]),
         ],
       })
-    await saveSelection(repository.id, ["161335"])
+    await refresh(repository.id)
     let gate = await fetchCiGate(repository.id)
     expect(gate.status).toBe("CLOSED")
     expect(gate.definitions[0]?.failureLatched).toBe(true)
+    expect(gate.definitions[0]?.latestRun?.rawStatus).toBe("failed")
+    expect(gate.definitions[0]?.latestRun?.htmlUrl).toContain("/-/pipelines/48")
     expect(gate.activeIncident?.status).toBe("OPEN")
     expect(gate.activeIncident?.failedDefinitions).toEqual([
-      { identity: "161335", displayLabel: "CI" },
+      { identity: "42", displayLabel: "Project pipeline" },
     ])
 
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "201:1",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-            observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
+          observedDefinition("42", [
+            observedRun({ runIdentity: "49:14", rawStatus: "running" }),
+            observedRun({ runIdentity: "48:13", rawStatus: "failed" }),
           ]),
         ],
       })
     await refresh(repository.id)
-    gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("CLOSED")
-    expect(gate.activeIncident?.status).toBe("OPEN")
+    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
 
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
+          observedDefinition("42", [
             observedRun({
-              runIdentity: "202:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
+              runIdentity: "50:15",
+              rawStatus: "success",
+              event: "web",
             }),
-            observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
+            observedRun({ runIdentity: "48:13", rawStatus: "failed" }),
           ]),
         ],
       })
@@ -600,326 +589,86 @@ describe("Repository CI Gate observation", () => {
     expect(gate.activeIncident).toBeNull()
     expect(gate.latestResolvedIncident?.status).toBe("RESOLVED")
     expect(gate.latestResolvedIncident?.recoveryReason).toBe("NEWER_SUCCESS")
+    expect(githubObserveCalls).toBe(0)
+    expect(pullRequestCheckStatusCalls).toBe(0)
   })
 
-  test("a run first seen as pending latches Closed when that same run later fails", async () => {
+  test("canceled, skipped, manual, scheduled, pending, running, preparing, and waiting do not close an Open gate", async () => {
     const repository = await addRepository()
+    const statuses = [
+      "canceled",
+      "skipped",
+      "manual",
+      "scheduled",
+      "pending",
+      "running",
+      "preparing",
+      "waiting_for_resource",
+    ]
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "500:1",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-          ]),
+          observedDefinition(
+            "42",
+            statuses.map((status, index) =>
+              observedRun({
+                runIdentity: `${String(100 + index)}:${String(index + 1)}`,
+                rawStatus: status,
+              }),
+            ),
+          ),
         ],
       })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("OPEN")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "500:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("CLOSED")
-    expect(gate.definitions[0]?.failureLatched).toBe(true)
-    expect(gate.definitions[0]?.latestRun?.rawConclusion).toBe("failure")
-    expect(gate.activeIncident?.status).toBe("OPEN")
-  })
-
-  test("later observation tells GitHub the last-seen run identity", async () => {
-    const repository = await addRepository()
-    const seenLastRunIdentities: Array<{
-      readonly [identity: string]: string
-    }> = []
-    observe = (_repo, input) => {
-      seenLastRunIdentities.push(input.lastRunIdentities)
-      return Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "100:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    }
-    await saveSelection(repository.id, ["161335"])
-    expect(seenLastRunIdentities[0]).toEqual({})
-    await refresh(repository.id)
-    expect(seenLastRunIdentities[1]).toEqual({ "161335": "100:1" })
-  })
-
-  test("a pending rerun that later succeeds clears the failure latch", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:2",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:2",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe("NEWER_SUCCESS")
-  })
-
-  test("a pending rerun of a failed run stays Closed even when older success remains in history", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-            observedRun({
-              runIdentity: "199:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "200:2",
-              rawStatus: "in_progress",
-              rawConclusion: null,
-            }),
-            observedRun({
-              runIdentity: "199:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("CLOSED")
-    expect(gate.activeIncident?.status).toBe("OPEN")
-    expect(gate.definitions[0]?.latestRun?.runIdentity).toBe("200:2")
-  })
-
-  test("timeout and action-required conclusions latch Closed while canceled does not", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "900:1",
-              rawStatus: "completed",
-              rawConclusion: "timed_out",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "901:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("OPEN")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "902:1",
-              rawStatus: "completed",
-              rawConclusion: "action_required",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "903:1",
-              rawStatus: "completed",
-              rawConclusion: "cancelled",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["269289"])
+    await saveSelection(repository.id, ["42"])
     const gate = await fetchCiGate(repository.id)
     expect(gate.status).toBe("OPEN")
     expect(gate.definitions[0]?.failureLatched).toBe(false)
-  })
-
-  test("a failure and later success first seen together become a resolved incident without leaving Closed", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "301:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-              createdAt: "2026-09-07T13:00:00.000Z",
-            }),
-            observedRun({
-              runIdentity: "300:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-              createdAt: "2026-09-07T12:00:00.000Z",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    const gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
     expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.status).toBe("RESOLVED")
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe("NEWER_SUCCESS")
   })
 
-  test("Closed outranks a later permission error, which otherwise degrades an Open gate", async () => {
+  test("a pipeline-read permission failure degrades Open and cannot clear a Closed latch", async () => {
     const repository = await addRepository()
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "400:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
+          observedDefinition("42", [
+            observedRun({ runIdentity: "47:12", rawStatus: "success" }),
           ]),
         ],
       })
-    await saveSelection(repository.id, ["161335"])
+    await saveSelection(repository.id, ["42"])
     observe = () =>
       Effect.fail(
-        new GitHubRequestError({
+        new GitLabRequestError({
           message:
-            "Failed to observe CI Gate Definitions for acme/widgets: Actions read required",
+            "Failed to observe CI Gate Definitions for project/oauth_client: API/pipeline read required",
           statusCode: 403,
-          retryable: false,
         }),
       )
     await refresh(repository.id)
     let gate = await fetchCiGate(repository.id)
     expect(gate.status).toBe("DEGRADED")
-    expect(gate.diagnostic).toContain("Actions read required")
+    expect(gate.diagnostic).toContain("API/pipeline read required")
     expect(gate.activeIncident).toBeNull()
 
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "401:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
+          observedDefinition("42", [
+            observedRun({ runIdentity: "48:13", rawStatus: "failed" }),
           ]),
         ],
       })
     await refresh(repository.id)
     observe = () =>
       Effect.fail(
-        new GitHubRequestError({
+        new GitLabRequestError({
           message:
-            "Failed to observe CI Gate Definitions for acme/widgets: Actions read required",
+            "Failed to observe CI Gate Definitions for project/oauth_client: API/pipeline read required",
           statusCode: 403,
-          retryable: false,
         }),
       )
     await refresh(repository.id)
@@ -928,104 +677,42 @@ describe("Repository CI Gate observation", () => {
     expect(gate.activeIncident?.status).toBe("OPEN")
   })
 
-  test("removing a failed definition or clearing the selection resolves with an attributable reason", async () => {
+  test("a saved Project pipeline stays selected and Degraded when project CI becomes disabled", async () => {
     const repository = await addRepository()
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "500:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "600:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
+          observedDefinition("42", [
+            observedRun({ runIdentity: "47:12", rawStatus: "success" }),
           ]),
         ],
       })
-    await saveSelection(repository.id, ["161335", "269289"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
+    await saveSelection(repository.id, ["42"])
+    expect((await fetchCiGate(repository.id)).status).toBe("OPEN")
 
     observe = () =>
       Effect.succeed({
         defaultBranch: "main",
         observations: [
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "600:1",
-              rawStatus: "completed",
-              rawConclusion: "success",
-            }),
-          ]),
+          {
+            identity: "42",
+            kind: "unavailable",
+            reason: "not_found",
+            message: "Project CI is disabled for project/oauth_client",
+          },
         ],
-      })
-    await saveSelection(repository.id, ["269289"])
-    let gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("OPEN")
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe(
-      "DEFINITION_REMOVED",
-    )
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("269289", [
-            observedRun({
-              runIdentity: "601:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await refresh(repository.id)
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-    await saveSelection(repository.id, [])
-    gate = await fetchCiGate(repository.id)
-    expect(gate.status).toBe("DISABLED")
-    expect(gate.enabled).toBe(false)
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe("EMPTY_SELECTION")
-  })
-
-  test("a default-branch change clears old latches and starts an optimistic baseline", async () => {
-    const repository = await addRepository()
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          observedDefinition("161335", [
-            observedRun({
-              runIdentity: "700:1",
-              rawStatus: "completed",
-              rawConclusion: "failure",
-            }),
-          ]),
-        ],
-      })
-    await saveSelection(repository.id, ["161335"])
-    expect((await fetchCiGate(repository.id)).status).toBe("CLOSED")
-
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "develop",
-        observations: [observedDefinition("161335", [])],
       })
     await refresh(repository.id)
     const gate = await fetchCiGate(repository.id)
-    expect(gate.defaultBranch).toBe("develop")
-    expect(gate.status).toBe("OPEN")
+    expect(gate.status).toBe("DEGRADED")
+    expect(gate.definitions).toEqual([
+      expect.objectContaining({
+        identity: "42",
+        displayLabel: "Project pipeline",
+        failureLatched: false,
+      }),
+    ])
     expect(gate.activeIncident).toBeNull()
-    expect(gate.latestResolvedIncident?.recoveryReason).toBe(
-      "DEFAULT_BRANCH_CHANGED",
-    )
-    expect(gate.definitions[0]?.diagnostic).toBe("Not observed yet")
   })
 })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -32,6 +32,7 @@ import {
 } from "@ready-for-agent/github-service"
 import {
   GitLabProjectUnavailableError,
+  GitLabRequestError,
   GitLabService,
   type GitLabServiceShape,
 } from "@ready-for-agent/gitlab-service"
@@ -268,6 +269,9 @@ const defaultGitlab: GitLabServiceShape = {
   ensureIssueCompletedWithSummary: () => Effect.void,
   closeOpenPullRequestsForBranch: () => Effect.void,
   deleteBranch: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "main", observations: [] }),
 }
 
 const defaultAzureDevOps: AzureDevOpsServiceShape = {
@@ -13118,6 +13122,107 @@ describe("GraphQL API", () => {
     }
     expect(payload.data.ciGateCatalog.definitions).toEqual([])
     expect(payload.data.ciGateCatalog.error).toContain("Build read required")
+  })
+
+  test("ciGateCatalog returns the synthesized GitLab Project pipeline", async () => {
+    const gitlabRepository = makeRepositoryRecord({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    })
+    await runtime.dispose()
+    runtime = makeRuntime(
+      { listRepositories: Effect.succeed([gitlabRepository]) },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.succeed([
+            {
+              identity: "42",
+              displayLabel: "Project pipeline",
+              kind: "project-pipeline",
+              diagnosticMetadata: ".gitlab-ci.yml",
+            },
+          ]),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          ciGateCatalog(repositoryId: "${gitlabRepository.id}") {
+            error
+            definitions { identity displayLabel kind diagnosticMetadata }
+          }
+        }`,
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        ciGateCatalog: {
+          error: null,
+          definitions: [
+            {
+              identity: "42",
+              displayLabel: "Project pipeline",
+              kind: "project-pipeline",
+              diagnosticMetadata: ".gitlab-ci.yml",
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("ciGateCatalog returns GitLab pipeline-read guidance instead of failing the query", async () => {
+    const gitlabRepository = makeRepositoryRecord({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    })
+    await runtime.dispose()
+    runtime = makeRuntime(
+      { listRepositories: Effect.succeed([gitlabRepository]) },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        listCiGateCatalog: () =>
+          Effect.fail(
+            new GitLabRequestError({
+              message:
+                "Failed to list CI Gate Definitions for project/oauth_client: API/pipeline read required",
+              statusCode: 403,
+            }),
+          ),
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          ciGateCatalog(repositoryId: "${gitlabRepository.id}") {
+            error
+            definitions { identity }
+          }
+        }`,
+      }),
+    )
+    const payload = (await response.json()) as {
+      data: {
+        ciGateCatalog: { error: string | null; definitions: unknown[] }
+      }
+    }
+    expect(payload.data.ciGateCatalog.definitions).toEqual([])
+    expect(payload.data.ciGateCatalog.error).toContain(
+      "API/pipeline read required",
+    )
   })
 
   test("updateRepositorySettings saves catalog identities and rejects fabricated ones", async () => {

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -253,6 +253,9 @@ const defaultGitLabShape = {
   ensureIssueCompletedWithSummary: () => Effect.void,
   closeOpenPullRequestsForBranch: () => Effect.void,
   deleteBranch: () => Effect.void,
+  listCiGateCatalog: () => Effect.succeed([]),
+  observeCiGate: () =>
+    Effect.succeed({ defaultBranch: "main", observations: [] }),
 } satisfies GitLabServiceShape
 
 const defaultGitLabLayer = Layer.succeed(GitLabService, defaultGitLabShape)

--- a/packages/work-item-lifecycle/src/lib/gitlab-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/gitlab-service-test.ts
@@ -48,6 +48,9 @@ export const stubGitLabServiceLayer = (
       ensureIssueCompletedWithSummary: () => Effect.void,
       closeOpenPullRequestsForBranch: () => Effect.void,
       deleteBranch: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
+      observeCiGate: () =>
+        Effect.succeed({ defaultBranch: "main", observations: [] }),
       ...overrides,
     }),
   )

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -200,6 +200,9 @@ describe("closeIssue", () => {
         }),
       closeOpenPullRequestsForBranch: () => Effect.void,
       deleteBranch: () => Effect.void,
+      listCiGateCatalog: () => Effect.succeed([]),
+      observeCiGate: () =>
+        Effect.succeed({ defaultBranch: "main", observations: [] }),
     } satisfies GitLabServiceShape)
 
     await Effect.runPromise(

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -177,6 +177,9 @@ const stubGitLab = (
     ensureIssueCompletedWithSummary: () => Effect.void,
     closeOpenPullRequestsForBranch: () => Effect.void,
     deleteBranch: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "main", observations: [] }),
     ...overrides,
   } satisfies GitLabServiceShape)
 

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -240,6 +240,9 @@ const gitlabWith = (
     ensureIssueCompletedWithSummary: () => Effect.void,
     closeOpenPullRequestsForBranch: () => Effect.void,
     deleteBranch: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "main", observations: [] }),
     ...overrides,
   } satisfies GitLabServiceShape)
 

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -93,6 +93,9 @@ const stubGitLab = (
     ensureIssueCompletedWithSummary: () => Effect.void,
     closeOpenPullRequestsForBranch: () => Effect.void,
     deleteBranch: () => Effect.void,
+    listCiGateCatalog: () => Effect.succeed([]),
+    observeCiGate: () =>
+      Effect.succeed({ defaultBranch: "main", observations: [] }),
     ...overrides,
   } satisfies GitLabServiceShape)
 


### PR DESCRIPTION
GitLab Repositories can now opt into the same Repository CI Gate as GitHub, using one synthesized Project pipeline rather than multiple durable workflow definitions (issue #1254). When project CI is available, the catalog offers exactly that singleton. Identity is the GitLab project id; last-known CI configuration path is display metadata (default `.gitlab-ci.yml`). Pipeline execution names and job IDs are not selectors.

Observation runs after selection Save, on manual Refresh, and on the existing Repository poll, including while Paused. It uses the Repository's GitLab credential and official Pipelines API; `glab` is not required. Pipelines whose actual ref is the current default branch can latch or clear the gate when their source is push, schedule, web, trigger, or API. Merge-request validation and child pipelines are omitted rather than fetched extra. GitLab `failed` closes the gate and `success` clears the latch. Canceled, skipped, manual, scheduled, pending, running, preparing, waiting, and unavailable states do not close an otherwise Open gate. Missing pipeline-read permission Degrades with guidance and cannot clear a Closed latch. Incidents, recovery, and status stay on the generic modules. GitLab PR Status Check job aggregation is unchanged.

A saved Project pipeline that later becomes disabled stays selected and shows Degraded. A project with CI on but no project id is a request error, not an empty catalog.

Verification: GitLab adapter tests for singleton discovery, custom CI paths, pagination, last-seen stop, default-branch and merge-request filtering, disabled CI, deleted history, missing project id, and permission 403; GraphQL tests on a real database with a fake GitLab adapter for selection through Closed, non-decisive statuses, permission versus Closed, newer success recovery, and disabled saved-selection Degraded; existing GitLab PR Status Check and merge tests still pass; Keymaxxer helper wiring for observe.

Limitations: ordinary hold, CI Repair authorization, and merge-hold are later tickets; this change only plugs GitLab into the generic gate. Review deferred adapter-structure nits (duplicated catalog arms, pagination helper) with no Open/Closed impact.

Closes #1254