### PR TITLE
feat: hold ordinary remote work while the Repository CI Gate is Closed

### DIFF
--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -149,7 +149,9 @@ export function lifecycleFocusLaneFor(workItem: {
 }): LifecyclePipelineLaneId | null {
   if (
     workItem.status === "WAITING_FOR_BLOCKERS" ||
-    workItem.status === "WAITING_FOR_WORKER_SLOT"
+    workItem.status === "WAITING_FOR_WORKER_SLOT" ||
+    (workItem.status === "WAITING_FOR_CI_REPAIR" &&
+      workItem.state.toUpperCase() === "CREATE_WORKTREE")
   ) {
     return null
   }

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -135,6 +135,12 @@ describe("lifecycleFocusLaneFor", () => {
         status: "WAITING_FOR_CI_REPAIR",
       }),
     ).toBe("pr")
+    expect(
+      lifecycleFocusLaneFor({
+        state: "CREATE_WORKTREE",
+        status: "WAITING_FOR_CI_REPAIR",
+      }),
+    ).toBeNull()
   })
 
   test("falls back to the latest chip phase when state is non-operational", () => {

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -29,7 +29,7 @@ The board has six ordered lanes:
 
 | Lane | Meaning | Derived from |
 | --- | --- | --- |
-| Queue | Work cannot begin yet: waiting for blockers or a worker slot. | `WAITING_FOR_BLOCKERS`, `WAITING_FOR_WORKER_SLOT` |
+| Queue | Work cannot begin yet: waiting for blockers, a worker slot, or pre-admission CI repair. | `WAITING_FOR_BLOCKERS`, `WAITING_FOR_WORKER_SLOT`, pre-admission `WAITING_FOR_CI_REPAIR` |
 | Build | Startup and implementation work (including queued later Build steps). | `CREATE_WORKTREE`, `INSTALL_DEPENDENCIES`, `IMPLEMENT`, `ASSESS_CHANGES`, `PRE_COMMIT` |
 | Review | Local review is in progress (including a queued Review step). | `REVIEW` |
 | PR | Commit through cleanup on the pull-request path (including queued Watch and later PR steps). | `COMMIT`, `CREATE_PR`, `WATCH_PR_STATUS_CHECKS`, `RESOLVE_PR_MERGE_CONFLICT`, `INVESTIGATE_PR_STATUS_CHECKS`, `MARK_PR_READY_FOR_REVIEW`, `DECIDE_PR_MERGE`, `MERGE_PR`, `CLOSE_ISSUE`, `LOCAL_CLEANUP` |
@@ -42,8 +42,9 @@ Placement is driven by **lifecycle progress**, not scheduler status:
 - Attention and Merged take precedence over every lifecycle lane.
 - Queue is only for genuine blocked or not-admitted work. A `QUEUED` step run
   (status-check poll, agent turn, or later lifecycle step) stays in Build,
-  Review, or PR according to its state. Merge-approved Waiting for CI Repair
-  stays in PR; it is not a Queue hold.
+  Review, or PR according to its state. Pre-admission Waiting for CI Repair
+  belongs in Queue. Merge-approved Waiting for CI Repair stays in PR; it is
+  not a Queue hold.
 - Once work has entered Build, Review, or PR, queued execution of a later step
   in that path must not return it to Queue or an earlier lane.
 

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -281,8 +281,9 @@ export const workItem = snakeCase.table(
     waitingForBlockers: integer({ mode: "boolean" }).notNull().default(false),
     /**
      * Durable Waiting for CI Repair hold while the Repository CI Gate is Closed.
-     * Merge-approved work stays at Merge PR without a Worker Slot. Distinct from
-     * Waiting for blockers and Waiting for Worker Slot. Not a Lifecycle Step.
+     * Ordinary remote work waits before admission; merge-approved work stays at
+     * Merge PR without a Worker Slot. Distinct from Waiting for blockers and
+     * Waiting for Worker Slot. Not a Lifecycle Step.
      */
     waitingForCiRepair: integer({ mode: "boolean" }).notNull().default(false),
     /**

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -1576,6 +1576,8 @@ export const createGraphqlApi = <R>(
                     issue?.blockedBy.map((blocker) => blocker.issueNumber) ??
                     [],
                   failedCiGateDefinitionLabels,
+                  ciFailureIncidentSummary:
+                    snapshot?.activeIncident?.summary ?? null,
                 })
               }).pipe(Effect.withSpan("graphql-api.WorkItem.statusMessage")),
               context,

--- a/packages/graphql-api/src/lib/kanban-projection.ts
+++ b/packages/graphql-api/src/lib/kanban-projection.ts
@@ -5,7 +5,8 @@
  *
  * Lane rules match `docs/kanban.md`. Status and state comparisons are
  * case-insensitive so domain (lowercase) and GraphQL (uppercase) shapes both
- * classify correctly.
+ * classify correctly. Pre-admission Waiting for CI Repair is Queue;
+ * merge-approved Waiting for CI Repair stays in PR.
  */
 import {
   JOBS_COMPLETED_WINDOW_MS,
@@ -104,7 +105,8 @@ export function kanbanLaneFor(workItem: {
 
   if (
     status === "WAITING_FOR_BLOCKERS" ||
-    status === "WAITING_FOR_WORKER_SLOT"
+    status === "WAITING_FOR_WORKER_SLOT" ||
+    (status === "WAITING_FOR_CI_REPAIR" && state === "CREATE_WORKTREE")
   ) {
     return "QUEUE"
   }

--- a/packages/graphql-api/src/lib/repository-retry.ts
+++ b/packages/graphql-api/src/lib/repository-retry.ts
@@ -188,6 +188,7 @@ export const snapshotRetryTargets = (input: {
             state: workItem.state,
             paused: workItem.paused,
             waitingForBlockers: workItem.waitingForBlockers,
+            waitingForCiRepair: workItem.waitingForCiRepair,
             waitingSince: workItem.waitingSince,
             pullRequestNumber: workItem.pullRequestNumber,
             failureCode: workItem.failureCode,

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -281,6 +281,7 @@ export const workItemStatusMessage = (
   options?: {
     readonly blockerIssueNumbers?: readonly number[]
     readonly failedCiGateDefinitionLabels?: readonly string[]
+    readonly ciFailureIncidentSummary?: string | null
   },
 ): string | null => {
   if (workItemIsTerminal(workItem)) {
@@ -298,6 +299,7 @@ export const workItemStatusMessage = (
   if (workItem.waitingForCiRepair) {
     return formatWaitingForCiRepairMessage(
       options?.failedCiGateDefinitionLabels ?? [],
+      options?.ciFailureIncidentSummary,
     )
   }
   const postponedUntil = workItemPostponedUntil(workItem)

--- a/packages/graphql-api/test/ci-gate-admission-hold.test.ts
+++ b/packages/graphql-api/test/ci-gate-admission-hold.test.ts
@@ -1,5 +1,4 @@
-import { Effect, Layer, ManagedRuntime, Option } from "effect"
-import { SqlClient } from "effect/unstable/sql"
+import { Effect, Layer, ManagedRuntime } from "effect"
 import {
   ActiveAgentBackend,
   type AgentBackendId,
@@ -9,7 +8,11 @@ import {
 } from "@ready-for-agent/agent-backend"
 import { AzureDevOpsService } from "@ready-for-agent/azure-devops-service"
 import { DatabaseTest } from "@ready-for-agent/db/test"
-import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import {
+  DbService,
+  DbServiceLive,
+  type RepositoryRecord,
+} from "@ready-for-agent/db-service"
 import {
   type CiGateObservation,
   GitHubService,
@@ -18,12 +21,10 @@ import {
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { DirectoryPicker, LocalGit } from "@ready-for-agent/local-git"
-import { QueueService } from "@ready-for-agent/queue-service"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   LifecycleSteps,
   type LifecycleStepsShape,
-  WORK_ITEM_LIFECYCLE_QUEUE,
   WorkItemLifecycle,
   WorkItemLifecycleLive,
   stubActiveAgentBackendLayer,
@@ -66,7 +67,9 @@ const readyRuntime = (): AgentBackendRuntimeStatus => ({
   backend: { id: "opencode" as AgentBackendId, label: "OpenCode" },
   kind: "ready",
   reason: null,
-  models: [{ id: "opencode/deepseek-v4-flash-free", thinkingLevels: ["high"] }],
+  models: [
+    { id: "opencode/deepseek-v4-flash-free", thinkingLevels: ["low", "high"] },
+  ],
   provider: null,
   warnings: [],
 })
@@ -122,18 +125,9 @@ const graphqlRequest = (body: unknown) =>
     body: JSON.stringify(body),
   })
 
-describe("Hold approved merges during CI failure", () => {
+describe("Hold ordinary remote admission during CI failure", () => {
   let observe: GitHubServiceShape["observeCiGate"] = () =>
     Effect.succeed({ defaultBranch: "main", observations: [] })
-  let mergeCalls = 0
-  const steps: LifecycleStepsShape = {
-    ...successfulSteps,
-    mergePr: () =>
-      Effect.sync(() => {
-        mergeCalls += 1
-        return { _tag: "merged" as const }
-      }),
-  }
 
   const githubLayer = Layer.succeed(GitHubService, {
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
@@ -177,7 +171,16 @@ describe("Hold approved merges during CI failure", () => {
 
   const runtimeLayer = Layer.mergeAll(
     WorkItemLifecycleLive.pipe(
-      Layer.provideMerge(stubActiveAgentBackendLayer()),
+      Layer.provideMerge(
+        stubActiveAgentBackendLayer({
+          models: [
+            {
+              id: "opencode/deepseek-v4-flash-free",
+              thinkingLevels: ["low", "high"],
+            },
+          ],
+        }),
+      ),
       Layer.provideMerge(githubLayer),
       Layer.provideMerge(
         Layer.succeed(GitLabService, {
@@ -227,7 +230,7 @@ describe("Hold approved merges during CI failure", () => {
         }),
       ),
       Layer.provideMerge(
-        Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
+        Layer.succeed(LifecycleSteps, LifecycleSteps.of(successfulSteps)),
       ),
       Layer.provideMerge(DbServiceLive),
       Layer.provideMerge(SqliteQueueServiceLive),
@@ -302,33 +305,38 @@ describe("Hold approved merges during CI failure", () => {
   afterEach(async () => {
     await runtime.dispose()
     observe = () => Effect.succeed({ defaultBranch: "main", observations: [] })
-    mergeCalls = 0
     runtime = ManagedRuntime.make(runtimeLayer)
   })
 
-  const workItemQuery = (repositoryId: string) => ({
-    query: `query WorkItems($repositoryId: ID!) {
-      workItems(repositoryId: $repositoryId) {
-        id
-        state
-        status
-        statusLabel
-        statusMessage
-      }
-      kanbanStatus(repositoryId: $repositoryId) {
-        lanes {
-          id
-          workItems {
-            workItem { id status statusLabel statusMessage }
-          }
-        }
-      }
-    }`,
-    variables: { repositoryId },
-  })
+  const closeGate = (repository: RepositoryRecord) => {
+    observe = () =>
+      Effect.succeed({
+        defaultBranch: "main",
+        observations: [
+          {
+            identity: "161335",
+            kind: "observed" as const,
+            runs: [
+              observedRun({
+                runIdentity: "100:1",
+                rawConclusion: "failure",
+              }),
+            ],
+          },
+        ],
+      })
+    return runtime.runPromise(
+      Effect.gen(function* () {
+        yield* observeRepositoryCiGate({
+          repository,
+          origin: "operator",
+        })
+      }),
+    )
+  }
 
-  test("holds a merge-approved Work Item in the PR lane until CI recovers, then merges", async () => {
-    const setup = await runtime.runPromise(
+  const seedRepository = (issueNumber: number) =>
+    runtime.runPromise(
       Effect.gen(function* () {
         const db = yield* DbService
         const config = yield* db.getConfig
@@ -362,10 +370,10 @@ describe("Hold approved merges during CI failure", () => {
         })
         const issue = yield* db.storeIssue({
           repositoryId: repository.id,
-          issueNumber: 42,
+          issueNumber,
           title: "Implement feature",
           body: "Issue body",
-          url: "https://github.com/acme/widgets/issues/42",
+          url: `https://github.com/acme/widgets/issues/${issueNumber}`,
           state: "OPEN",
           githubCreatedAt: new Date("2026-01-15T12:00:00.000Z"),
           issueAuthor: null,
@@ -378,68 +386,51 @@ describe("Hold approved merges during CI failure", () => {
       }),
     )
 
-    const workItemId = await runtime.runPromise(
+  const workItemQuery = (repositoryId: string) => ({
+    query: `query WorkItems($repositoryId: ID!) {
+      workItems(repositoryId: $repositoryId) {
+        id
+        state
+        status
+        statusLabel
+        statusMessage
+        canRetry
+        executionProfile { buildModel }
+        mergePolicy
+      }
+      kanbanStatus(repositoryId: $repositoryId) {
+        lanes {
+          id
+          workItems {
+            workItem { id status statusLabel statusMessage }
+          }
+        }
+      }
+    }`,
+    variables: { repositoryId },
+  })
+
+  test("places Implement Now in Queue as Waiting for CI Repair without Failed or Needs Human", async () => {
+    const setup = await seedRepository(42)
+    await closeGate(setup.repository)
+
+    const created = await runtime.runPromise(
       Effect.gen(function* () {
         const lifecycle = yield* WorkItemLifecycle
-        const queue = yield* QueueService
-        const sql = yield* SqlClient.SqlClient
-        const created = yield* lifecycle.implementNow(
+        return yield* lifecycle.implementNow(
           setup.repository.id,
           setup.issue.issueNumber,
         )
-        observe = () =>
-          Effect.succeed({
-            defaultBranch: "main",
-            observations: [
-              {
-                identity: "161335",
-                kind: "observed" as const,
-                runs: [
-                  observedRun({
-                    runIdentity: "100:1",
-                    rawConclusion: "failure",
-                  }),
-                ],
-              },
-            ],
-          })
-        yield* observeRepositoryCiGate({
-          repository: setup.repository,
-          origin: "operator",
-        })
-        const claimAndRun = Effect.gen(function* () {
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
-          if (Option.isNone(claimed)) {
-            return yield* Effect.die("expected a queued lifecycle job")
-          }
-          return yield* lifecycle.runStep(
-            (claimed.value.payload as { stepRunId: string }).stepRunId,
-          )
-        })
-        for (let index = 0; index < 8; index += 1) {
-          yield* claimAndRun
-        }
-        yield* sql.unsafe(
-          `UPDATE work_item SET check_start_last_observed_is_draft = NULL WHERE id = ?`,
-          [created.id],
-        )
-        yield* claimAndRun
-        const afterDecide = yield* claimAndRun
-        expect(afterDecide._tag).toBe("processed")
-        if (afterDecide._tag === "processed") {
-          expect(afterDecide.workItem.state).toBe("merge_pr")
-          expect(afterDecide.workItem.waitingForCiRepair).toBe(true)
-          expect(afterDecide.workItem.holdsWorkerSlot).toBe(false)
-        }
-        return created.id
       }),
     )
+    expect(created.waitingForCiRepair).toBe(true)
+    expect(created.holdsWorkerSlot).toBe(false)
+    expect(created.stepRuns).toHaveLength(0)
 
-    const heldResponse = await createGraphqlApi(runtime).fetch(
+    const response = await createGraphqlApi(runtime).fetch(
       graphqlRequest(workItemQuery(setup.repository.id)),
     )
-    const heldPayload = (await heldResponse.json()) as {
+    const payload = (await response.json()) as {
       data: {
         workItems: ReadonlyArray<{
           id: string
@@ -447,101 +438,164 @@ describe("Hold approved merges during CI failure", () => {
           status: string
           statusLabel: string
           statusMessage: string | null
+          canRetry: boolean
         }>
         kanbanStatus: {
           lanes: ReadonlyArray<{
             id: string
             workItems: ReadonlyArray<{
-              workItem: {
-                id: string
-                status: string
-                statusLabel: string
-                statusMessage: string | null
-              }
+              workItem: { id: string; status: string }
             }>
           }>
         }
       }
     }
-    const held = heldPayload.data.workItems.find(
-      (item) => item.id === workItemId,
-    )
+    const held = payload.data.workItems.find((item) => item.id === created.id)
     expect(held).toMatchObject({
-      state: "MERGE_PR",
+      state: "CREATE_WORKTREE",
       status: "WAITING_FOR_CI_REPAIR",
       statusLabel: "Waiting for CI Repair",
+      canRetry: false,
     })
     expect(held?.statusMessage).toContain("Waiting for CI Repair")
     expect(held?.statusMessage).toContain("CI")
-    const prLane = heldPayload.data.kanbanStatus.lanes.find(
-      (lane) => lane.id === "PR",
-    )
-    expect(
-      prLane?.workItems.some((entry) => entry.workItem.id === workItemId),
-    ).toBe(true)
-    const queueLane = heldPayload.data.kanbanStatus.lanes.find(
+    expect(held?.status).not.toBe("FAILED")
+    expect(held?.status).not.toBe("NEEDS_HUMAN")
+    const queueLane = payload.data.kanbanStatus.lanes.find(
       (lane) => lane.id === "QUEUE",
     )
     expect(
-      queueLane?.workItems.some((entry) => entry.workItem.id === workItemId),
+      queueLane?.workItems.some((entry) => entry.workItem.id === created.id),
+    ).toBe(true)
+    const prLane = payload.data.kanbanStatus.lanes.find(
+      (lane) => lane.id === "PR",
+    )
+    expect(
+      prLane?.workItems.some((entry) => entry.workItem.id === created.id),
     ).toBe(false)
-    expect(mergeCalls).toBe(0)
+  })
 
-    observe = () =>
-      Effect.succeed({
-        defaultBranch: "main",
-        observations: [
-          {
-            identity: "161335",
-            kind: "observed" as const,
-            runs: [
-              observedRun({
-                runIdentity: "101:1",
-                rawConclusion: "success",
-              }),
-              observedRun({
-                runIdentity: "100:1",
-                rawConclusion: "failure",
-              }),
-            ],
-          },
-        ],
-      })
+  test("holds Implement With profile and Merge Policy in Queue", async () => {
+    const setup = await seedRepository(43)
+    await closeGate(setup.repository)
 
-    await runtime.runPromise(
+    const created = await runtime.runPromise(
       Effect.gen(function* () {
-        const db = yield* DbService
-        const repositories = yield* db.listRepositories
-        const repository = repositories.find(
-          (entry) => entry.id === setup.repository.id,
-        )
-        if (repository === undefined) {
-          return yield* Effect.die("missing repository")
-        }
-        yield* observeRepositoryCiGate({
-          repository,
-          origin: "polling",
-        })
         const lifecycle = yield* WorkItemLifecycle
-        const queue = yield* QueueService
-        const sql = yield* SqlClient.SqlClient
-        const woken = yield* lifecycle.getWorkItem(workItemId)
-        expect(woken.waitingForCiRepair).toBe(false)
-        expect(woken.holdsWorkerSlot).toBe(true)
-        yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-        const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
-        expect(Option.isSome(claimed)).toBe(true)
-        if (Option.isSome(claimed)) {
-          const afterMerge = yield* lifecycle.runStep(
-            (claimed.value.payload as { stepRunId: string }).stepRunId,
-          )
-          expect(afterMerge._tag).toBe("processed")
-          if (afterMerge._tag === "processed") {
-            expect(afterMerge.workItem.state).toBe("local_cleanup")
-          }
-        }
+        const items = yield* lifecycle.implementWith(
+          setup.repository.id,
+          setup.issue.issueNumber,
+          {
+            agentBackendId: "opencode",
+            buildModel: "opencode/deepseek-v4-flash-free",
+            buildThinkingLevel: "high",
+            reviewSameAsBuild: true,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          },
+          { mergePolicy: "always" },
+        )
+        return items[0]
       }),
     )
-    expect(mergeCalls).toBe(1)
+    expect(created?.waitingForCiRepair).toBe(true)
+    expect(created?.holdsWorkerSlot).toBe(false)
+    expect(created?.mergeMode).toBe("always")
+    expect(created?.executionProfile?.build.model).toBe(
+      "opencode/deepseek-v4-flash-free",
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest(workItemQuery(setup.repository.id)),
+    )
+    const payload = (await response.json()) as {
+      data: {
+        workItems: ReadonlyArray<{
+          id: string
+          status: string
+          mergePolicy: string | null
+          executionProfile: { buildModel: string } | null
+        }>
+        kanbanStatus: {
+          lanes: ReadonlyArray<{
+            id: string
+            workItems: ReadonlyArray<{ workItem: { id: string } }>
+          }>
+        }
+      }
+    }
+    const held = payload.data.workItems.find((item) => item.id === created?.id)
+    expect(held?.status).toBe("WAITING_FOR_CI_REPAIR")
+    expect(held?.mergePolicy).toBe("ALWAYS")
+    expect(held?.executionProfile?.buildModel).toBe(
+      "opencode/deepseek-v4-flash-free",
+    )
+    const queueLane = payload.data.kanbanStatus.lanes.find(
+      (lane) => lane.id === "QUEUE",
+    )
+    expect(
+      queueLane?.workItems.some((entry) => entry.workItem.id === created?.id),
+    ).toBe(true)
+  })
+
+  test("Repository Intake creates ordinary held Work Items", async () => {
+    const setup = await seedRepository(44)
+    await closeGate(setup.repository)
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation Intake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            results {
+              __typename
+              ... on RepositoryIntakeCreated {
+                issueNumber
+                action
+                workItem {
+                  id
+                  state
+                  status
+                  statusLabel
+                  statusMessage
+                }
+              }
+            }
+          }
+        }`,
+        variables: { repositoryId: setup.repository.id },
+      }),
+    )
+    const payload = (await response.json()) as {
+      data: {
+        startRepositoryIntake: {
+          results: ReadonlyArray<{
+            __typename: string
+            issueNumber: number
+            action: string
+            workItem: {
+              id: string
+              state: string
+              status: string
+              statusLabel: string
+              statusMessage: string | null
+            }
+          }>
+        }
+      }
+    }
+    expect(payload.data.startRepositoryIntake.results).toHaveLength(1)
+    const result = payload.data.startRepositoryIntake.results[0]
+    expect(result).toMatchObject({
+      __typename: "RepositoryIntakeCreated",
+      issueNumber: 44,
+      action: "IMPLEMENT_NOW",
+      workItem: {
+        state: "CREATE_WORKTREE",
+        status: "WAITING_FOR_CI_REPAIR",
+        statusLabel: "Waiting for CI Repair",
+      },
+    })
+    expect(result?.workItem.statusMessage).toContain("Waiting for CI Repair")
+    expect(result?.workItem.statusMessage).toContain("CI")
   })
 })

--- a/packages/graphql-api/test/kanban-projection.test.ts
+++ b/packages/graphql-api/test/kanban-projection.test.ts
@@ -100,6 +100,11 @@ describe("kanbanLaneFor", () => {
       status: "waiting_for_worker_slot",
       lane: "QUEUE",
     },
+    {
+      state: "create_worktree",
+      status: "waiting_for_ci_repair",
+      lane: "QUEUE",
+    },
   ] as const)(
     "places blocked or not-admitted $state in Queue",
     ({ state, status, lane }) => {

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -387,8 +387,27 @@ describe("paused Work Item statusLabel drain", () => {
         failedCiGateDefinitionLabels: ["CI", "Nightly"],
       }),
     ).toBe("Waiting for CI Repair: CI, Nightly")
+    expect(
+      workItemStatusMessage(held, {
+        failedCiGateDefinitionLabels: ["CI"],
+        ciFailureIncidentSummary: "CI Gate closed: CI failed.",
+      }),
+    ).toBe("Waiting for CI Repair: CI Gate closed: CI failed.")
     expect(workItemCanRetry(held)).toBe(false)
     expect(workItemStateLabel(held)).toBe("Merge PR")
+  })
+
+  test("shows Waiting for CI Repair for pre-admission holds without Failed or Needs Human", () => {
+    const held = workItemWith({
+      state: "create_worktree",
+      holdsWorkerSlot: false,
+      waitingForCiRepair: true,
+      stepRuns: [],
+    })
+    expect(workItemStatus(held)).toBe("waiting_for_ci_repair")
+    expect(workItemStatusLabel(held)).toBe("Waiting for CI Repair")
+    expect(workItemCanRetry(held)).toBe(false)
+    expect(workItemStateLabel(held)).toBe("Create worktree")
   })
 
   test("keeps blockers and Pause ahead of Waiting for CI Repair", () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -968,8 +968,8 @@ enum WorkItemStatus {
   WAITING_FOR_BLOCKERS
   """
   Durable hold on an ordinary remote Work Item while its Repository CI Gate is
-  Closed. Merge-approved work stays at Merge PR without a Worker Slot. This is
-  not a Work Item lifecycle state.
+  Closed. New remote work waits before admission; merge-approved work stays at
+  Merge PR without a Worker Slot. This is not a Work Item lifecycle state.
   """
   WAITING_FOR_CI_REPAIR
   """

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -946,8 +946,8 @@ enum WorkItemStatus {
   WAITING_FOR_BLOCKERS
   """
   Durable hold on an ordinary remote Work Item while its Repository CI Gate is
-  Closed. Merge-approved work stays at Merge PR without a Worker Slot. This is
-  not a Work Item lifecycle state.
+  Closed. New remote work waits before admission; merge-approved work stays at
+  Merge PR without a Worker Slot. This is not a Work Item lifecycle state.
   """
   WAITING_FOR_CI_REPAIR
   """

--- a/packages/work-item-lifecycle/project.json
+++ b/packages/work-item-lifecycle/project.json
@@ -9,7 +9,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "NODE_ENV=test bun test --timeout 30000"
+        "command": "NODE_ENV=test bun --conditions=@ready-for-agent/source test --timeout 30000"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -147,9 +147,10 @@ export interface WorkItemRecord {
    */
   readonly waitingForBlockers: boolean
   /**
-   * When true, the Work Item is Waiting for CI Repair. Ordinary merge-approved
-   * work stays at Merge PR without a Worker Slot until the Repository CI Gate
-   * is no longer Closed. Not a Lifecycle Step.
+   * When true, the Work Item is Waiting for CI Repair. Ordinary remote work
+   * waits before admission, and merge-approved work stays at Merge PR, without
+   * a Worker Slot until the Repository CI Gate is no longer Closed. Not a
+   * Lifecycle Step.
    */
   readonly waitingForCiRepair: boolean
   /**
@@ -217,7 +218,11 @@ export const formatWaitingForBlockersMessage = (
  */
 export const formatWaitingForCiRepairMessage = (
   failedDefinitionLabels: readonly string[] = [],
+  incidentSummary?: string | null,
 ): string => {
+  if (incidentSummary != null && incidentSummary.length > 0) {
+    return `Waiting for CI Repair: ${incidentSummary}`
+  }
   if (failedDefinitionLabels.length === 0) {
     return "Waiting for CI Repair"
   }

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -786,6 +786,32 @@ const pollDelayUntilDeadline = (
   )
 }
 
+/** Implement Locally runs through Review, then pauses before Commit. */
+const IMPLEMENT_LOCALLY_LOCAL_STEPS = new Set<string>([
+  "create_worktree",
+  "install_dependencies",
+  "implement",
+  "assess_changes",
+  "pre_commit",
+  "review",
+])
+
+const isImplementLocallyLocalPath = (input: {
+  readonly pauseBeforeStep: OperationalLifecycleStep | null
+  readonly state: string
+}): boolean =>
+  input.pauseBeforeStep === "commit" &&
+  IMPLEMENT_LOCALLY_LOCAL_STEPS.has(input.state)
+
+const isExemptFromClosedCiGateAdmissionHold = (input: {
+  readonly pauseBeforeStep: OperationalLifecycleStep | null
+  readonly state: string
+}): boolean =>
+  input.state === "local_cleanup" ||
+  input.state === "close_issue" ||
+  input.state === "needs_human" ||
+  isImplementLocallyLocalPath(input)
+
 const nextOperationalStep = (
   step: OperationalLifecycleStep,
 ): OperationalLifecycleStep | "complete" => {
@@ -1198,8 +1224,9 @@ export interface WorkItemLifecycleShape {
   >
   /**
    * After the Repository CI Gate is no longer Closed: lift Waiting for CI
-   * Repair holds. Non-paused merge-approved Work Items rejoin ordinary FIFO
-   * Worker Slot admission. Paused Work Items keep Pause and are not started.
+   * Repair holds. Non-paused pre-admission and merge-approved Work Items
+   * rejoin ordinary FIFO Worker Slot admission. Paused Work Items keep Pause
+   * and are not started.
    */
   readonly releaseWaitingForCiRepair: (
     repositoryId: string,
@@ -1260,6 +1287,7 @@ export const isParkedAttentionWithoutOwnedPr = (input: {
   readonly state: WorkItemState
   readonly paused: boolean
   readonly waitingForBlockers: boolean
+  readonly waitingForCiRepair: boolean
   readonly waitingSince: Date | number | null
   readonly pullRequestNumber: number | null
   readonly failureCode: string | null
@@ -1275,6 +1303,9 @@ export const isParkedAttentionWithoutOwnedPr = (input: {
     return false
   }
   if (input.waitingForBlockers) {
+    return false
+  }
+  if (input.waitingForCiRepair) {
     return false
   }
   if (input.waitingSince !== null) {
@@ -1315,6 +1346,7 @@ export const shouldCompleteParkedAttentionWhenIssueNoLongerRelevant = (input: {
   readonly state: WorkItemState
   readonly paused: boolean
   readonly waitingForBlockers: boolean
+  readonly waitingForCiRepair: boolean
   readonly waitingSince: Date | number | null
   readonly pullRequestNumber: number | null
   readonly failureCode: string | null
@@ -2052,6 +2084,16 @@ export const makeWorkItemLifecycleLive = (
               .pipe(Effect.mapError(toDatabaseError))
             return true
           }
+          if (
+            !isExemptFromClosedCiGateAdmissionHold({
+              pauseBeforeStep: current.pause_before_step,
+              state: current.state,
+            }) &&
+            (yield* repositoryCiGateIsClosed(current.repository_id))
+          ) {
+            yield* applyCiRepairMergeHold(workItemId, now)
+            return false
+          }
           const limit = yield* maxWorkerSlots()
           const occupied = yield* countOccupiedWorkerSlots()
           if (occupied < limit) {
@@ -2111,6 +2153,8 @@ export const makeWorkItemLifecycleLive = (
           }
 
           const now = yield* Clock.currentTimeMillis
+          let admittedThisRound = 0
+          let convertedThisRound = 0
           for (const waiter of waiters) {
             const stillFree =
               (yield* countOccupiedWorkerSlots()) < (yield* maxWorkerSlots())
@@ -2184,13 +2228,23 @@ export const makeWorkItemLifecycleLive = (
               )
             if (didAdmit) {
               admitted += 1
+              admittedThisRound += 1
               const row = yield* loadWorkItemRow(waiter.id)
               if (row) {
+                yield* notifyWorkItemsChanged(row.repository_id)
+              }
+            } else {
+              const row = yield* loadWorkItemRow(waiter.id)
+              if (row?.waiting_for_ci_repair) {
+                convertedThisRound += 1
                 yield* notifyWorkItemsChanged(row.repository_id)
               }
             }
           }
           if (waiters.length < free) {
+            break
+          }
+          if (admittedThisRound === 0 && convertedThisRound === 0) {
             break
           }
         }
@@ -2334,8 +2388,8 @@ export const makeWorkItemLifecycleLive = (
               return Boolean(failedRows[0])
             }
 
-            // Implementable: clear hold and admit like a fresh Implement Now
-            // (full remote path — pause_before_step stays null from Queue).
+            // Implementable: leave Waiting for blockers. A Closed Repository
+            // CI Gate holds ordinary remote admission before Worker Slots.
             return yield* sql
               .withTransaction(
                 Effect.gen(function* () {
@@ -2347,19 +2401,32 @@ export const makeWorkItemLifecycleLive = (
                     return false
                   }
 
+                  const holdForCiRepair = yield* repositoryCiGateIsClosed(
+                    current.repository_id,
+                  )
+
                   // Leave Waiting for blockers before admission so the row is
                   // eligible for Worker Slot wait / Step Run enqueue. RETURNING
                   // gates concurrent abandon/reset that already left the hold.
                   const clearedRows = (yield* sql
                     .unsafe(
                       `UPDATE work_item
-                       SET waiting_for_blockers = 0, waiting_for_ci_repair = 0,
+                       SET waiting_for_blockers = 0,
+                           waiting_for_ci_repair = ?,
+                           holds_worker_slot = CASE WHEN ? = 1 THEN 0 ELSE holds_worker_slot END,
+                           waiting_since = CASE WHEN ? = 1 THEN NULL ELSE waiting_since END,
                            updated_at = ?
                        WHERE id = ?
                          AND waiting_for_blockers = 1
                          AND state NOT IN ('complete', 'failed', 'abandoned')
                        RETURNING id, state, created_at`,
-                      [now, held.id],
+                      [
+                        holdForCiRepair ? 1 : 0,
+                        holdForCiRepair ? 1 : 0,
+                        holdForCiRepair ? 1 : 0,
+                        now,
+                        held.id,
+                      ],
                     )
                     .pipe(Effect.mapError(toDatabaseError))) as readonly {
                     readonly id: string
@@ -2369,6 +2436,10 @@ export const makeWorkItemLifecycleLive = (
                   const cleared = clearedRows[0]
                   if (!cleared) {
                     return false
+                  }
+
+                  if (holdForCiRepair) {
+                    return true
                   }
 
                   const limit = yield* maxWorkerSlots()
@@ -2562,13 +2633,14 @@ export const makeWorkItemLifecycleLive = (
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
 
+        // Recovered holds join ordinary admission behind every existing
+        // Worker Slot waiter. Admit waiters even when this Repository has
+        // no CI Repair holds, so Closed-gate skips resume on reopen.
+        yield* admitWaitingWorkItems
+
         if (heldRows.length === 0) {
           return 0
         }
-
-        // Recovered merges join ordinary admission behind every existing
-        // Worker Slot waiter before they attempt to take any capacity.
-        yield* admitWaitingWorkItems
 
         let changed = 0
         for (const held of heldRows) {
@@ -2627,6 +2699,11 @@ export const makeWorkItemLifecycleLive = (
                   )) as readonly { readonly id: string }[]
                   if (!activeRows[0]) {
                     yield* enqueueStepRunForWorkItem(held.id, pendingStep, now)
+                    yield* consumeAutonomousRetryIfPending(
+                      held.id,
+                      pendingStep,
+                      now,
+                    )
                   }
                   return true
                 }),
@@ -2693,6 +2770,7 @@ export const makeWorkItemLifecycleLive = (
           state: workItem.state,
           paused: Boolean(workItem.paused),
           waitingForBlockers: Boolean(workItem.waiting_for_blockers),
+          waitingForCiRepair: Boolean(workItem.waiting_for_ci_repair),
           waitingSince: workItem.waiting_since,
           pullRequestNumber: workItem.pull_request_number,
           failureCode: workItem.failure_code,
@@ -2912,6 +2990,7 @@ export const makeWorkItemLifecycleLive = (
               state: workItem.state,
               paused: workItem.paused,
               waitingForBlockers: workItem.waitingForBlockers,
+              waitingForCiRepair: workItem.waitingForCiRepair,
               waitingSince: workItem.waitingSince,
               pullRequestNumber: workItem.pullRequestNumber,
               failureCode: workItem.failureCode,
@@ -6192,7 +6271,10 @@ export const makeWorkItemLifecycleLive = (
               }
 
               if (
-                pendingStep === "merge_pr" &&
+                !isExemptFromClosedCiGateAdmissionHold({
+                  pauseBeforeStep: workItem.pause_before_step,
+                  state: pendingStep,
+                }) &&
                 (yield* repositoryCiGateIsClosed(workItem.repository_id))
               ) {
                 yield* applyCiRepairMergeHold(workItemId, now)
@@ -7805,6 +7887,22 @@ export const makeWorkItemLifecycleLive = (
                 }
               }
 
+              const retryRow = yield* loadWorkItemRow(workItemId)
+              if (
+                retryRow !== null &&
+                !isExemptFromClosedCiGateAdmissionHold({
+                  pauseBeforeStep: retryRow.pause_before_step,
+                  state: pendingStep,
+                }) &&
+                (yield* repositoryCiGateIsClosed(retryRow.repository_id))
+              ) {
+                yield* applyCiRepairMergeHold(workItemId, now)
+                if (autonomous !== undefined) {
+                  yield* setPendingAutonomousRetry(workItemId, true, now)
+                }
+                return
+              }
+
               const acquired = yield* tryAcquireWorkerSlot(workItemId, now)
               if (!acquired) {
                 if (autonomous !== undefined) {
@@ -8113,16 +8211,23 @@ export const makeWorkItemLifecycleLive = (
               return yield* sql
                 .withTransaction(
                   Effect.gen(function* () {
+                    const holdForCiRepair =
+                      !isExemptFromClosedCiGateAdmissionHold({
+                        pauseBeforeStep: options.pauseBeforeStep,
+                        state: step,
+                      }) && (yield* repositoryCiGateIsClosed(repositoryId))
                     const limit = yield* maxWorkerSlots()
                     const occupied = yield* countOccupiedWorkerSlots()
-                    const admit = occupied < limit
+                    const admit = !holdForCiRepair && occupied < limit
+                    const waitingSince = holdForCiRepair || admit ? null : now
 
                     if (explicitProfile !== undefined) {
                       yield* sql.unsafe(
                         `INSERT INTO work_item (
                  id, repository_id, issue_number, agent_backend,
                   issue_title, state, state_ready_at, paused,
-                  waiting_since, waiting_for_blockers, merge_mode, auto_merge_override,
+                  waiting_since, waiting_for_blockers, waiting_for_ci_repair,
+                  merge_mode, auto_merge_override,
                   holds_worker_slot,
                   pause_before_step, worktree_path, session_id, failure_code,
                   failure_message,
@@ -8132,7 +8237,7 @@ export const makeWorkItemLifecycleLive = (
                   execution_profile_review_model,
                   execution_profile_review_thinking_level,
                   created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?, NULL, NULL, NULL, NULL, 1, ?, ?, ?, ?, ?, ?, ?)`,
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, 1, ?, ?, ?, ?, ?, ?, ?)`,
                         [
                           workItemId,
                           repositoryId,
@@ -8141,7 +8246,8 @@ export const makeWorkItemLifecycleLive = (
                           matchedIssue.title,
                           step,
                           now,
-                          admit ? null : now,
+                          waitingSince,
+                          holdForCiRepair ? 1 : 0,
                           mergeMode,
                           options.autoMergeOverride === undefined
                             ? null
@@ -8172,10 +8278,11 @@ export const makeWorkItemLifecycleLive = (
                         `INSERT INTO work_item (
                  id, repository_id, issue_number, agent_backend,
                   issue_title, state, state_ready_at, paused,
-                  waiting_since, waiting_for_blockers, merge_mode, holds_worker_slot,
+                  waiting_since, waiting_for_blockers, waiting_for_ci_repair,
+                  merge_mode, holds_worker_slot,
                   pause_before_step, worktree_path, session_id, failure_code,
                   failure_message, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
                         [
                           workItemId,
                           repositoryId,
@@ -8184,7 +8291,8 @@ export const makeWorkItemLifecycleLive = (
                           matchedIssue.title,
                           step,
                           now,
-                          admit ? null : now,
+                          waitingSince,
+                          holdForCiRepair ? 1 : 0,
                           mergeMode,
                           admit ? 1 : 0,
                           options.pauseBeforeStep,
@@ -8420,6 +8528,7 @@ export const makeWorkItemLifecycleLive = (
               Effect.gen(function* () {
                 const limit = yield* maxWorkerSlots()
                 let occupied = yield* countOccupiedWorkerSlots()
+                const gateClosed = yield* repositoryCiGateIsClosed(repositoryId)
                 const workItemIds: WorkItemId[] = []
 
                 for (const child of openChildren) {
@@ -8480,13 +8589,15 @@ export const makeWorkItemLifecycleLive = (
 
                   const workItemId = makeWorkItemId()
                   const blocked = child.blockedBy.length > 0
-                  const admit = !blocked && occupied < limit
+                  const holdForCiRepair = !blocked && gateClosed
+                  const admit = !blocked && !holdForCiRepair && occupied < limit
                   const executionProfile = create.executionProfile
                   yield* sql.unsafe(
                     `INSERT INTO work_item (
                      id, repository_id, issue_number, agent_backend,
                       issue_title, state, state_ready_at, paused,
-                      waiting_since, waiting_for_blockers, merge_mode, auto_merge_override,
+                      waiting_since, waiting_for_blockers, waiting_for_ci_repair,
+                      merge_mode, auto_merge_override,
                       holds_worker_slot,
                       pause_before_step, worktree_path, session_id, failure_code,
                       failure_message,
@@ -8496,7 +8607,7 @@ export const makeWorkItemLifecycleLive = (
                       execution_profile_review_model,
                       execution_profile_review_thinking_level,
                       created_at, updated_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, ?, ?)`,
                     [
                       workItemId,
                       repositoryId,
@@ -8505,8 +8616,9 @@ export const makeWorkItemLifecycleLive = (
                       child.title,
                       step,
                       now,
-                      blocked || admit ? null : now,
+                      blocked || holdForCiRepair || admit ? null : now,
                       blocked ? 1 : 0,
+                      holdForCiRepair ? 1 : 0,
                       pin.mergeMode,
                       sqlMergeOverride(pin.autoMergeOverride),
                       admit ? 1 : 0,

--- a/packages/work-item-lifecycle/test/ci-gate-admission-hold.spec.ts
+++ b/packages/work-item-lifecycle/test/ci-gate-admission-hold.spec.ts
@@ -1,0 +1,890 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Deferred, Effect, Fiber, Layer, Option } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { DatabaseTest, makeFileDatabaseTest } from "@ready-for-agent/db/test"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import { QueueService } from "@ready-for-agent/queue-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  LifecycleSteps,
+  type LifecycleStepsShape,
+  WORK_ITEM_LIFECYCLE_QUEUE,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+  stubActiveAgentBackendLayer,
+  stubAzureDevOpsServiceLayer,
+  stubGitHubServiceLayer,
+  stubGitLabServiceLayer,
+} from "../src/index.js"
+import { describe, expect, it, setDefaultTimeout } from "bun:test"
+
+setDefaultTimeout(30_000)
+
+const successfulSteps: LifecycleStepsShape = {
+  createWorktree: () =>
+    Effect.succeed({
+      worktreePath: "/tmp/worktrees/acme-widgets-42",
+      startingCommitOid: "abc123",
+    }),
+  installDependencies: () => Effect.void,
+  implement: () => Effect.succeed("ses_test_implement_session"),
+  assessChanges: () => Effect.succeed({ _tag: "changes" }),
+  preCommit: () => Effect.void,
+  review: () => Effect.succeed({ _tag: "clean" as const }),
+  commit: () =>
+    Effect.succeed({
+      _tag: "committed" as const,
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  createPr: () =>
+    Effect.succeed({
+      pullRequestNumber: 101,
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  watchPrStatusChecks: () =>
+    Effect.succeed({
+      _tag: "succeeded",
+      createdAt: new Date(0),
+      headSha: "settled-head",
+      headPushedAt: new Date(0),
+      isDraft: false,
+    }),
+  resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
+  investigatePrStatusChecks: () =>
+    Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
+  markPrReadyForReview: () => Effect.succeed({ completion: "native" as const }),
+  decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+  mergePr: () => Effect.succeed({ _tag: "merged" }),
+  closeIssue: () => Effect.void,
+  localCleanup: () => Effect.void,
+  removeWorktree: () => Effect.void,
+}
+
+const sampleRepository = {
+  forge: "github" as const,
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+  localPath: "/repos/acme/widgets.git",
+  isBare: true,
+}
+
+const sampleIssueFields = {
+  title: "Implement feature",
+  body: "Issue body",
+  url: "https://github.com/acme/widgets/issues/42",
+  state: "OPEN" as const,
+  githubCreatedAt: new Date("2026-01-15T12:00:00.000Z"),
+  issueAuthor: null,
+  parent: null,
+  parentPosition: null,
+  hasChildren: false,
+  blockedBy: [],
+}
+
+const implementWithProfile = {
+  agentBackendId: "opencode",
+  buildModel: "build-model",
+  buildThinkingLevel: "high",
+  reviewSameAsBuild: true,
+  reviewModel: null,
+  reviewThinkingLevel: null,
+} as const
+
+const makeTestLayer = (
+  steps: LifecycleStepsShape = successfulSteps,
+  filename?: string,
+) =>
+  WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(
+      stubActiveAgentBackendLayer({
+        models: [
+          { id: "build-model", thinkingLevels: ["high"] },
+          {
+            id: "opencode/deepseek-v4-flash-free",
+            thinkingLevels: ["low", "high"],
+          },
+        ],
+      }),
+    ),
+    Layer.provideMerge(stubGitHubServiceLayer()),
+    Layer.provideMerge(stubGitLabServiceLayer()),
+    Layer.provideMerge(stubAzureDevOpsServiceLayer()),
+    Layer.provideMerge(Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps))),
+    Layer.provideMerge(DbServiceLive),
+    Layer.provideMerge(SqliteQueueServiceLive),
+    Layer.provideMerge(
+      filename === undefined ? DatabaseTest : makeFileDatabaseTest(filename),
+    ),
+  )
+
+type TestRequirements = Layer.Layer.Success<ReturnType<typeof makeTestLayer>>
+
+const runWithSteps = <A, E>(
+  steps: LifecycleStepsShape,
+  test: Effect.Effect<A, E, TestRequirements>,
+): Promise<A> => Effect.runPromise(Effect.provide(test, makeTestLayer(steps)))
+
+const seedHarnessBuildModel = Effect.gen(function* () {
+  const db = yield* DbService
+  const config = yield* db.getConfig
+  if (config.defaultModel !== null && config.defaultThinkingLevel !== null) {
+    return
+  }
+  yield* db.updateConfig({
+    selectedAgentBackend: "opencode",
+    defaultModel: config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+    defaultThinkingLevel: config.defaultThinkingLevel ?? "low",
+    reviewModel: config.reviewModel,
+    reviewThinkingLevel: config.reviewThinkingLevel,
+    maxConcurrentAgentTurns: config.maxConcurrentAgentTurns,
+    maxConcurrentWorkItems: config.maxConcurrentWorkItems,
+  })
+})
+
+const seedActionableIssue = Effect.gen(function* () {
+  const db = yield* DbService
+  yield* seedHarnessBuildModel
+  const repository = yield* db.addRepository(sampleRepository)
+  const issue = yield* db.storeIssue({
+    repositoryId: repository.id,
+    issueNumber: 42,
+    ...sampleIssueFields,
+  })
+  return { repository, issue }
+})
+
+const setMaxWorkItems = (maxConcurrentWorkItems: number) =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const config = yield* db.getConfig
+    yield* db.updateConfig({
+      selectedAgentBackend: "opencode",
+      defaultModel: config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+      defaultThinkingLevel: config.defaultThinkingLevel ?? "low",
+      reviewModel: config.reviewModel,
+      reviewThinkingLevel: config.reviewThinkingLevel,
+      maxConcurrentAgentTurns: config.maxConcurrentAgentTurns,
+      maxConcurrentWorkItems,
+    })
+  })
+
+const seedSiblingIssue = (repositoryId: string, issueNumber: number) =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    return yield* db.storeIssue({
+      repositoryId,
+      issueNumber,
+      ...sampleIssueFields,
+      url: `https://github.com/acme/widgets/issues/${issueNumber}`,
+    })
+  })
+
+const closeCiGate = (repositoryId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const now = Date.now()
+    yield* sql.unsafe(
+      `INSERT INTO ci_gate_definition_observation (
+         id, repository_id, definition_identity, failure_latched,
+         last_raw_status, last_raw_conclusion, created_at, updated_at
+       ) VALUES (?, ?, '161335', 1, 'completed', 'failure', ?, ?)
+       ON CONFLICT(repository_id, definition_identity) DO UPDATE SET
+         failure_latched = 1,
+         last_raw_status = 'completed',
+         last_raw_conclusion = 'failure',
+         updated_at = excluded.updated_at`,
+      [`cgo-${repositoryId.slice(-8)}`, repositoryId, now, now],
+    )
+  })
+
+const openCiGate = (repositoryId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `DELETE FROM ci_gate_definition_observation WHERE repository_id = ?`,
+      [repositoryId],
+    )
+  })
+
+const makeQueuedJobsAvailable = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+  yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+})
+
+const claimAndRunPending = Effect.gen(function* () {
+  const lifecycle = yield* WorkItemLifecycle
+  const queue = yield* QueueService
+  yield* makeQueuedJobsAvailable
+  const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+  expect(Option.isSome(claimed)).toBe(true)
+  if (Option.isNone(claimed)) {
+    return yield* Effect.die("expected a queued lifecycle job")
+  }
+  return yield* lifecycle.runStep(
+    (claimed.value.payload as { stepRunId: string }).stepRunId,
+  )
+})
+
+const expectPreAdmissionHold = (workItem: {
+  readonly state: string
+  readonly waitingForCiRepair: boolean
+  readonly holdsWorkerSlot: boolean
+  readonly waitingSince: Date | null
+  readonly waitingForBlockers: boolean
+  readonly paused: boolean
+  readonly stepRuns: readonly unknown[]
+}) => {
+  expect(workItem.state).toBe("create_worktree")
+  expect(workItem.waitingForCiRepair).toBe(true)
+  expect(workItem.holdsWorkerSlot).toBe(false)
+  expect(workItem.waitingSince).toBeNull()
+  expect(workItem.waitingForBlockers).toBe(false)
+  expect(workItem.paused).toBe(false)
+  expect(workItem.stepRuns).toHaveLength(0)
+}
+
+describe("Waiting for CI Repair pre-admission hold", () => {
+  it("holds Implement Now without a Worker Slot or Step Run", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const queue = yield* QueueService
+        const { repository, issue } = yield* seedActionableIssue
+        yield* closeCiGate(repository.id)
+
+        const created = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        expectPreAdmissionHold(created)
+        expect(created.executionProfile).toBeNull()
+        expect(created.mergeMode).toBe("ordinary")
+        expect(created.autoMergeOverride).toBeNull()
+        expect(created.pauseBeforeStep).toBeNull()
+        expect(
+          Option.isNone(yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)),
+        ).toBe(true)
+      }),
+    ))
+
+  it("holds Implement With and keeps the execution profile and Merge Policy pin", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const { repository, issue } = yield* seedActionableIssue
+        yield* closeCiGate(repository.id)
+
+        const created = yield* lifecycle.implementWith(
+          repository.id,
+          issue.issueNumber,
+          implementWithProfile,
+          { mergePolicy: "always" },
+        )
+        expect(created).toHaveLength(1)
+        const workItem = created[0]
+        if (workItem === undefined) {
+          return yield* Effect.die("expected Implement With Work Item")
+        }
+        expectPreAdmissionHold(workItem)
+        expect(workItem.executionProfile).toEqual({
+          agentBackend: "opencode",
+          build: { model: "build-model", thinkingLevel: "high" },
+          review: { kind: "same_as_build" },
+        })
+        expect(workItem.mergeMode).toBe("always")
+        expect(workItem.pauseBeforeStep).toBeNull()
+      }),
+    ))
+
+  it("holds parent Implement All children without authorizing CI Repair", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const db = yield* DbService
+        yield* seedHarnessBuildModel
+        const repository = yield* db.addRepository({
+          ...sampleRepository,
+          localPath: "/repos/acme/widgets-parent.git",
+          projectPath: "acme/widgets-parent",
+        })
+        yield* db.storeIssue({
+          repositoryId: repository.id,
+          issueNumber: 100,
+          ...sampleIssueFields,
+          title: "Parent feature",
+          url: "https://github.com/acme/widgets/issues/100",
+          hasChildren: true,
+        })
+        yield* db.storeIssue({
+          repositoryId: repository.id,
+          issueNumber: 101,
+          ...sampleIssueFields,
+          title: "Child work",
+          url: "https://github.com/acme/widgets/issues/101",
+          parent: {
+            issueNumber: 100,
+            issueUrl: "https://github.com/acme/widgets/issues/100",
+          },
+          parentPosition: 0,
+        })
+        yield* db.storeIssue({
+          repositoryId: repository.id,
+          issueNumber: 102,
+          ...sampleIssueFields,
+          title: "Blocked child",
+          url: "https://github.com/acme/widgets/issues/102",
+          parent: {
+            issueNumber: 100,
+            issueUrl: "https://github.com/acme/widgets/issues/100",
+          },
+          parentPosition: 1,
+          blockedBy: [
+            {
+              issueNumber: 1,
+              issueUrl: "https://github.com/acme/widgets/issues/1",
+            },
+          ],
+        })
+        yield* closeCiGate(repository.id)
+
+        const covered = yield* lifecycle.implementAllWithAutoMerge(
+          repository.id,
+          100,
+        )
+        expect(covered).toHaveLength(2)
+        const actionable = covered.find((item) => item.issueNumber === 101)
+        const blocked = covered.find((item) => item.issueNumber === 102)
+        if (actionable === undefined || blocked === undefined) {
+          return yield* Effect.die("expected both children")
+        }
+        expectPreAdmissionHold(actionable)
+        expect(actionable.mergeMode).toBe("always")
+        expect(actionable.executionProfile).toBeNull()
+        expect(blocked.waitingForBlockers).toBe(true)
+        expect(blocked.waitingForCiRepair).toBe(false)
+        expect(blocked.holdsWorkerSlot).toBe(false)
+        expect(blocked.stepRuns).toHaveLength(0)
+        expect(blocked.mergeMode).toBe("always")
+      }),
+    ))
+
+  it("keeps a blocked Queue Work Item waiting for blockers until they clear", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const db = yield* DbService
+        yield* seedHarnessBuildModel
+        const repository = yield* db.addRepository({
+          ...sampleRepository,
+          localPath: "/repos/acme/widgets-blocked.git",
+          projectPath: "acme/widgets-blocked",
+        })
+        const issue = yield* db.storeIssue({
+          repositoryId: repository.id,
+          issueNumber: 77,
+          ...sampleIssueFields,
+          title: "Blocked leaf",
+          url: "https://github.com/acme/widgets/issues/77",
+          blockedBy: [
+            {
+              issueNumber: 12,
+              issueUrl: "https://github.com/acme/widgets/issues/12",
+            },
+          ],
+        })
+        yield* closeCiGate(repository.id)
+
+        const held = yield* lifecycle.queue(repository.id, issue.issueNumber)
+        expect(held.waitingForBlockers).toBe(true)
+        expect(held.waitingForCiRepair).toBe(false)
+        expect(held.holdsWorkerSlot).toBe(false)
+        expect(held.stepRuns).toHaveLength(0)
+
+        yield* db.storeIssue({
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+          ...sampleIssueFields,
+          title: issue.title,
+          url: issue.url,
+          blockedBy: [],
+        })
+        expect(yield* lifecycle.releaseWaitingForBlockers(repository.id)).toBe(
+          1,
+        )
+
+        const afterBlockers = yield* lifecycle.getWorkItem(held.id)
+        expect(afterBlockers.waitingForBlockers).toBe(false)
+        expectPreAdmissionHold(afterBlockers)
+      }),
+    ))
+
+  it("holds Retry of ordinary remote work without creating a Step Run", () => {
+    let createCalls = 0
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      createWorktree: () => {
+        createCalls += 1
+        if (createCalls === 1) {
+          return Effect.die("injected create worktree failure")
+        }
+        return Effect.succeed({
+          worktreePath: "/tmp/worktrees/acme-widgets-42",
+          startingCommitOid: "abc123",
+        })
+      },
+    }
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const queue = yield* QueueService
+        const { repository, issue } = yield* seedActionableIssue
+        const created = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        const failed = yield* claimAndRunPending
+        expect(failed._tag).toBe("processed")
+        if (failed._tag === "processed") {
+          expect(failed.workItem.stepRuns[0]?.status).toBe("failed")
+        }
+
+        yield* closeCiGate(repository.id)
+        const retried = yield* lifecycle.retry(created.id)
+        expect(retried.waitingForCiRepair).toBe(true)
+        expect(retried.holdsWorkerSlot).toBe(false)
+        expect(retried.waitingSince).toBeNull()
+        expect(retried.state).toBe("create_worktree")
+        expect(retried.stepRuns.some((run) => run.status === "queued")).toBe(
+          false,
+        )
+        expect(
+          Option.isNone(yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)),
+        ).toBe(true)
+        expect(createCalls).toBe(1)
+      }),
+    )
+  })
+
+  it("holds Start of ordinary remote work after Pause", () => {
+    const started = Effect.runSync(Deferred.make<void>())
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      createWorktree: () =>
+        Deferred.succeed(started, undefined).pipe(
+          Effect.as({
+            worktreePath: "/tmp/worktrees/acme-widgets-42",
+            startingCommitOid: "abc123",
+          }),
+        ),
+    }
+    return runWithSteps(
+      steps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const queue = yield* QueueService
+        const { repository, issue } = yield* seedActionableIssue
+        const created = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        const fiber = yield* Effect.forkChild(
+          lifecycle.runStep(created.stepRuns[0]!.id),
+        )
+        yield* Deferred.await(started)
+        yield* lifecycle.pause(created.id)
+        yield* Fiber.join(fiber)
+
+        yield* closeCiGate(repository.id)
+        const resumed = yield* lifecycle.start(created.id)
+        expect(resumed.paused).toBe(false)
+        expect(resumed.waitingForCiRepair).toBe(true)
+        expect(resumed.holdsWorkerSlot).toBe(false)
+        expect(resumed.waitingSince).toBeNull()
+        expect(resumed.stepRuns.some((run) => run.status === "queued")).toBe(
+          false,
+        )
+        expect(
+          Option.isNone(yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)),
+        ).toBe(true)
+      }),
+    )
+  })
+
+  it("lets Implement Locally finish and pause, then holds remote continuation", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const queue = yield* QueueService
+        const { repository, issue } = yield* seedActionableIssue
+        yield* closeCiGate(repository.id)
+
+        const created = yield* lifecycle.implementLocally(
+          repository.id,
+          issue.issueNumber,
+        )
+        expect(created.waitingForCiRepair).toBe(false)
+        expect(created.holdsWorkerSlot).toBe(true)
+        expect(created.pauseBeforeStep).toBe("commit")
+        expect(created.stepRuns).toHaveLength(1)
+
+        for (const expectedNext of [
+          "install_dependencies",
+          "implement",
+          "assess_changes",
+          "pre_commit",
+          "review",
+          "commit",
+        ] as const) {
+          const result = yield* claimAndRunPending
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe(expectedNext)
+            expect(result.workItem.waitingForCiRepair).toBe(false)
+            if (expectedNext === "commit") {
+              expect(result.workItem.paused).toBe(true)
+              expect(result.workItem.holdsWorkerSlot).toBe(false)
+            }
+          }
+        }
+
+        const started = yield* lifecycle.start(created.id)
+        expect(started.state).toBe("commit")
+        expect(started.paused).toBe(false)
+        expect(started.waitingForCiRepair).toBe(true)
+        expect(started.holdsWorkerSlot).toBe(false)
+        expect(started.waitingSince).toBeNull()
+        expect(
+          started.stepRuns.some(
+            (run) => run.step === "commit" && run.status === "queued",
+          ),
+        ).toBe(false)
+        expect(
+          Option.isNone(yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)),
+        ).toBe(true)
+      }),
+    ))
+
+  it("does not start a paused held Work Item when the gate reopens", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const { repository, issue } = yield* seedActionableIssue
+        yield* closeCiGate(repository.id)
+        const created = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        const paused = yield* lifecycle.pause(created.id)
+        expect(paused.paused).toBe(true)
+        expect(paused.waitingForCiRepair).toBe(true)
+
+        yield* openCiGate(repository.id)
+        expect(yield* lifecycle.releaseWaitingForCiRepair(repository.id)).toBe(
+          1,
+        )
+        const afterWake = yield* lifecycle.getWorkItem(created.id)
+        expect(afterWake.paused).toBe(true)
+        expect(afterWake.waitingForCiRepair).toBe(false)
+        expect(afterWake.holdsWorkerSlot).toBe(false)
+        expect(afterWake.stepRuns).toHaveLength(0)
+      }),
+    ))
+
+  it("rejoins ordinary FIFO Worker Slot admission without priority", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const { repository, issue } = yield* seedActionableIssue
+        yield* setMaxWorkItems(1)
+        const occupying = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        expect(occupying.holdsWorkerSlot).toBe(true)
+
+        const waiterIssue = yield* seedSiblingIssue(repository.id, 43)
+        const waiter = yield* lifecycle.implementNow(
+          repository.id,
+          waiterIssue.issueNumber,
+        )
+        expect(waiter.holdsWorkerSlot).toBe(false)
+        expect(waiter.waitingSince).not.toBeNull()
+
+        yield* closeCiGate(repository.id)
+        const heldIssue = yield* seedSiblingIssue(repository.id, 44)
+        const held = yield* lifecycle.implementNow(
+          repository.id,
+          heldIssue.issueNumber,
+        )
+        expectPreAdmissionHold(held)
+
+        yield* setMaxWorkItems(2)
+        yield* openCiGate(repository.id)
+        expect(yield* lifecycle.releaseWaitingForCiRepair(repository.id)).toBe(
+          1,
+        )
+
+        const admittedWaiter = yield* lifecycle.getWorkItem(waiter.id)
+        const recovered = yield* lifecycle.getWorkItem(held.id)
+        expect(admittedWaiter.holdsWorkerSlot).toBe(true)
+        expect(admittedWaiter.waitingSince).toBeNull()
+        expect(admittedWaiter.waitingForCiRepair).toBe(false)
+        expect(recovered.waitingForCiRepair).toBe(false)
+        expect(recovered.holdsWorkerSlot).toBe(false)
+        expect(recovered.waitingSince).not.toBeNull()
+        expect(recovered.stepRuns).toHaveLength(0)
+      }),
+    ))
+
+  it("converts Worker Slot waiters to Waiting for CI Repair without hanging when a slot is free", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const { repository, issue } = yield* seedActionableIssue
+        yield* setMaxWorkItems(1)
+        const occupying = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        expect(occupying.holdsWorkerSlot).toBe(true)
+
+        const waiterIssue = yield* seedSiblingIssue(repository.id, 43)
+        const waiter = yield* lifecycle.implementNow(
+          repository.id,
+          waiterIssue.issueNumber,
+        )
+        expect(waiter.waitingSince).not.toBeNull()
+
+        yield* closeCiGate(repository.id)
+        yield* setMaxWorkItems(2)
+        expect(yield* lifecycle.admitWaitingWorkItems).toBe(0)
+
+        const heldWaiter = yield* lifecycle.getWorkItem(waiter.id)
+        expect(heldWaiter.waitingForCiRepair).toBe(true)
+        expect(heldWaiter.holdsWorkerSlot).toBe(false)
+        expect(heldWaiter.waitingSince).toBeNull()
+        expect(heldWaiter.stepRuns).toHaveLength(0)
+        const stillOccupying = yield* lifecycle.getWorkItem(occupying.id)
+        expect(stillOccupying.holdsWorkerSlot).toBe(true)
+        expect(stillOccupying.waitingForCiRepair).toBe(false)
+      }),
+    ))
+
+  it("admits an Open-gate waiter after converting Closed-gate waiters in the same pass", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const db = yield* DbService
+        yield* seedHarnessBuildModel
+        yield* setMaxWorkItems(1)
+        const closedRepo = yield* db.addRepository({
+          ...sampleRepository,
+          localPath: "/repos/acme/closed.git",
+          projectPath: "acme/closed",
+        })
+        const openRepo = yield* db.addRepository({
+          ...sampleRepository,
+          localPath: "/repos/acme/open.git",
+          projectPath: "acme/open",
+        })
+        yield* db.storeIssue({
+          repositoryId: closedRepo.id,
+          issueNumber: 42,
+          ...sampleIssueFields,
+          url: "https://github.com/acme/closed/issues/42",
+        })
+        yield* db.storeIssue({
+          repositoryId: closedRepo.id,
+          issueNumber: 43,
+          ...sampleIssueFields,
+          url: "https://github.com/acme/closed/issues/43",
+        })
+        yield* db.storeIssue({
+          repositoryId: openRepo.id,
+          issueNumber: 42,
+          ...sampleIssueFields,
+          url: "https://github.com/acme/open/issues/42",
+        })
+
+        const occupying = yield* lifecycle.implementNow(closedRepo.id, 42)
+        expect(occupying.holdsWorkerSlot).toBe(true)
+        const closedWaiter = yield* lifecycle.implementNow(closedRepo.id, 43)
+        expect(closedWaiter.waitingSince).not.toBeNull()
+        const openWaiter = yield* lifecycle.implementNow(openRepo.id, 42)
+        expect(openWaiter.waitingSince).not.toBeNull()
+
+        yield* closeCiGate(closedRepo.id)
+        yield* setMaxWorkItems(2)
+        expect(yield* lifecycle.admitWaitingWorkItems).toBe(1)
+
+        const heldClosed = yield* lifecycle.getWorkItem(closedWaiter.id)
+        expect(heldClosed.waitingForCiRepair).toBe(true)
+        expect(heldClosed.holdsWorkerSlot).toBe(false)
+        const admittedOpen = yield* lifecycle.getWorkItem(openWaiter.id)
+        expect(admittedOpen.waitingForCiRepair).toBe(false)
+        expect(admittedOpen.holdsWorkerSlot).toBe(true)
+        expect(admittedOpen.waitingSince).toBeNull()
+      }),
+    ))
+
+  it("abandons a Needs Human Work Item while the gate is Closed", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const sql = yield* SqlClient.SqlClient
+        const { repository, issue } = yield* seedActionableIssue
+        const created = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        yield* sql.unsafe(
+          `UPDATE work_item
+           SET state = 'needs_human',
+               pull_request_number = 88,
+               failure_code = 'needs_human',
+               failure_message = 'Human merge required',
+               holds_worker_slot = 0,
+               waiting_since = NULL
+           WHERE id = ?`,
+          [created.id],
+        )
+        yield* closeCiGate(repository.id)
+
+        const abandoned = yield* lifecycle.abandon(created.id)
+        expect(abandoned.state).toBe("abandoned")
+        expect(abandoned.waitingForCiRepair).toBe(false)
+        expect(abandoned.holdsWorkerSlot).toBe(false)
+      }),
+    ))
+
+  it("admits recovered holds in creation order under the live Worker Slot cap", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const { repository, issue } = yield* seedActionableIssue
+        yield* closeCiGate(repository.id)
+        const first = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        const secondIssue = yield* seedSiblingIssue(repository.id, 43)
+        const second = yield* lifecycle.implementNow(
+          repository.id,
+          secondIssue.issueNumber,
+        )
+        expectPreAdmissionHold(first)
+        expectPreAdmissionHold(second)
+
+        yield* setMaxWorkItems(1)
+        yield* openCiGate(repository.id)
+        expect(yield* lifecycle.releaseWaitingForCiRepair(repository.id)).toBe(
+          2,
+        )
+
+        const recoveredFirst = yield* lifecycle.getWorkItem(first.id)
+        const recoveredSecond = yield* lifecycle.getWorkItem(second.id)
+        expect(recoveredFirst.holdsWorkerSlot).toBe(true)
+        expect(recoveredFirst.waitingForCiRepair).toBe(false)
+        expect(recoveredFirst.stepRuns).toHaveLength(1)
+        expect(recoveredSecond.holdsWorkerSlot).toBe(false)
+        expect(recoveredSecond.waitingForCiRepair).toBe(false)
+        expect(recoveredSecond.waitingSince).not.toBeNull()
+        expect(recoveredSecond.stepRuns).toHaveLength(0)
+      }),
+    ))
+
+  it("preserves held intent, profile, and Merge Policy across restart", () =>
+    Effect.gen(function* () {
+      const dir = yield* Effect.promise(() =>
+        mkdtemp(join(tmpdir(), "ci-gate-admission-hold-")),
+      )
+      const filename = join(dir, "harness.sqlite")
+      try {
+        const first = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const lifecycle = yield* WorkItemLifecycle
+            const { repository, issue } = yield* seedActionableIssue
+            yield* closeCiGate(repository.id)
+            const created = yield* lifecycle.implementWith(
+              repository.id,
+              issue.issueNumber,
+              implementWithProfile,
+              { mergePolicy: "classify" },
+            )
+            const workItem = created[0]
+            if (workItem === undefined) {
+              return yield* Effect.die("expected held Implement With")
+            }
+            expectPreAdmissionHold(workItem)
+            return {
+              workItemId: workItem.id,
+              repositoryId: repository.id,
+            }
+          }).pipe(Effect.provide(makeTestLayer(successfulSteps, filename))),
+        )
+
+        const second = yield* Effect.scoped(
+          Effect.gen(function* () {
+            const lifecycle = yield* WorkItemLifecycle
+            const reloaded = yield* lifecycle.getWorkItem(first.workItemId)
+            expectPreAdmissionHold(reloaded)
+            expect(reloaded.executionProfile).toEqual({
+              agentBackend: "opencode",
+              build: { model: "build-model", thinkingLevel: "high" },
+              review: { kind: "same_as_build" },
+            })
+            expect(reloaded.mergeMode).toBe("ordinary")
+            expect(reloaded.autoMergeOverride).toBe(true)
+
+            yield* openCiGate(first.repositoryId)
+            expect(
+              yield* lifecycle.releaseWaitingForCiRepair(first.repositoryId),
+            ).toBe(1)
+            const woken = yield* lifecycle.getWorkItem(first.workItemId)
+            expect(woken.waitingForCiRepair).toBe(false)
+            expect(woken.holdsWorkerSlot).toBe(true)
+            expect(woken.executionProfile).toEqual(reloaded.executionProfile)
+            expect(woken.autoMergeOverride).toBe(true)
+            return woken.state
+          }).pipe(Effect.provide(makeTestLayer(successfulSteps, filename))),
+        )
+        expect(second).toBe("create_worktree")
+      } finally {
+        yield* Effect.promise(() => rm(dir, { recursive: true, force: true }))
+      }
+    }).pipe(Effect.runPromise))
+
+  it("does not hold ordinary Implement Now when the cached gate is Open", () =>
+    runWithSteps(
+      successfulSteps,
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const { repository, issue } = yield* seedActionableIssue
+        const created = yield* lifecycle.implementNow(
+          repository.id,
+          issue.issueNumber,
+        )
+        expect(created.waitingForCiRepair).toBe(false)
+        expect(created.holdsWorkerSlot).toBe(true)
+        expect(created.stepRuns).toHaveLength(1)
+      }),
+    ))
+})

