### PR TITLE
fix: wait for Vite HTTP readiness before smoke polling

### DIFF
--- a/apps/harness/scripts/dev-smoke-health.ts
+++ b/apps/harness/scripts/dev-smoke-health.ts
@@ -1,0 +1,63 @@
+export const VITE_LISTENING_MARKER = "[harness:smoke] Vite HTTP listener ready"
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+/** Cap each poll so a hung TCP/fetch cannot outrun the overall deadline. */
+const GRAPHQL_HEALTH_POLL_MS = 5_000
+
+export const waitForGraphqlHealth = async (
+  baseUrl: string,
+  timeoutMs: number,
+  isAlive: () => boolean,
+  isListening: () => boolean,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    if (!isAlive()) {
+      throw new Error(
+        `Dev server exited before GraphQL health succeeded: ${
+          lastError instanceof Error ? lastError.message : String(lastError)
+        }`,
+      )
+    }
+    // Vite's temporary TCP port probes can accept a poll and then never close.
+    // Only contact the real HTTP listener, not a probe using the same port.
+    if (!isListening()) {
+      lastError = new Error("Vite has not signalled HTTP listening")
+      await sleep(250)
+      continue
+    }
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
+    const pollMs = Math.min(GRAPHQL_HEALTH_POLL_MS, remainingMs)
+    try {
+      const response = await fetch(`${baseUrl}/graphql`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "{ health }" }),
+        signal: AbortSignal.timeout(pollMs),
+      })
+      if (response.status === 200) {
+        const payload = (await response.json()) as {
+          data?: { health?: boolean }
+        }
+        if (payload.data?.health === true) {
+          return
+        }
+        lastError = new Error(
+          `Unexpected GraphQL payload: ${JSON.stringify(payload)}`,
+        )
+      } else {
+        lastError = new Error(`HTTP ${response.status}`)
+      }
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(250)
+  }
+  throw new Error(
+    `Timed out waiting for GraphQL health at ${baseUrl}/graphql: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  )
+}

--- a/apps/harness/scripts/dev-smoke.ts
+++ b/apps/harness/scripts/dev-smoke.ts
@@ -8,6 +8,10 @@ import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import {
+  VITE_LISTENING_MARKER,
+  waitForGraphqlHealth,
+} from "./dev-smoke-health.ts"
 import { smokeProcessSnapshot } from "./smoke-diagnostics.ts"
 
 const harnessRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -21,58 +25,6 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 /** Overall wait for cold CI Vite first boot (empty dep graph, no Nx cache). */
 const GRAPHQL_HEALTH_TIMEOUT_MS = 360_000
-/** Cap each poll so a hung TCP/fetch cannot outrun the overall deadline. */
-const GRAPHQL_HEALTH_POLL_MS = 5_000
-
-const waitForGraphqlHealth = async (
-  baseUrl: string,
-  timeoutMs: number,
-  isAlive: () => boolean,
-): Promise<void> => {
-  const deadline = Date.now() + timeoutMs
-  let lastError: unknown
-  while (Date.now() < deadline) {
-    if (!isAlive()) {
-      throw new Error(
-        `Dev server exited before GraphQL health succeeded: ${
-          lastError instanceof Error ? lastError.message : String(lastError)
-        }`,
-      )
-    }
-    const remainingMs = deadline - Date.now()
-    if (remainingMs <= 0) break
-    const pollMs = Math.min(GRAPHQL_HEALTH_POLL_MS, remainingMs)
-    try {
-      const response = await fetch(`${baseUrl}/graphql`, {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ query: "{ health }" }),
-        signal: AbortSignal.timeout(pollMs),
-      })
-      if (response.status === 200) {
-        const payload = (await response.json()) as {
-          data?: { health?: boolean }
-        }
-        if (payload.data?.health === true) {
-          return
-        }
-        lastError = new Error(
-          `Unexpected GraphQL payload: ${JSON.stringify(payload)}`,
-        )
-      } else {
-        lastError = new Error(`HTTP ${response.status}`)
-      }
-    } catch (error) {
-      lastError = error
-    }
-    await sleep(250)
-  }
-  throw new Error(
-    `Timed out waiting for GraphQL health at ${baseUrl}/graphql: ${
-      lastError instanceof Error ? lastError.message : String(lastError)
-    }`,
-  )
-}
 
 const killTree = async (child: ChildProcess) => {
   if (child.pid === undefined) return
@@ -178,6 +130,7 @@ try {
     baseUrl,
     GRAPHQL_HEALTH_TIMEOUT_MS,
     () => !childExited,
+    () => output.includes(VITE_LISTENING_MARKER),
   )
 
   console.log("[harness:smoke] GraphQL healthy; requesting GET /")

--- a/apps/harness/test/dev-smoke-health.test.ts
+++ b/apps/harness/test/dev-smoke-health.test.ts
@@ -1,0 +1,78 @@
+import { type Socket, createServer } from "node:net"
+import { setTimeout } from "node:timers/promises"
+import { waitForGraphqlHealth } from "../scripts/dev-smoke-health.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("dev smoke health polling", () => {
+  test("leaves the temporary port probe alone until the real HTTP server is listening", async () => {
+    const connections: Socket[] = []
+    // Vite briefly binds a raw TCP server and waits for close before HTTP startup.
+    const probe = createServer((socket) => connections.push(socket))
+    await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve))
+    const address = probe.address()
+    if (address === null || typeof address === "string") {
+      throw new Error("Port probe did not bind a TCP port")
+    }
+    let listening = false
+    let alive = true
+    let httpServer: ReturnType<typeof Bun.serve> | undefined
+    const result = waitForGraphqlHealth(
+      `http://127.0.0.1:${address.port}`,
+      2_000,
+      () => alive,
+      () => listening,
+    ).then(
+      () => null,
+      (error: unknown) => error,
+    )
+    try {
+      await setTimeout(300)
+      expect(connections).toHaveLength(0)
+      await new Promise<void>((resolve, reject) => {
+        probe.close((error) =>
+          error === undefined ? resolve() : reject(error),
+        )
+      })
+      httpServer = Bun.serve({
+        hostname: "127.0.0.1",
+        port: address.port,
+        async fetch(request) {
+          expect(request.method).toBe("POST")
+          expect(new URL(request.url).pathname).toBe("/graphql")
+          expect(await request.json()).toEqual({ query: "{ health }" })
+          return Response.json({ data: { health: true } })
+        },
+      })
+      listening = true
+      expect(await result).toBeNull()
+    } finally {
+      alive = false
+      for (const socket of connections) socket.destroy()
+      probe.close()
+      await httpServer?.stop(true)
+      await result
+    }
+  })
+
+  test("still enforces the deadline if Vite never signals listening", async () => {
+    await expect(
+      waitForGraphqlHealth(
+        "http://127.0.0.1:1",
+        10,
+        () => true,
+        () => false,
+      ),
+    ).rejects.toThrow("Timed out waiting for GraphQL health")
+  })
+
+  test("still detects process exit before Vite signals listening", async () => {
+    await expect(
+      waitForGraphqlHealth(
+        "http://127.0.0.1:1",
+        1_000,
+        () => false,
+        () => false,
+      ),
+    ).rejects.toThrow("Dev server exited before GraphQL health succeeded")
+  })
+})

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -72,7 +72,11 @@ describe("single application server topology", () => {
       "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
     )
     expect(smokeScript).toContain("{ health }")
-    expect(smokeScript).toContain("AbortSignal.timeout")
+    const healthPoll = await readFile(
+      new URL("../scripts/dev-smoke-health.ts", import.meta.url),
+      "utf8",
+    )
+    expect(healthPoll).toContain("AbortSignal.timeout")
     expect(smokeScript).toContain("GRAPHQL_HEALTH_TIMEOUT_MS")
     expect(smokeScript).not.toContain("E2E_KEYMAXXER_MASTER_KEY")
   })

