### PR TITLE
fix: diagnose intermittent CI smoke startup hangs

### DIFF
--- a/apps/harness/scripts/dev-smoke.ts
+++ b/apps/harness/scripts/dev-smoke.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { smokeProcessSnapshot } from "./smoke-diagnostics.ts"
 
 const harnessRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const workspaceRoot = resolve(harnessRoot, "../..")
@@ -103,8 +104,10 @@ const env: NodeJS.ProcessEnv = {
   PORT: String(port),
   KEYMAXXER_ENABLED: "false",
   NO_BROWSER: "1",
+  HARNESS_STARTUP_DIAGNOSTICS: "1",
 }
 
+console.log("[harness:smoke] migrating isolated database")
 const migrate = spawn(
   process.execPath,
   [
@@ -129,6 +132,7 @@ if (migrateCode !== 0) {
 }
 
 // Same boot path as harness:dev — Bun runs vite.js (not the Node shebang).
+console.log("[harness:smoke] migration complete; launching preflight then Vite")
 const child = spawn(
   process.execPath,
   [
@@ -137,7 +141,7 @@ const child = spawn(
     sidecarWrapper,
     "bash",
     "-c",
-    "bun --conditions @ready-for-agent/source src/server/preflight.ts && bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
+    "bun --conditions @ready-for-agent/source src/server/preflight.ts && printf '[harness:smoke] preflight exited; launching Vite\\n' && bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
   ],
   {
     cwd: harnessRoot,
@@ -167,12 +171,16 @@ const cleanup = async () => {
 }
 
 try {
+  console.log(
+    `[harness:smoke] waiting for GraphQL health (processGroup=${child.pid ?? "?"}, timeoutMs=${GRAPHQL_HEALTH_TIMEOUT_MS})`,
+  )
   await waitForGraphqlHealth(
     baseUrl,
     GRAPHQL_HEALTH_TIMEOUT_MS,
     () => !childExited,
   )
 
+  console.log("[harness:smoke] GraphQL healthy; requesting GET /")
   const root = await fetch(`${baseUrl}/`, { redirect: "manual" })
   if (root.status <= 0) {
     throw new Error(`GET / failed with status ${root.status}`)
@@ -189,6 +197,10 @@ try {
   }
   if (childExited) {
     console.error(`Dev server exit code: ${exitCode ?? "?"}`)
+  }
+  if (child.pid !== undefined) {
+    console.error("--- smoke process snapshot ---")
+    console.error(smokeProcessSnapshot(child.pid))
   }
   await cleanup()
   process.exit(1)

--- a/apps/harness/scripts/smoke-diagnostics.ts
+++ b/apps/harness/scripts/smoke-diagnostics.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from "node:child_process"
+
+/** Inspect only the smoke process group, never command arguments or environment. */
+export const smokeProcessSnapshot = (processGroupId: number): string => {
+  const result = spawnSync("ps", ["-eo", "pid=,ppid=,pgid=,stat=,comm="], {
+    encoding: "utf8",
+    timeout: 2_000,
+    stdio: ["ignore", "pipe", "ignore"],
+  })
+  if (result.error !== undefined || result.status !== 0) {
+    return "Smoke process snapshot unavailable (ps failed or timed out)."
+  }
+  const processes = result.stdout
+    .split("\n")
+    .filter((line) => line.trim().split(/\s+/, 3)[2] === String(processGroupId))
+  return [
+    "PID PPID PGID STAT COMM",
+    ...processes,
+    ...(processes.length === 0 ? ["(smoke process group has exited)"] : []),
+  ].join("\n")
+}

--- a/apps/harness/src/server/preflight.ts
+++ b/apps/harness/src/server/preflight.ts
@@ -1,8 +1,20 @@
 import { createApplication } from "./application.server.js"
 
 if (import.meta.main) {
+  const startedAt = Date.now()
+  const report = (phase: string) => {
+    if (process.env.HARNESS_STARTUP_DIAGNOSTICS === "1") {
+      console.info(
+        `[preflight pid=${process.pid} elapsedMs=${Date.now() - startedAt}] ${phase}`,
+      )
+    }
+  }
+  report("create:start")
   const application = await createApplication(process.env, {
     startWorker: false,
   })
+  report("create:complete")
+  report("dispose:start")
   await application.dispose()
+  report("dispose:complete; awaiting process exit")
 }

--- a/apps/harness/test/smoke-diagnostics.test.ts
+++ b/apps/harness/test/smoke-diagnostics.test.ts
@@ -1,0 +1,139 @@
+import { spawn, spawnSync } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { smokeProcessSnapshot } from "../scripts/smoke-diagnostics.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("smoke diagnostics", () => {
+  test.each([false, true])(
+    "preflight lifecycle markers are opt-in (enabled=%s)",
+    (enabled) => {
+      const runDir = mkdtempSync(join(tmpdir(), "rfa-preflight-diagnostics-"))
+      const env = {
+        HOME: runDir,
+        PATH: "",
+        KEYMAXXER_ENABLED: "false",
+        SQLITE_DATABASE_PATH: join(runDir, "harness.db"),
+        HARNESS_STARTUP_DIAGNOSTICS: enabled ? "1" : "0",
+      }
+      const options = { env, encoding: "utf8", timeout: 15_000 } as const
+      try {
+        const migrate = spawnSync(
+          process.execPath,
+          [
+            "--conditions",
+            "@ready-for-agent/source",
+            fileURLToPath(
+              new URL(
+                "../../../packages/db/src/bin/migrate.ts",
+                import.meta.url,
+              ),
+            ),
+          ],
+          options,
+        )
+        expect(migrate.error).toBeUndefined()
+        expect(migrate.status).toBe(0)
+
+        const preflight = spawnSync(
+          process.execPath,
+          [
+            "--conditions",
+            "@ready-for-agent/source",
+            fileURLToPath(
+              new URL("../src/server/preflight.ts", import.meta.url),
+            ),
+          ],
+          options,
+        )
+        expect(preflight.error).toBeUndefined()
+        expect(preflight.status).toBe(0)
+        expect(preflight.stdout).toContain(
+          "Default Agent Backend 'opencode' is not available",
+        )
+        const markers = preflight.stdout
+          .split("\n")
+          .filter((line) => line.startsWith("[preflight "))
+        if (enabled) {
+          expect(markers.map((line) => line.replace(/^\[.*?\] /, ""))).toEqual([
+            "create:start",
+            "create:complete",
+            "dispose:start",
+            "dispose:complete; awaiting process exit",
+          ])
+          for (const marker of markers) {
+            expect(marker).toMatch(
+              new RegExp(
+                `^\\[preflight pid=${preflight.pid} elapsedMs=\\d+\\]`,
+              ),
+            )
+          }
+        } else {
+          expect(markers).toEqual([])
+        }
+      } finally {
+        rmSync(runDir, { recursive: true, force: true })
+      }
+    },
+    40_000,
+  )
+
+  test("process snapshot identifies the smoke group without arguments or environment", async () => {
+    const secret = "smoke-diagnostic-secret-sentinel"
+    const child = spawn(
+      process.execPath,
+      ["--eval", `setInterval(() => {}, 1000); // ${secret}`],
+      { detached: true, stdio: "ignore", env: { SECRET: secret } },
+    )
+    const exited = new Promise<void>((resolve) =>
+      child.once("exit", () => resolve()),
+    )
+    try {
+      expect(child.pid).toBeDefined()
+      if (child.pid === undefined)
+        throw new Error("Smoke fixture did not spawn")
+      const snapshot = smokeProcessSnapshot(child.pid)
+      expect(snapshot).toStartWith("PID PPID PGID STAT COMM\n")
+      expect(snapshot).toMatch(
+        new RegExp(`\\b${child.pid}\\s+${process.pid}\\s+${child.pid}\\s+`),
+      )
+      expect(snapshot).not.toContain(secret)
+      expect(snapshot).not.toContain("--eval")
+      for (const line of snapshot.split("\n").slice(1)) {
+        expect(line.trim().split(/\s+/)[2]).toBe(String(child.pid))
+      }
+    } finally {
+      child.kill("SIGKILL")
+      await exited
+    }
+  })
+
+  test("an exited process group is explicit", () => {
+    expect(smokeProcessSnapshot(2_147_483_647)).toBe(
+      "PID PPID PGID STAT COMM\n(smoke process group has exited)",
+    )
+  })
+
+  test("missing ps reports unavailability without failing or exposing environment", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--eval",
+        `import { smokeProcessSnapshot } from ${JSON.stringify(fileURLToPath(new URL("../scripts/smoke-diagnostics.ts", import.meta.url)))}; console.log(smokeProcessSnapshot(process.pid))`,
+      ],
+      {
+        env: { PATH: "/dev/null", SECRET: "smoke-diagnostic-secret-sentinel" },
+        encoding: "utf8",
+        timeout: 5_000,
+      },
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe(
+      "Smoke process snapshot unavailable (ps failed or timed out).\n",
+    )
+    expect(result.stderr).toBe("")
+  })
+})


### PR DESCRIPTION
## Investigation

The reported CI/CD job timed out waiting for GraphQL health after printing the expected missing-OpenCode guidance: https://github.com/berenddeboer/ready-for-agent/actions/runs/34179730305/job/102759574299

OpenCode absence is intentionally supported and the notice is not fatal. The exact commit and Bun revision pass locally without backend CLIs, including 50 preflight subprocess runs and a fresh checkout with the CI double isolated install and no Nx cache. Rerunning the failed GitHub job also passed all harness suites; the original CI/CD run is now successful. The intermittent hang has not been reproduced or assigned a proven root cause.

## Changes

- Add opt-in preflight creation/disposal markers with PID and elapsed time.
- Distinguish completed disposal from actual preflight process exit and Vite launch.
- Report smoke migration and health-check phases.
- On failure, capture only the smoke process group PID/PPID/PGID/state/command-name columns, never process arguments or environment. Bound collection to two seconds.
- Add real subprocess tests for missing-backend preflight completion and diagnostic safety/fallback behavior.

This is diagnostic hardening, not a speculative startup workaround. CI workflow ordering, health checks, and the existing timeout are preserved. No retries or skipped checks are added.

## Validation

- harness:test: 744 Bun tests and 145 Vitest tests pass
- harness:lint, harness:typecheck, harness:knip pass
- Missing-backend harness:smoke passes
- Forced bind failure produces phase markers and a safe process snapshot
- Commit hook affected lint/typecheck/test passes, including downstream ready-for-agent tests
- Original GitHub CI/CD rerun succeeds

After PR checks and review, merge and verify the new main-branch CI/CD run.