--- a/packages/work-item-lifecycle/test/ci-gate-merge-hold.spec.ts
+++ b/packages/work-item-lifecycle/test/ci-gate-merge-hold.spec.ts
@@ -253,12 +253,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
 
         const afterWatch = yield* claimAndRunPending
@@ -294,12 +293,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "always")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
 
         const afterWatch = yield* claimAndRunPending
@@ -466,12 +464,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
         yield* claimAndRunPending
         const held = yield* claimAndRunPending
@@ -508,12 +505,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
         yield* claimAndRunPending
         const held = yield* claimAndRunPending
@@ -525,14 +521,14 @@ describe("Waiting for CI Repair merge hold", () => {
 
         yield* setMaxWorkItems(1)
         const occupyingIssue = yield* seedSiblingIssue(repository.id, 43)
-        const occupying = yield* lifecycle.implementNow(
+        const occupying = yield* lifecycle.implementLocally(
           repository.id,
           occupyingIssue.issueNumber,
         )
         expect(occupying.holdsWorkerSlot).toBe(true)
 
         const waiterIssue = yield* seedSiblingIssue(repository.id, 44)
-        const waiter = yield* lifecycle.implementNow(
+        const waiter = yield* lifecycle.implementLocally(
           repository.id,
           waiterIssue.issueNumber,
         )
@@ -568,12 +564,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
         yield* claimAndRunPending
         const held = yield* claimAndRunPending
@@ -623,12 +618,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
         yield* claimAndRunPending
         yield* claimAndRunPending
@@ -676,12 +670,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
         yield* claimAndRunPending
         yield* claimAndRunPending
@@ -714,11 +707,11 @@ describe("Waiting for CI Repair merge hold", () => {
             const lifecycle = yield* WorkItemLifecycle
             const { repository, issue } = yield* seedActionableIssue
             yield* setMergePolicy(repository.id, "classify")
-            yield* closeCiGate(repository.id)
             const created = yield* lifecycle.implementNow(
               repository.id,
               issue.issueNumber,
             )
+            yield* closeCiGate(repository.id)
             yield* driveThroughCreatePr(created.id)
             yield* claimAndRunPending
             const held = yield* claimAndRunPending
@@ -774,12 +767,11 @@ describe("Waiting for CI Repair merge hold", () => {
         const lifecycle = yield* WorkItemLifecycle
         const { repository, issue } = yield* seedActionableIssue
         yield* setMergePolicy(repository.id, "classify")
-        yield* closeCiGate(repository.id)
-
         const created = yield* lifecycle.implementNow(
           repository.id,
           issue.issueNumber,
         )
+        yield* closeCiGate(repository.id)
         yield* driveThroughCreatePr(created.id)
         yield* claimAndRunPending
         const held = yield* claimAndRunPending


### PR DESCRIPTION
When a Repository CI Gate is Closed, the harness could still admit ordinary remote work. Implement Now, Implement With, Intake, Implement All, Retry, and Start could take a Worker Slot and start CI on a default branch whose selected CI is already failing (issue #1252). Merge-approved work was already held by #1251.

This change keeps new remote work off that path until the gate is no longer Closed. Ordinary remote Work Items enter Waiting for CI Repair before admission: no Worker Slot and no Step Run. The hold is durable across restart and is not a new Lifecycle Step.

- Implement Now, Implement With, Repository Intake, and parent Implement All create ordinary held Work Items. They do not infer or bulk-authorize CI Repair. Implement With keeps its execution profile and Merge Policy pin.
- A blocked Queue item stays Waiting for blockers first. When blockers clear during a Closed incident, it moves to Waiting for CI Repair instead of remote admission.
- Retry and Start on ordinary remote work respect the Closed gate. Implement Locally may finish its local path and pause before Commit; remote continuation then takes the hold.
- Pause remains authoritative: gate recovery never starts a paused Work Item.
- The hold is applied before Worker Slot capacity. Closed-gate Worker Slot waiters convert to Waiting for CI Repair when a slot is free, without hanging and without starving Open-gate waiters in the same pass. Needs Human abandon and local cleanup still run while Closed.
- New pre-admission holds appear in Queue. Merge-approved Waiting for CI Repair from #1251 stays in PR.
- Status names the active CI Failure Incident and failed CI Gate Definitions. The Work Item is not Failed or Needs Human.
- When the incident resolves, eligible holds rejoin ordinary FIFO Worker Slot admission behind existing waiters, in creation order under the live cap.

Verification: lifecycle tests for Implement Now/With, Implement All, blocker release, Retry, Start after Pause, Implement Locally then remote hold, paused reopen, FIFO versus an existing waiter, waiter conversion without hang, mixed Closed/Open waiters, Needs Human abandon while Closed, creation-order recovery under the live cap, restart of a held Implement With pin, and Open-gate Implement Now; GraphQL tests for Queue placement, status copy, Implement With pins, and Intake; merge-hold coverage updated so work is admitted before the gate closes. Repository pre-commit (affected lint, typecheck, and test) passed. Local review of the uncommitted worktree found no runtime or contract findings.

Review deferred structure and extra coverage only (shared hold helper still named for merge, duplicated Queue classification, extra CLI/migration/postponed-wake fixtures). No live skip remains.

Closes #1252