--- a/apps/harness/vite.config.ts
+++ b/apps/harness/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from "@tailwindcss/vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+import { VITE_LISTENING_MARKER } from "./scripts/dev-smoke-health.ts"
 import { backendRuntimeRestart } from "./src/server/backend-runtime-restart.js"
 import {
   parseHostFlagFromArgv,
@@ -20,6 +21,16 @@ const listenPort = Number(process.env.PORT ?? 6056)
 
 export default defineConfig({
   plugins: [
+    {
+      name: "ready-for-agent-smoke-readiness",
+      apply: "serve",
+      configureServer(server) {
+        if (process.env.HARNESS_STARTUP_DIAGNOSTICS !== "1") return
+        server.httpServer?.once("listening", () => {
+          console.info(VITE_LISTENING_MARKER)
+        })
+      },
+    },
     backendRuntimeRestart(workspaceRoot),
     tanstackStart({ spa: { enabled: true } }),
     react(),


### PR DESCRIPTION
## Root Cause

Follow-up to #1277 and the original failing CI/CD job. The post-merge run failed again: https://github.com/berenddeboer/ready-for-agent/actions/runs/34530827201/job/103050840350

The new diagnostics proved that preflight creation, disposal, and process exit all completed normally. Vite itself remained alive without opening its HTTP listener.

Reproduced on Ubuntu 24.04 with Bun 1.4.0, two-CPU affinity, and CI-like Nx execution. Temporary dependency instrumentation showed config loading and plugin initialization completed. A smoke health request then connected to the temporary wildcard TCP socket Vite uses to check port availability. That socket never completed closing, so the real HTTP listener never started. OpenCode absence is unrelated. All temporary dependency instrumentation was removed.

## Fix

- Emit a smoke-only readiness marker from the real Vite HTTP server listening event.
- Wait for that signal before sending GraphQL health requests, avoiding the temporary port probes.
- Preserve the overall 360-second deadline, per-request timeouts, process-exit detection, GraphQL assertion, and root-page check.
- Add a real TCP-probe regression test plus timeout and early-exit tests.

No dependency upgrades, workflow skips, automatic retries, or extended timeouts.

## Validation

- Regression test fails before the fix because a request reaches the temporary probe, and passes with the readiness gate.
- 60 consecutive CI-like Ubuntu smoke runs passed, including 40 with no temporary instrumentation. These exercise real Vite marker emission and smoke consumption end to end.
- harness:test: 747 Bun tests + 145 Vitest tests passed.
- harness:lint, harness:typecheck, harness:build, harness:knip passed.
- Commit hook affected lint/typecheck/test passed, including downstream application tests.
- Independent review found no correctness or security defects.

Will merge after checks and verify the resulting main CI/CD run.