### PR TITLE
fix: cap first CI Gate observation to one official API page (#1269)

### DIFF
--- a/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service-live.ts
@@ -1618,7 +1618,8 @@ export const makeAzureDevOpsService = (options: {
               return "stop"
             }
           }
-          return "continue"
+          // First observation (no last-seen run) uses one official API page.
+          return lastRunIdentity === null ? "stop" : "continue"
         },
       )
       return {

--- a/packages/azure-devops-service/test/ci-gate-observation.spec.ts
+++ b/packages/azure-devops-service/test/ci-gate-observation.spec.ts
@@ -299,7 +299,7 @@ describe("Azure DevOps CI Gate observation", () => {
     ])
   })
 
-  test("includes every relevant build across continuation-token pages", async () => {
+  test("caps first observation to one continuation-token page when last-seen is empty", async () => {
     const pageOne = Array.from({ length: 100 }, (_, index) =>
       buildPayload({
         id: 1000 - index,
@@ -329,20 +329,7 @@ describe("Azure DevOps CI Gate observation", () => {
       if (url.searchParams.get("continuationToken") === null) {
         return json({ value: pageOne }, { continuationToken: "builds-2" })
       }
-      if (url.searchParams.get("continuationToken") === "builds-2") {
-        return json({
-          value: [
-            buildPayload({
-              id: 1,
-              reason: "individualCI",
-              status: "completed",
-              result: "failed",
-              queueTime: "2026-09-06T09:00:00Z",
-            }),
-          ],
-        })
-      }
-      throw new Error(`unexpected continuation ${url.search}`)
+      throw new Error(`unexpected extra page ${url.search}`)
     }) as typeof fetch)
 
     const observation = await Effect.runPromise(
@@ -352,15 +339,14 @@ describe("Azure DevOps CI Gate observation", () => {
       }),
     )
     const definition = observation.observations[0]
-    expect(continuationTokens).toEqual([null, "builds-2"])
+    expect(continuationTokens).toEqual([null])
     expect(definition?.kind).toBe("observed")
     if (definition?.kind !== "observed") {
       throw new Error("expected observed definition")
     }
-    expect(definition.runs).toHaveLength(101)
+    expect(definition.runs).toHaveLength(100)
     expect(definition.runs[0]?.runIdentity).toBe("1000:20260907.1000")
-    expect(definition.runs[100]?.runIdentity).toBe("1:20260907.1")
-    expect(definition.runs[100]?.rawConclusion).toBe("failed")
+    expect(definition.runs.at(-1)?.runIdentity).toBe("901:20260907.901")
   })
 
   test("stops paging once the last-seen build identity is included", async () => {

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -3589,7 +3589,12 @@ const makeObserveCiGate =
             break
           }
         }
-        if (reachedLastSeen || workflowRuns.length < PAGE_SIZE) {
+        // First observation (no last-seen run) uses one official API page.
+        if (
+          reachedLastSeen ||
+          lastSeen === null ||
+          workflowRuns.length < PAGE_SIZE
+        ) {
           break
         }
       }

--- a/packages/github-service/test/ci-gate-observation.spec.ts
+++ b/packages/github-service/test/ci-gate-observation.spec.ts
@@ -166,7 +166,8 @@ describe("GitHub CI Gate observation", () => {
     expect(definition.runs[2]?.rawConclusion).toBe("failure")
   })
 
-  it("includes every relevant run across paginated official API pages", async () => {
+  it("caps first observation to one official API page when last-seen is empty", async () => {
+    const requestedPages: string[] = []
     const pageOne = Array.from({ length: 100 }, (_, index) =>
       workflowRunPayload({
         id: 1000 - index,
@@ -185,24 +186,11 @@ describe("GitHub CI Gate observation", () => {
         return new Response("not found", { status: 404 })
       }
       const page = url.searchParams.get("page") ?? "1"
+      requestedPages.push(page)
       if (page === "1") {
         return jsonResponse({ total_count: 101, workflow_runs: pageOne })
       }
-      if (page === "2") {
-        return jsonResponse({
-          total_count: 101,
-          workflow_runs: [
-            workflowRunPayload({
-              id: 1,
-              event: "push",
-              status: "completed",
-              conclusion: "failure",
-              createdAt: "2026-09-06T09:00:00Z",
-            }),
-          ],
-        })
-      }
-      return jsonResponse({ total_count: 101, workflow_runs: [] })
+      throw new Error(`unexpected extra page ${page}`)
     })
 
     const observation = await Effect.runPromise(
@@ -212,14 +200,14 @@ describe("GitHub CI Gate observation", () => {
       }),
     )
     const definition = observation.observations[0]
+    expect(requestedPages).toEqual(["1"])
     expect(definition?.kind).toBe("observed")
     if (definition?.kind !== "observed") {
       throw new Error("expected observed definition")
     }
-    expect(definition.runs).toHaveLength(101)
+    expect(definition.runs).toHaveLength(100)
     expect(definition.runs[0]?.runIdentity).toBe("1000:1")
-    expect(definition.runs[100]?.runIdentity).toBe("1:1")
-    expect(definition.runs[100]?.rawConclusion).toBe("failure")
+    expect(definition.runs.at(-1)?.runIdentity).toBe("901:1")
   })
 
   it("stops paging once the last-seen run identity is included", async () => {

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -938,7 +938,8 @@ export const makeGitLabService = (options: {
               break
             }
           }
-          if (reachedLastSeen) {
+          // First observation (no last-seen run) uses one official API page.
+          if (reachedLastSeen || lastSeen === null) {
             break
           }
           const nextPage = response.headers.get("x-next-page")?.trim() ?? ""

--- a/packages/gitlab-service/test/ci-gate-observation.spec.ts
+++ b/packages/gitlab-service/test/ci-gate-observation.spec.ts
@@ -184,7 +184,8 @@ describe("GitLab CI Gate observation", () => {
     expect(requested.some((path) => path.includes("/bridges"))).toBe(false)
   })
 
-  test("includes every relevant pipeline across paginated official API pages", async () => {
+  test("caps first observation to one official API page when last-seen is empty", async () => {
+    const requestedPages: string[] = []
     const pageOne = Array.from({ length: 100 }, (_, index) =>
       pipelinePayload({
         id: 1000 - index,
@@ -203,21 +204,11 @@ describe("GitLab CI Gate observation", () => {
         return new Response("not found", { status: 404 })
       }
       const page = url.searchParams.get("page") ?? "1"
+      requestedPages.push(page)
       if (page === "1") {
         return jsonResponse(pageOne, 200, { "x-next-page": "2" })
       }
-      if (page === "2") {
-        return jsonResponse([
-          pipelinePayload({
-            id: 1,
-            iid: 1,
-            source: "push",
-            status: "failed",
-            createdAt: "2026-09-06T09:00:00.000Z",
-          }),
-        ])
-      }
-      return jsonResponse([])
+      throw new Error(`unexpected extra page ${page}`)
     }) as typeof fetch)
 
     const observation = await Effect.runPromise(
@@ -227,14 +218,14 @@ describe("GitLab CI Gate observation", () => {
       }),
     )
     const definition = observation.observations[0]
+    expect(requestedPages).toEqual(["1"])
     expect(definition?.kind).toBe("observed")
     if (definition?.kind !== "observed") {
       throw new Error("expected observed definition")
     }
-    expect(definition.runs).toHaveLength(101)
+    expect(definition.runs).toHaveLength(100)
     expect(definition.runs[0]?.runIdentity).toBe("1000:1000")
-    expect(definition.runs[100]?.runIdentity).toBe("1:1")
-    expect(definition.runs[100]?.rawStatus).toBe("failed")
+    expect(definition.runs.at(-1)?.runIdentity).toBe("901:901")
   })
 
   test("stops paging once the last-seen pipeline identity is included", async () => {


### PR DESCRIPTION
Saving a Repository CI Gate selection waited on a full default-branch history dump. First observation has no last-seen run, so each Forge adapter paged until history ran out. A busy GitHub CI workflow on trunk is many sequential API calls; Save then already shows Open, and often a reconstructed “newer success” incident from older failures. Later Saves of the same definition were cheap. This contradicts ADR 0068: observation should stay inexpensive (#1269).

First observation now fetches at most one official API page of default-branch runs for that definition. Incremental observation is unchanged: when a last-seen run identity exists, paging still stops once that run is included.

- GitHub, GitLab, and Azure DevOps all enforce the same first-observation cap.
- Repository Settings Save still awaits that observation so the card is Open, Closed, or Degraded when Save returns. Observation failure still persists the selection.
- A latest success on that page is Open with no reconstructed historical incident. A latest failure still latches Closed. A failure and a later success on the same page still become a resolved CI Failure Incident.
- Empty selection still disables the gate without hitting the Forge.

Verification: GitHub, GitLab, and Azure `observeCiGate` specs now assert a full first page with empty last-seen does not request a second page, and still stop once the last-seen run is included. Full adapter suites passed (GitHub 185, GitLab 81, Azure DevOps 90). GraphQL Save coverage still returns Open for a successful definition and records a resolved incident when failure-then-success appear together on one page. Local review of the uncommitted worktree found no runtime or contract findings.

Limitations: Save is not backgrounded. Failures older than the first page are not reconstructed on first observation. Catalog re-validation, polling cadence, and waiting for in-progress checks are unchanged.

Closes #1269