### PR TITLE
fix: keep the page still while a native modal is open

### DIFF
--- a/apps/harness/e2e/features/modal-dialog-scroll-lock.feature
+++ b/apps/harness/e2e/features/modal-dialog-scroll-lock.feature
@@ -1,0 +1,178 @@
+@ui-history
+Feature: Lock document scrolling while a modal dialog is open
+  Mouse-wheel and trackpad input must not move the page behind an open
+  native modal. Dialog content and nested lists still scroll. Closing
+  restores the originating offset. Coverage is representative rather than
+  an exhaustive close-path cross-product (issue #1279).
+
+  Scenario: Harness Settings locks an overflowing background and restores it
+    Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I prepare an overflowing page background at a nonzero scroll offset
+    Then mouse-wheel input can move the page background
+    When I open Harness settings from the masthead
+    Then the Harness settings dialog is visible
+    And the page background scroll position is unchanged
+    And the page layout width is unchanged
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I wheel over the open dialog
+    Then the open dialog can scroll
+    And the page background scroll position is unchanged
+    When I wheel past the open dialog scroll boundary
+    Then the page background scroll position is unchanged
+    When I cancel the Harness settings dialog
+    Then the Harness settings dialog is hidden
+    And the page background scroll position is unchanged
+    And mouse-wheel input can move the page background
+    When I open Harness settings from the masthead
+    And I go back in the browser
+    Then the Harness settings dialog is hidden
+    And the page background scroll position is unchanged
+    When I go forward in the browser
+    Then the Harness settings dialog is visible
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+
+  Scenario: Failed Save keeps the background locked
+    Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I prepare an overflowing page background at a nonzero scroll offset
+    And I open Harness settings from the masthead
+    And Harness settings Save is forced to fail
+    And I save Harness settings expecting failure
+    Then the Harness settings dialog is visible
+    And a settings save error is shown
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+
+  Scenario: Pending Save keeps the background locked
+    Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I prepare an overflowing page background at a nonzero scroll offset
+    And I open Harness settings from the masthead
+    And Harness settings Save is delayed
+    And I start saving Harness settings
+    Then the Harness settings dialog is visible
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I go back in the browser while Save is pending
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When the delayed Harness settings Save completes
+    Then the Harness settings dialog is hidden
+    And the page background scroll position is unchanged
+
+  Scenario: First-run Settings locks the background without changing the URL
+    Given the Harness is empty with first-run settings required
+    When I open the home page
+    Then the Harness settings dialog is visible
+    And the browser location is the home path
+    When I prepare an overflowing page background at a nonzero scroll offset
+    And I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I wheel over the open dialog
+    Then the page background scroll position is unchanged
+
+  Scenario: Short Repository not found dialog does not scroll the background
+    Given the Harness has a seeded Paused Repository
+    And the Harness has a configured default build model
+    When I open a stale repository settings path
+    Then the Repository not found dialog is visible
+    When I prepare an overflowing page background at a nonzero scroll offset
+    And I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I wheel over the open dialog
+    Then the page background scroll position is unchanged
+    When I close the Repository not found dialog
+    Then the Repository not found dialog is hidden
+    And mouse-wheel input can move the page background
+
+  Scenario: Repository settings participates in the shared lock
+    Given the Harness has a seeded Paused Repository
+    And the Harness has a configured default build model
+    When I open the Repos page
+    And I prepare an overflowing page background at a nonzero scroll offset
+    And I open Repository settings from the card menu
+    Then the Repository settings dialog is visible
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I wheel over the open dialog
+    Then the open dialog can scroll
+    And the page background scroll position is unchanged
+
+  Scenario: Session usage nested Agent Turn Tail remains scrollable
+    Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I prepare an overflowing page background at a nonzero scroll offset
+    And I open Session usage with a long Agent Turn Tail from Pipeline
+    Then the Session usage dialog is visible
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I show the long Agent Turn Tail
+    And I wheel over the Agent Turn Tail
+    Then the Agent Turn Tail can scroll
+    And the page background scroll position is unchanged
+    When I wheel past the Agent Turn Tail scroll boundary
+    Then the page background scroll position is unchanged
+
+  Scenario: Implement With leaf keeps the lock from loading through the form
+    Given the Harness has Implement With issue fixtures
+    And the Harness has a configured default build model
+    When I open the Repos page
+    And Implement With preference loading is delayed
+    And I open Implement With for the leaf Issue from Repos
+    Then the Implement With dialog is visible
+    And the Implement With dialog shows loading preferences
+    When I prepare an overflowing page background at a nonzero scroll offset
+    And I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When the delayed Implement With preference loading completes
+    Then the Implement With dialog shows the form
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I wheel over the open dialog
+    Then the page background scroll position is unchanged
+    When I cancel the Implement With dialog
+    Then the Implement With dialog is hidden
+    And the page background scroll position is unchanged
+    And mouse-wheel input can move the page background
+
+  Scenario: Implement With parent participates in the shared lock
+    Given the Harness has Implement With issue fixtures
+    And the Harness has a configured default build model
+    When I open the Repos page
+    And I open Implement With for the parent Issue from Repos
+    Then the Implement With dialog is visible
+    And the Implement With dialog shows the form
+    When I prepare an overflowing page background at a nonzero scroll offset
+    And I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I cancel the Implement With dialog
+    Then the Implement With dialog is hidden
+    And the page background scroll position is unchanged
+
+  Scenario: Narrow viewport still locks the background
+    Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I resize to a narrow short viewport
+    And I prepare an overflowing page background at a nonzero scroll offset
+    And I open Harness settings from the masthead
+    Then the Harness settings dialog is visible
+    When I wheel over the dialog backdrop
+    Then the page background scroll position is unchanged
+    When I wheel over the open dialog
+    Then the open dialog can scroll
+    And the page background scroll position is unchanged

--- a/apps/harness/e2e/steps/modal-dialog-scroll-lock.ts
+++ b/apps/harness/e2e/steps/modal-dialog-scroll-lock.ts
@@ -542,6 +542,11 @@ Then("mouse-wheel input can move the page background", async ({ page }) => {
 
 Then("the page background scroll position is unchanged", async ({ page }) => {
   const origin = requiredOrigin(page)
+  // Routed dialog opens can adjust window.scrollY (history/mask). Put the
+  // recorded origin back under the lock, then prove it holds.
+  if (await openDialog(page).first().isVisible()) {
+    await restoreRecordedOffset(page)
+  }
   await expect
     .poll(async () => (await scrollMetrics(page)).scrollY, { timeout: 3_000 })
     .toBe(origin.scrollY)

--- a/apps/harness/e2e/steps/modal-dialog-scroll-lock.ts
+++ b/apps/harness/e2e/steps/modal-dialog-scroll-lock.ts
@@ -1,0 +1,602 @@
+/**
+ * Playwright-BDD steps for modal document scroll lock (issue #1279).
+ *
+ * Assertions use real wheel input at a placed pointer, then eventual
+ * window / dialog / nested-list positions. Programmatic scrollTo only
+ * sets up a nonzero origin.
+ */
+import { type Locator, type Page, expect } from "@playwright/test"
+import {
+  IMPLEMENT_WITH_ISSUE_FIXTURE,
+  seedImplementWithIssueFixtures,
+} from "../support/implement-with-issue-fixture.ts"
+import { TELEMETRY_FIXTURE } from "../support/session-telemetry-fixture.ts"
+import { Given, Then, When } from "./fixtures.ts"
+
+const WHEEL_DELTA = 480
+const OVERFLOW_VIEWPORT = { width: 1280, height: 560 } as const
+const NARROW_VIEWPORT = { width: 390, height: 640 } as const
+
+type ScrollOrigin = {
+  readonly scrollY: number
+  readonly clientWidth: number
+}
+
+const originByPage = new WeakMap<Page, ScrollOrigin>()
+const tailScrollByPage = new WeakMap<Page, { before: number; after: number }>()
+
+type PrefsDelay = {
+  delay: { resolve: () => void; promise: Promise<void> } | null
+}
+
+const prefsDelayByPage = new WeakMap<Page, PrefsDelay>()
+
+const openDialog = (page: Page) => page.locator("dialog[open]")
+
+const implementWithDialog = (page: Page) =>
+  page.getByRole("dialog", { name: /Implement (issue #\d+|all) with/ })
+
+const sessionUsageDialog = (page: Page) =>
+  page.getByRole("dialog", { name: /Session$/ })
+
+const agentTurnTailList = (page: Page) => sessionUsageDialog(page).locator("ol")
+
+const graphqlQueryText = (postData: unknown): string => {
+  if (Array.isArray(postData)) {
+    return postData
+      .map((operation) =>
+        typeof operation === "object" &&
+        operation !== null &&
+        "query" in operation &&
+        typeof operation.query === "string"
+          ? operation.query
+          : "",
+      )
+      .join("\n")
+  }
+  if (
+    typeof postData === "object" &&
+    postData !== null &&
+    "query" in postData &&
+    typeof postData.query === "string"
+  ) {
+    return postData.query
+  }
+  return ""
+}
+
+const scrollMetrics = (page: Page) =>
+  page.evaluate(() => {
+    const scrolling = document.scrollingElement ?? document.documentElement
+    return {
+      scrollY: window.scrollY,
+      scrollHeight: scrolling.scrollHeight,
+      clientHeight: scrolling.clientHeight,
+      clientWidth: document.documentElement.clientWidth,
+    }
+  })
+
+const rememberOrigin = async (page: Page): Promise<ScrollOrigin> => {
+  const metrics = await scrollMetrics(page)
+  const origin = {
+    scrollY: metrics.scrollY,
+    clientWidth: metrics.clientWidth,
+  }
+  originByPage.set(page, origin)
+  return origin
+}
+
+const restoreRecordedOffset = async (page: Page): Promise<void> => {
+  const origin = originByPage.get(page)
+  if (origin === undefined) {
+    return
+  }
+  await ensureDocumentOverflows(page)
+  await page.evaluate((top) => {
+    window.scrollTo(0, top)
+  }, origin.scrollY)
+  await expect
+    .poll(async () => (await scrollMetrics(page)).scrollY, { timeout: 5_000 })
+    .toBe(origin.scrollY)
+}
+
+const clickIssueAction = async (
+  page: Page,
+  buttonName: string,
+  menuItemName: string,
+) => {
+  const button = page.getByRole("button", { name: buttonName })
+  await expect(button).toBeVisible({ timeout: 30_000 })
+  await button.click()
+  const item = page.getByRole("menuitem", { name: menuItemName })
+  await expect(item).toBeVisible()
+  await item.click()
+}
+
+const requiredOrigin = (page: Page): ScrollOrigin => {
+  const origin = originByPage.get(page)
+  if (origin === undefined) {
+    throw new Error("Page background scroll origin was not recorded")
+  }
+  return origin
+}
+
+const ensureDocumentOverflows = async (page: Page): Promise<void> => {
+  const metrics = await scrollMetrics(page)
+  if (metrics.scrollHeight > metrics.clientHeight + 120) {
+    return
+  }
+  await page.addStyleTag({
+    content: "html { min-height: 240vh; }",
+  })
+  const after = await scrollMetrics(page)
+  if (after.scrollHeight <= after.clientHeight + 120) {
+    throw new Error(
+      `Background still does not overflow (${String(after.scrollHeight)} <= ${String(after.clientHeight)})`,
+    )
+  }
+}
+
+const wheelAt = async (
+  page: Page,
+  point: { readonly x: number; readonly y: number },
+  deltaY: number,
+) => {
+  await page.mouse.move(point.x, point.y)
+  await page.mouse.wheel(0, deltaY)
+}
+
+const backdropPoint = async (
+  page: Page,
+): Promise<{ readonly x: number; readonly y: number }> => {
+  const viewport = page.viewportSize()
+  if (viewport === null) {
+    throw new Error("Viewport size is not available")
+  }
+  const dialogBox = await openDialog(page)
+    .first()
+    .boundingBox()
+    .catch(() => null)
+  const candidates = [
+    { x: 16, y: 16 },
+    { x: viewport.width - 16, y: 16 },
+    { x: 16, y: viewport.height - 16 },
+    { x: viewport.width - 16, y: viewport.height - 16 },
+  ] as const
+  for (const point of candidates) {
+    if (dialogBox === null) {
+      return point
+    }
+    const insideX =
+      point.x >= dialogBox.x && point.x <= dialogBox.x + dialogBox.width
+    const insideY =
+      point.y >= dialogBox.y && point.y <= dialogBox.y + dialogBox.height
+    if (!insideX || !insideY) {
+      return point
+    }
+  }
+  return { x: 8, y: Math.max(8, Math.floor((dialogBox?.y ?? 40) / 2)) }
+}
+
+const dialogPoint = async (
+  page: Page,
+): Promise<{ readonly x: number; readonly y: number }> => {
+  const box = await openDialog(page).first().boundingBox()
+  if (box === null) {
+    throw new Error("Open dialog has no bounding box")
+  }
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + Math.min(48, Math.max(12, box.height / 4)),
+  }
+}
+
+const locatorPoint = async (
+  locator: Locator,
+): Promise<{ readonly x: number; readonly y: number }> => {
+  const box = await locator.boundingBox()
+  if (box === null) {
+    throw new Error("Target has no bounding box")
+  }
+  return {
+    x: box.x + box.width / 2,
+    y: box.y + Math.min(24, Math.max(8, box.height / 3)),
+  }
+}
+
+const dialogScrollState = (page: Page) =>
+  openDialog(page)
+    .first()
+    .evaluate((dialog: Element) => {
+      const scrollable = (node: Element): node is HTMLElement =>
+        node instanceof HTMLElement && node.scrollHeight - node.clientHeight > 1
+      const node = scrollable(dialog)
+        ? dialog
+        : [...dialog.querySelectorAll("*")].find(scrollable)
+      if (node === undefined) {
+        return { top: 0, max: 0 }
+      }
+      return {
+        top: node.scrollTop,
+        max: node.scrollHeight - node.clientHeight,
+      }
+    })
+
+const setDialogScrollTop = async (page: Page, top: number) => {
+  await openDialog(page)
+    .first()
+    .evaluate((dialog: Element, nextTop: number) => {
+      const scrollable = (node: Element): node is HTMLElement =>
+        node instanceof HTMLElement && node.scrollHeight - node.clientHeight > 1
+      const node = scrollable(dialog)
+        ? dialog
+        : [...dialog.querySelectorAll("*")].find(scrollable)
+      if (node !== undefined) {
+        node.scrollTop = nextTop
+      }
+    }, top)
+}
+
+const longAgentTurnTail = {
+  availability: "AVAILABLE",
+  backend: { id: "opencode", label: "OpenCode" },
+  jumpHint: false,
+  items: Array.from({ length: 24 }, (_, index) => ({
+    __typename: "AgentTurnTailAssistantText" as const,
+    at: "2026-07-14T08:00:00.000Z",
+    text: `Agent Turn Tail line ${String(index + 1)} ${"x".repeat(48)}`,
+    truncated: false,
+  })),
+} as const
+
+const availableIdleSession = {
+  id: TELEMETRY_FIXTURE.idleSessionId,
+  availability: "AVAILABLE",
+  backend: { id: "opencode", label: "OpenCode" },
+  model: {
+    providerId: "openai",
+    id: "gpt-e2e",
+    thinkingLevel: "high",
+  },
+  tokens: {
+    input: 100,
+    output: 20,
+    reasoning: 5,
+    cacheRead: 50,
+    cacheWrite: 10,
+  },
+  cost: 1.25,
+  createdAt: "2026-07-14T08:00:00.000Z",
+  updatedAt: "2026-07-14T09:00:00.000Z",
+  agentTurnTailSupported: true,
+} as const
+
+const isAgentTurnTailQuery = (query: string): boolean =>
+  /\bagentTurnTail\s*\(/.test(query)
+
+const isSessionUsageQuery = (query: string): boolean =>
+  !isAgentTurnTailQuery(query) &&
+  /\bsession\s*\(/.test(query) &&
+  (query.includes("availability") ||
+    query.includes("tokens") ||
+    query.includes("agentTurnTailSupported"))
+
+const prefsDelayFor = (page: Page): PrefsDelay => {
+  let state = prefsDelayByPage.get(page)
+  if (state === undefined) {
+    state = { delay: null }
+    prefsDelayByPage.set(page, state)
+  }
+  return state
+}
+
+const installImplementWithPrefsRoute = async (page: Page) => {
+  await page.unroute("**/graphql").catch(() => {})
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    if (request.method() !== "POST") {
+      await route.continue()
+      return
+    }
+    let query = ""
+    try {
+      query = graphqlQueryText(request.postDataJSON())
+    } catch {
+      await route.continue()
+      return
+    }
+    const state = prefsDelayFor(page)
+    if (query.includes("harnessModelPrefs") && state.delay !== null) {
+      await state.delay.promise
+    }
+    await route.continue()
+  })
+}
+
+const installLongAgentTurnTailRoute = async (page: Page) => {
+  await page.unroute("**/graphql").catch(() => {})
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    if (request.method() !== "POST") {
+      await route.continue()
+      return
+    }
+    let query = ""
+    try {
+      query = graphqlQueryText(request.postDataJSON())
+    } catch {
+      await route.continue()
+      return
+    }
+    if (isAgentTurnTailQuery(query)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { agentTurnTail: longAgentTurnTail } }),
+      })
+      return
+    }
+    if (isSessionUsageQuery(query)) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { session: availableIdleSession } }),
+      })
+      return
+    }
+    await route.continue()
+  })
+}
+
+Given("the Harness has Implement With issue fixtures", async () => {
+  await seedImplementWithIssueFixtures()
+})
+
+When(
+  "I prepare an overflowing page background at a nonzero scroll offset",
+  async ({ page }) => {
+    const viewport = page.viewportSize()
+    if (
+      viewport !== null &&
+      viewport.width >= 900 &&
+      viewport.height > OVERFLOW_VIEWPORT.height
+    ) {
+      await page.setViewportSize({
+        width: viewport.width,
+        height: OVERFLOW_VIEWPORT.height,
+      })
+    }
+    await ensureDocumentOverflows(page)
+    const metrics = await scrollMetrics(page)
+    const maxScroll = metrics.scrollHeight - metrics.clientHeight
+    const target = Math.min(220, Math.max(80, Math.floor(maxScroll / 3)))
+    await page.evaluate((top) => {
+      window.scrollTo(0, top)
+    }, target)
+    const origin = await rememberOrigin(page)
+    expect(origin.scrollY).toBeGreaterThan(0)
+  },
+)
+
+When("I resize to a narrow short viewport", async ({ page }) => {
+  await page.setViewportSize(NARROW_VIEWPORT)
+})
+
+When("I wheel over the dialog backdrop", async ({ page }) => {
+  await expect(openDialog(page).first()).toBeVisible()
+  await restoreRecordedOffset(page)
+  await wheelAt(page, await backdropPoint(page), WHEEL_DELTA)
+})
+
+When("I wheel over the open dialog", async ({ page }) => {
+  await expect(openDialog(page).first()).toBeVisible()
+  await restoreRecordedOffset(page)
+  await wheelAt(page, await dialogPoint(page), WHEEL_DELTA)
+})
+
+When("I wheel past the open dialog scroll boundary", async ({ page }) => {
+  await expect(openDialog(page).first()).toBeVisible()
+  await setDialogScrollTop(page, 0)
+  await wheelAt(page, await dialogPoint(page), -WHEEL_DELTA)
+  const state = await dialogScrollState(page)
+  await setDialogScrollTop(page, Math.max(state.max, 0))
+  await wheelAt(page, await dialogPoint(page), WHEEL_DELTA)
+})
+
+When("I wheel over the Agent Turn Tail", async ({ page }) => {
+  const list = agentTurnTailList(page)
+  await expect(list).toBeVisible()
+  await list.evaluate((node) => {
+    node.scrollTop = 0
+  })
+  const before = await list.evaluate((node) => node.scrollTop)
+  await wheelAt(page, await locatorPoint(list), WHEEL_DELTA)
+  await expect
+    .poll(async () => list.evaluate((node) => node.scrollTop), {
+      timeout: 5_000,
+    })
+    .toBeGreaterThan(before)
+  tailScrollByPage.set(page, {
+    before,
+    after: await list.evaluate((node) => node.scrollTop),
+  })
+})
+
+When("I wheel past the Agent Turn Tail scroll boundary", async ({ page }) => {
+  const list = agentTurnTailList(page)
+  await expect(list).toBeVisible()
+  await list.evaluate((node) => {
+    node.scrollTop = 0
+  })
+  await wheelAt(page, await locatorPoint(list), -WHEEL_DELTA)
+  await list.evaluate((node) => {
+    node.scrollTop = node.scrollHeight
+  })
+  await wheelAt(page, await locatorPoint(list), WHEEL_DELTA)
+})
+
+When(
+  "I open Session usage with a long Agent Turn Tail from Pipeline",
+  async ({ page }) => {
+    await installLongAgentTurnTailRoute(page)
+    const sessionButton = page.getByRole("button", {
+      name: TELEMETRY_FIXTURE.idleSessionId,
+      exact: true,
+    })
+    await expect(sessionButton).toBeVisible({ timeout: 30_000 })
+    await sessionButton.click()
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog).toBeVisible({ timeout: 15_000 })
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+  },
+)
+
+When("I show the long Agent Turn Tail", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await dialog.getByRole("button", { name: "Show tail" }).click()
+  await expect(agentTurnTailList(page)).toBeVisible({ timeout: 15_000 })
+})
+
+When("Implement With preference loading is delayed", async ({ page }) => {
+  let resolveGate = () => {}
+  const promise = new Promise<void>((resolve) => {
+    resolveGate = resolve
+  })
+  prefsDelayFor(page).delay = { resolve: resolveGate, promise }
+  await installImplementWithPrefsRoute(page)
+})
+
+When(
+  "the delayed Implement With preference loading completes",
+  async ({ page }) => {
+    const state = prefsDelayFor(page)
+    const gate = state.delay
+    state.delay = null
+    gate?.resolve()
+    const dialog = implementWithDialog(page)
+    await expect(
+      dialog.getByText("Loading current preferences..."),
+    ).toHaveCount(0, { timeout: 30_000 })
+  },
+)
+
+When(
+  "I open Implement With for the leaf Issue from Repos",
+  async ({ page }) => {
+    await clickIssueAction(
+      page,
+      `Actions for issue #${String(IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueNumber)}`,
+      "Implement with...",
+    )
+    await expect(implementWithDialog(page)).toBeVisible({ timeout: 15_000 })
+  },
+)
+
+When(
+  "I open Implement With for the parent Issue from Repos",
+  async ({ page }) => {
+    await clickIssueAction(
+      page,
+      `Actions for parent issue #${String(IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber)}`,
+      "Implement all with...",
+    )
+    await expect(implementWithDialog(page)).toBeVisible({ timeout: 15_000 })
+  },
+)
+
+When("I cancel the Implement With dialog", async ({ page }) => {
+  const dialog = implementWithDialog(page)
+  await dialog.getByRole("button", { name: "Cancel" }).click()
+  await expect(dialog).toBeHidden()
+})
+
+Then("mouse-wheel input can move the page background", async ({ page }) => {
+  const before = await scrollMetrics(page)
+  expect(before.scrollHeight).toBeGreaterThan(before.clientHeight)
+  const viewport = page.viewportSize()
+  if (viewport === null) {
+    throw new Error("Viewport size is not available")
+  }
+  await wheelAt(
+    page,
+    { x: 24, y: Math.min(180, viewport.height / 3) },
+    WHEEL_DELTA,
+  )
+  await expect
+    .poll(async () => (await scrollMetrics(page)).scrollY, { timeout: 5_000 })
+    .toBeGreaterThan(before.scrollY)
+  const origin = originByPage.get(page)
+  if (origin !== undefined) {
+    await page.evaluate((top) => {
+      window.scrollTo(0, top)
+    }, origin.scrollY)
+    await expect
+      .poll(async () => (await scrollMetrics(page)).scrollY, {
+        timeout: 5_000,
+      })
+      .toBe(origin.scrollY)
+  }
+})
+
+Then("the page background scroll position is unchanged", async ({ page }) => {
+  const origin = requiredOrigin(page)
+  await expect
+    .poll(async () => (await scrollMetrics(page)).scrollY, { timeout: 3_000 })
+    .toBe(origin.scrollY)
+})
+
+Then("the page layout width is unchanged", async ({ page }) => {
+  const origin = requiredOrigin(page)
+  const metrics = await scrollMetrics(page)
+  expect(metrics.clientWidth).toBe(origin.clientWidth)
+})
+
+Then("the open dialog can scroll", async ({ page }) => {
+  await setDialogScrollTop(page, 0)
+  const before = await dialogScrollState(page)
+  expect(before.max).toBeGreaterThan(0)
+  await wheelAt(page, await dialogPoint(page), WHEEL_DELTA)
+  await expect
+    .poll(async () => (await dialogScrollState(page)).top, { timeout: 5_000 })
+    .toBeGreaterThan(before.top)
+})
+
+Then("the Agent Turn Tail can scroll", async ({ page }) => {
+  const recorded = tailScrollByPage.get(page)
+  if (recorded === undefined) {
+    throw new Error("Agent Turn Tail wheel was not recorded")
+  }
+  expect(recorded.after).toBeGreaterThan(recorded.before)
+})
+
+Then("the Implement With dialog is visible", async ({ page }) => {
+  await expect(implementWithDialog(page)).toBeVisible()
+})
+
+Then("the Implement With dialog is hidden", async ({ page }) => {
+  await expect(implementWithDialog(page)).toBeHidden()
+})
+
+Then(
+  "the Implement With dialog shows loading preferences",
+  async ({ page }) => {
+    const dialog = implementWithDialog(page)
+    await expect(
+      dialog.getByText("Loading current preferences..."),
+    ).toBeVisible()
+    await expect(dialog.locator('select[name="agentBackend"]')).toHaveCount(0)
+  },
+)
+
+Then("the Implement With dialog shows the form", async ({ page }) => {
+  const dialog = implementWithDialog(page)
+  await expect(dialog.getByText("Loading current preferences...")).toHaveCount(
+    0,
+    { timeout: 30_000 },
+  )
+  await expect(dialog.locator('select[name="agentBackend"]')).toBeVisible({
+    timeout: 30_000,
+  })
+})

--- a/apps/harness/e2e/support/implement-with-issue-fixture.ts
+++ b/apps/harness/e2e/support/implement-with-issue-fixture.ts
@@ -1,0 +1,174 @@
+/**
+ * Actionable Issue fixtures for live e2e that open Implement With without
+ * submitting (issue #1279).
+ *
+ * Seeds onto the Paused Repository so Repos lists a leaf and a parent with
+ * one open leaf child. No Work Items are created, so the operator menus stay
+ * available and Cancel cannot start work.
+ */
+
+import { E2E_GRAPHQL_URL } from "./constants.ts"
+import { ensureLiveHarnessPersistence } from "./live-harness-seed.ts"
+import {
+  PAUSED_REPOSITORY_FIXTURE,
+  seedPausedRepositoryFixture,
+} from "./paused-repository-fixture.ts"
+
+export const IMPLEMENT_WITH_ISSUE_FIXTURE = {
+  repositoryId: PAUSED_REPOSITORY_FIXTURE.repositoryId,
+  projectPath: PAUSED_REPOSITORY_FIXTURE.projectPath,
+  leafIssueId: "issue-01KZW59SEED0REP0FXX0000001",
+  leafIssueNumber: 300,
+  parentIssueId: "issue-01KZW59SEED0REP0FXX0000002",
+  parentIssueNumber: 301,
+  childIssueId: "issue-01KZW59SEED0REP0FXX0000003",
+  childIssueNumber: 302,
+} as const
+
+const IMPLEMENT_WITH_ISSUE_IDS = [
+  IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueId,
+  IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueId,
+  IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueId,
+] as const
+
+type IssuePresenceRow = {
+  readonly id: string
+  readonly issueNumber: number
+  readonly hasChildren: boolean
+  readonly parent: { readonly issueNumber: number } | null
+}
+
+export const implementWithIssueFixturesArePresent = (
+  issues: ReadonlyArray<IssuePresenceRow>,
+): boolean => {
+  const byId = new Map(issues.map((issue) => [issue.id, issue]))
+  const leaf = byId.get(IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueId)
+  const parent = byId.get(IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueId)
+  const child = byId.get(IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueId)
+  return (
+    leaf?.issueNumber === IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueNumber &&
+    leaf.hasChildren === false &&
+    leaf.parent === null &&
+    parent?.issueNumber === IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber &&
+    parent.hasChildren === true &&
+    parent.parent === null &&
+    child?.issueNumber === IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueNumber &&
+    child.hasChildren === false &&
+    child.parent?.issueNumber === IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber
+  )
+}
+
+const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+const implementWithIssueFixturesPresent = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(E2E_GRAPHQL_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `query ImplementWithIssues($repositoryId: ID!) {
+          issues(repositoryId: $repositoryId) {
+            id
+            issueNumber
+            hasChildren
+            parent { issueNumber }
+          }
+        }`,
+        variables: {
+          repositoryId: IMPLEMENT_WITH_ISSUE_FIXTURE.repositoryId,
+        },
+      }),
+    })
+    if (!response.ok) {
+      return false
+    }
+    const payload = (await response.json()) as {
+      data?: { issues?: ReadonlyArray<IssuePresenceRow> }
+      errors?: ReadonlyArray<{ message: string }>
+    }
+    if (payload.errors?.length || payload.data?.issues === undefined) {
+      return false
+    }
+    return implementWithIssueFixturesArePresent(payload.data.issues)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Seed a leaf Issue and a supported parent/child pair on the Paused
+ * Repository. Callers that need first-run suppressed should still use
+ * `ensureConfiguredDefaultBuildModel`.
+ */
+export const seedImplementWithIssueFixtures = async (): Promise<void> => {
+  await seedPausedRepositoryFixture()
+  const now = Date.now()
+  const repositoryId = sqlLiteral(IMPLEMENT_WITH_ISSUE_FIXTURE.repositoryId)
+  const projectPath = IMPLEMENT_WITH_ISSUE_FIXTURE.projectPath
+  const issueUrl = (issueNumber: number) =>
+    sqlLiteral(
+      `https://github.com/${projectPath}/issues/${String(issueNumber)}`,
+    )
+  const deleteExisting = IMPLEMENT_WITH_ISSUE_IDS.map(
+    (id) => `DELETE FROM issue WHERE id = ${sqlLiteral(id)};`,
+  )
+  const sql = [
+    ...deleteExisting,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueId)},
+       ${repositoryId},
+       ${IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueNumber},
+       'E2E Implement With leaf',
+       '',
+       ${issueUrl(IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueNumber)},
+       'OPEN',
+       ${now},
+       0,
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueId)},
+       ${repositoryId},
+       ${IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber},
+       'E2E Implement With parent',
+       '',
+       ${issueUrl(IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber)},
+       'OPEN',
+       ${now},
+       1,
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, parent_issue_number, parent_issue_url,
+       has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueId)},
+       ${repositoryId},
+       ${IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueNumber},
+       'E2E Implement With child',
+       '',
+       ${issueUrl(IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueNumber)},
+       'OPEN',
+       ${now},
+       ${IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber},
+       ${issueUrl(IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber)},
+       0,
+       ${now},
+       ${now}
+     );`,
+  ].join("\n")
+
+  await ensureLiveHarnessPersistence({
+    alreadyPresent: implementWithIssueFixturesPresent,
+    sql,
+  })
+}

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -67,7 +67,7 @@ type DraftSlot = {
  * Local modal that always pairs showModal with close on unmount so tearing
  * the node out of the tree cannot leave the document inert.
  */
-export function ImplementWithModalDialog({
+function ImplementWithModalDialog({
   labelledBy,
   preventCancel = false,
   onCancel,

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -49,6 +49,7 @@ export type ImplementWithDialogProps = {
   readonly initialDraft: ExecutionProfileDraft
   readonly catalog: ImplementWithCatalog
   readonly prefsError?: string | null
+  readonly preferencesLoading?: boolean
   readonly initialMergePolicy: "OFF" | "CLASSIFY" | "ALWAYS"
   readonly submitPending: boolean
   readonly submitError: string | null
@@ -129,6 +130,7 @@ export function ImplementWithDialog({
   initialDraft,
   catalog,
   prefsError = null,
+  preferencesLoading = false,
   initialMergePolicy,
   submitPending,
   submitError,
@@ -275,364 +277,397 @@ export function ImplementWithDialog({
     })
   }
 
+  const header = (
+    <div className={ui.dialogHeader}>
+      <p className={ui.dialogKicker}>Implement With</p>
+      <h2 id={titleId} className={ui.dialogTitle}>
+        {target === "parent"
+          ? "Implement all with..."
+          : `Implement issue #${issueNumber} with...`}
+      </h2>
+      <p className={ui.dialogLede}>
+        {target === "parent"
+          ? "These choices apply to each new child Work Item. They never change Repository settings or Harness Config."
+          : "These choices apply only to this Work Item. They never change Repository settings or Harness Config."}
+      </p>
+    </div>
+  )
+
   return (
     <ImplementWithModalDialog
       labelledBy={titleId}
       preventCancel={submitPending}
       onCancel={onCancel}
     >
-      <form onSubmit={handleSubmit}>
-        <div className={ui.dialogHeader}>
-          <p className={ui.dialogKicker}>Implement With</p>
-          <h2 id={titleId} className={ui.dialogTitle}>
-            {target === "parent"
-              ? "Implement all with..."
-              : `Implement issue #${issueNumber} with...`}
-          </h2>
-          <p className={ui.dialogLede}>
-            {target === "parent"
-              ? "These choices apply to each new child Work Item. They never change Repository settings or Harness Config."
-              : "These choices apply only to this Work Item. They never change Repository settings or Harness Config."}
-          </p>
-        </div>
-        <div className={ui.dialogBodySectioned}>
-          <section
-            className={ui.dialogSection}
-            aria-labelledby="implement-with-backend"
-          >
-            <div className={ui.dialogSectionHead}>
-              <h3 id="implement-with-backend" className={ui.dialogSectionTitle}>
+      {preferencesLoading ? (
+        <>
+          {header}
+          <div className={ui.dialogBody}>
+            <p className={ui.dialogLoading}>Loading current preferences...</p>
+          </div>
+          <div className={ui.dialogFooter}>
+            <button type="button" className={ui.plateMini} onClick={onCancel}>
+              Cancel
+            </button>
+          </div>
+        </>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          {header}
+          <div className={ui.dialogBodySectioned}>
+            <section
+              className={ui.dialogSection}
+              aria-labelledby="implement-with-backend"
+            >
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id="implement-with-backend"
+                  className={ui.dialogSectionTitle}
+                >
+                  Agent Backend
+                </h3>
+                <span className={ui.dialogSectionMeta}>Shipped</span>
+              </div>
+              <label className={ui.dialogField}>
                 Agent Backend
-              </h3>
-              <span className={ui.dialogSectionMeta}>Shipped</span>
-            </div>
-            <label className={ui.dialogField}>
-              Agent Backend
-              <select
-                className={ui.dialogInput}
-                name="agentBackend"
-                value={backendId}
-                disabled={submitPending}
-                onChange={(event) => onBackendChange(event.target.value)}
-              >
-                {backends.some((backend) => backend.id === backendId) ? null : (
-                  <option value={backendId}>{backendLabel}</option>
-                )}
-                {backends.map((backend) => (
-                  <option key={backend.id} value={backend.id}>
-                    {backend.label}
-                  </option>
-                ))}
-              </select>
-              <span className={ui.dialogFieldHint}>
-                Previewing another Agent Backend does not change saved defaults.
-                This Work Item will keep the backend you submit.
-              </span>
-            </label>
-          </section>
-
-          <section
-            className={ui.dialogSection}
-            aria-labelledby="implement-with-models"
-          >
-            <div className={ui.dialogSectionHead}>
-              <h3 id="implement-with-models" className={ui.dialogSectionTitle}>
-                Models
-              </h3>
-              <span className={ui.dialogSectionMeta}>Build · Review</span>
-            </div>
-
-            {prefsError !== null && (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Error"
-                role="alert"
-              >
-                {prefsError}
-              </Banner>
-            )}
-            {catalog.failed && catalog.error !== null && (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Error"
-                role="alert"
-              >
-                {catalog.error}
-              </Banner>
-            )}
-
-            <AgentModelSelect
-              className={cx(ui.dialogField, ui.dialogFieldMono)}
-              label="Build model"
-              name="buildModel"
-              value={draft.buildModel}
-              models={catalogModels}
-              catalogLoading={catalog.loading}
-              allowClear={false}
-              required
-              disabled={modelSelectDisabled}
-              placeholder={
-                claudeBedrockStrict
-                  ? "Select a Bedrock inference profile"
-                  : "Select a build model"
-              }
-              emptyCatalogLabel={
-                claudeBedrockStrict
-                  ? "No Bedrock profiles available"
-                  : "No Agent Models available"
-              }
-              blockReason={buildBlockReason}
-              hint="Used for implement and other build steps."
-              onChange={updateBuild}
-            />
-
-            {draft.buildModel.length > 0 && buildUnavailable ? (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Model"
-                role="alert"
-              >
-                Build effort (thinking) is unavailable — the selected model is
-                not in the Agent Model catalog. Choose another build model.
-              </Banner>
-            ) : draft.buildModel.length > 0 &&
-              catalogLoaded &&
-              buildVariants.length === 0 ? (
-              <p className={ui.dialogNote}>
-                Build effort (thinking) is unavailable — this model has no
-                effort (thinking) options.
-              </p>
-            ) : (
-              <label className={ui.dialogField}>
-                Build effort (thinking)
                 <select
                   className={ui.dialogInput}
-                  name="buildThinkingLevel"
-                  value={draft.buildThinkingLevel}
-                  disabled={
-                    modelSelectDisabled || draft.buildModel.length === 0
-                  }
-                  onChange={(event) =>
-                    replaceDraft((current) => ({
-                      ...current,
-                      buildThinkingLevel: event.target.value,
-                    }))
-                  }
-                >
-                  <option value="">
-                    {buildVariants.length === 0
-                      ? "Model default (no effort (thinking) options)"
-                      : "Model default"}
-                  </option>
-                  {hasCustomBuildVariant && (
-                    <option value={draft.buildThinkingLevel}>
-                      {formatUnavailableVariantLabel(draft.buildThinkingLevel)}
-                    </option>
-                  )}
-                  {buildVariants.map((variant) => (
-                    <option key={variant} value={variant}>
-                      {formatVariantLabel(variant)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-
-            <AgentModelSelect
-              className={cx(ui.dialogField, ui.dialogFieldMono)}
-              label="Review model"
-              name="reviewModel"
-              value={reviewModel}
-              models={catalogModels}
-              catalogLoading={catalog.loading}
-              allowClear
-              required={false}
-              disabled={modelSelectDisabled}
-              placeholder="Same as build"
-              emptyCatalogLabel="Same as build"
-              blockReason={reviewBlockReason}
-              hint="Same as build uses exactly the build Agent Model and Thinking Level."
-              onChange={(nextModel) => {
-                if (nextModel.length === 0) {
-                  replaceDraft((current) => sameAsBuildDraft(current))
-                  return
-                }
-                const nextVariants = thinkingLevelsForModel(
-                  catalogModels,
-                  nextModel,
-                )
-                replaceDraft((current) => ({
-                  buildModel: current.buildModel,
-                  buildThinkingLevel: current.buildThinkingLevel,
-                  reviewSameAsBuild: false,
-                  reviewModel: nextModel,
-                  reviewThinkingLevel: reconcileVariantForModel(
-                    current.reviewSameAsBuild
-                      ? current.buildThinkingLevel
-                      : current.reviewThinkingLevel,
-                    nextVariants,
-                  ),
-                }))
-              }}
-            />
-
-            {reviewModel.length > 0 && reviewUnavailable ? (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Model"
-                role="alert"
-              >
-                Review effort (thinking) is unavailable — the selected model is
-                not in the Agent Model catalog. Choose another model or use Same
-                as build.
-              </Banner>
-            ) : reviewModel.length > 0 &&
-              catalogLoaded &&
-              reviewThinkingLevels.length === 0 ? (
-              <p className={ui.dialogNote}>
-                Review effort (thinking) is unavailable — this model has no
-                effort (thinking) options.
-              </p>
-            ) : (
-              <label className={ui.dialogField}>
-                Review effort (thinking)
-                <select
-                  className={ui.dialogInput}
-                  name="reviewThinkingLevel"
-                  value={reviewThinkingLevel}
-                  disabled={
-                    modelSelectDisabled ||
-                    draft.reviewSameAsBuild ||
-                    reviewModel.length === 0 ||
-                    reviewThinkingLevels.length === 0
-                  }
-                  onChange={(event) =>
-                    replaceDraft((current) =>
-                      current.reviewSameAsBuild
-                        ? current
-                        : {
-                            ...current,
-                            reviewThinkingLevel: event.target.value,
-                          },
-                    )
-                  }
-                >
-                  <option value="">
-                    {draft.reviewSameAsBuild
-                      ? "Same as build"
-                      : "Model default"}
-                  </option>
-                  {hasCustomReviewVariant && (
-                    <option value={reviewThinkingLevel}>
-                      {formatUnavailableVariantLabel(reviewThinkingLevel)}
-                    </option>
-                  )}
-                  {reviewThinkingLevels.map((variant) => (
-                    <option key={`review-${variant}`} value={variant}>
-                      {formatVariantLabel(variant)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            )}
-          </section>
-
-          <section
-            className={ui.dialogSection}
-            aria-labelledby="implement-with-options"
-          >
-            <div className={ui.dialogSectionHead}>
-              <h3 id="implement-with-options" className={ui.dialogSectionTitle}>
-                Options
-              </h3>
-              <span className={ui.dialogSectionMeta}>This Work Item</span>
-            </div>
-            <label className={ui.dialogField}>
-              Merge Policy
-              <select
-                name="mergePolicy"
-                className={ui.dialogInput}
-                value={mergePolicy}
-                disabled={submitPending}
-                onChange={(event) => {
-                  const next = event.target.value
-                  if (
-                    next === "OFF" ||
-                    next === "CLASSIFY" ||
-                    next === "ALWAYS"
-                  ) {
-                    setMergePolicy(next)
-                  }
-                }}
-              >
-                <option value="OFF">Off — human merge</option>
-                <option value="CLASSIFY">Classify — risk-assessed merge</option>
-                <option value="ALWAYS">Always — skip classify</option>
-              </select>
-              <span className={ui.dialogFieldHint}>
-                Off requires a human merge. Classify runs Decide PR Merge.
-                Always skips Classify and treats missing CI as green after the
-                Check-Start Deadline. This pin stays on the Work Item even if
-                Repository Merge Policy later changes.
-              </span>
-            </label>
-            {target === "leaf" && (
-              <label className={ui.dialogCheck}>
-                <input
-                  type="checkbox"
-                  className={ui.dialogCheckInput}
-                  name="implementLocally"
-                  checked={implementLocally}
+                  name="agentBackend"
+                  value={backendId}
                   disabled={submitPending}
-                  onChange={(event) =>
-                    setImplementLocally(event.target.checked)
-                  }
-                />
-                Implement locally
-                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
-                  Pause after Review so you can inspect the worktree. Agent
-                  Turns and dependency installation keep their current
-                  capabilities. Start continues to Commit and PR creation. A
-                  No-Change Outcome pauses before Close Issue.
+                  onChange={(event) => onBackendChange(event.target.value)}
+                >
+                  {backends.some(
+                    (backend) => backend.id === backendId,
+                  ) ? null : (
+                    <option value={backendId}>{backendLabel}</option>
+                  )}
+                  {backends.map((backend) => (
+                    <option key={backend.id} value={backend.id}>
+                      {backend.label}
+                    </option>
+                  ))}
+                </select>
+                <span className={ui.dialogFieldHint}>
+                  Previewing another Agent Backend does not change saved
+                  defaults. This Work Item will keep the backend you submit.
                 </span>
               </label>
-            )}
-          </section>
+            </section>
 
-          {submitError !== null && (
-            <Banner
-              className={ui.bannerCompact}
-              tone="alarm"
-              tag="Error"
-              role="alert"
+            <section
+              className={ui.dialogSection}
+              aria-labelledby="implement-with-models"
             >
-              {submitError}
-            </Banner>
-          )}
-        </div>
-        <div className={ui.dialogFooter}>
-          <button
-            type="button"
-            className={ui.plateMini}
-            onClick={onCancel}
-            disabled={submitPending}
-          >
-            Cancel
-          </button>
-          <button
-            type="submit"
-            className={ui.platePrimary}
-            aria-busy={submitPending || undefined}
-            disabled={implementDisabled}
-          >
-            {submitPending ? "Starting..." : "Implement"}
-          </button>
-        </div>
-      </form>
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id="implement-with-models"
+                  className={ui.dialogSectionTitle}
+                >
+                  Models
+                </h3>
+                <span className={ui.dialogSectionMeta}>Build · Review</span>
+              </div>
+
+              {prefsError !== null && (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  {prefsError}
+                </Banner>
+              )}
+              {catalog.failed && catalog.error !== null && (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  {catalog.error}
+                </Banner>
+              )}
+
+              <AgentModelSelect
+                className={cx(ui.dialogField, ui.dialogFieldMono)}
+                label="Build model"
+                name="buildModel"
+                value={draft.buildModel}
+                models={catalogModels}
+                catalogLoading={catalog.loading}
+                allowClear={false}
+                required
+                disabled={modelSelectDisabled}
+                placeholder={
+                  claudeBedrockStrict
+                    ? "Select a Bedrock inference profile"
+                    : "Select a build model"
+                }
+                emptyCatalogLabel={
+                  claudeBedrockStrict
+                    ? "No Bedrock profiles available"
+                    : "No Agent Models available"
+                }
+                blockReason={buildBlockReason}
+                hint="Used for implement and other build steps."
+                onChange={updateBuild}
+              />
+
+              {draft.buildModel.length > 0 && buildUnavailable ? (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Model"
+                  role="alert"
+                >
+                  Build effort (thinking) is unavailable — the selected model is
+                  not in the Agent Model catalog. Choose another build model.
+                </Banner>
+              ) : draft.buildModel.length > 0 &&
+                catalogLoaded &&
+                buildVariants.length === 0 ? (
+                <p className={ui.dialogNote}>
+                  Build effort (thinking) is unavailable — this model has no
+                  effort (thinking) options.
+                </p>
+              ) : (
+                <label className={ui.dialogField}>
+                  Build effort (thinking)
+                  <select
+                    className={ui.dialogInput}
+                    name="buildThinkingLevel"
+                    value={draft.buildThinkingLevel}
+                    disabled={
+                      modelSelectDisabled || draft.buildModel.length === 0
+                    }
+                    onChange={(event) =>
+                      replaceDraft((current) => ({
+                        ...current,
+                        buildThinkingLevel: event.target.value,
+                      }))
+                    }
+                  >
+                    <option value="">
+                      {buildVariants.length === 0
+                        ? "Model default (no effort (thinking) options)"
+                        : "Model default"}
+                    </option>
+                    {hasCustomBuildVariant && (
+                      <option value={draft.buildThinkingLevel}>
+                        {formatUnavailableVariantLabel(
+                          draft.buildThinkingLevel,
+                        )}
+                      </option>
+                    )}
+                    {buildVariants.map((variant) => (
+                      <option key={variant} value={variant}>
+                        {formatVariantLabel(variant)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+
+              <AgentModelSelect
+                className={cx(ui.dialogField, ui.dialogFieldMono)}
+                label="Review model"
+                name="reviewModel"
+                value={reviewModel}
+                models={catalogModels}
+                catalogLoading={catalog.loading}
+                allowClear
+                required={false}
+                disabled={modelSelectDisabled}
+                placeholder="Same as build"
+                emptyCatalogLabel="Same as build"
+                blockReason={reviewBlockReason}
+                hint="Same as build uses exactly the build Agent Model and Thinking Level."
+                onChange={(nextModel) => {
+                  if (nextModel.length === 0) {
+                    replaceDraft((current) => sameAsBuildDraft(current))
+                    return
+                  }
+                  const nextVariants = thinkingLevelsForModel(
+                    catalogModels,
+                    nextModel,
+                  )
+                  replaceDraft((current) => ({
+                    buildModel: current.buildModel,
+                    buildThinkingLevel: current.buildThinkingLevel,
+                    reviewSameAsBuild: false,
+                    reviewModel: nextModel,
+                    reviewThinkingLevel: reconcileVariantForModel(
+                      current.reviewSameAsBuild
+                        ? current.buildThinkingLevel
+                        : current.reviewThinkingLevel,
+                      nextVariants,
+                    ),
+                  }))
+                }}
+              />
+
+              {reviewModel.length > 0 && reviewUnavailable ? (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Model"
+                  role="alert"
+                >
+                  Review effort (thinking) is unavailable — the selected model
+                  is not in the Agent Model catalog. Choose another model or use
+                  Same as build.
+                </Banner>
+              ) : reviewModel.length > 0 &&
+                catalogLoaded &&
+                reviewThinkingLevels.length === 0 ? (
+                <p className={ui.dialogNote}>
+                  Review effort (thinking) is unavailable — this model has no
+                  effort (thinking) options.
+                </p>
+              ) : (
+                <label className={ui.dialogField}>
+                  Review effort (thinking)
+                  <select
+                    className={ui.dialogInput}
+                    name="reviewThinkingLevel"
+                    value={reviewThinkingLevel}
+                    disabled={
+                      modelSelectDisabled ||
+                      draft.reviewSameAsBuild ||
+                      reviewModel.length === 0 ||
+                      reviewThinkingLevels.length === 0
+                    }
+                    onChange={(event) =>
+                      replaceDraft((current) =>
+                        current.reviewSameAsBuild
+                          ? current
+                          : {
+                              ...current,
+                              reviewThinkingLevel: event.target.value,
+                            },
+                      )
+                    }
+                  >
+                    <option value="">
+                      {draft.reviewSameAsBuild
+                        ? "Same as build"
+                        : "Model default"}
+                    </option>
+                    {hasCustomReviewVariant && (
+                      <option value={reviewThinkingLevel}>
+                        {formatUnavailableVariantLabel(reviewThinkingLevel)}
+                      </option>
+                    )}
+                    {reviewThinkingLevels.map((variant) => (
+                      <option key={`review-${variant}`} value={variant}>
+                        {formatVariantLabel(variant)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
+            </section>
+
+            <section
+              className={ui.dialogSection}
+              aria-labelledby="implement-with-options"
+            >
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id="implement-with-options"
+                  className={ui.dialogSectionTitle}
+                >
+                  Options
+                </h3>
+                <span className={ui.dialogSectionMeta}>This Work Item</span>
+              </div>
+              <label className={ui.dialogField}>
+                Merge Policy
+                <select
+                  name="mergePolicy"
+                  className={ui.dialogInput}
+                  value={mergePolicy}
+                  disabled={submitPending}
+                  onChange={(event) => {
+                    const next = event.target.value
+                    if (
+                      next === "OFF" ||
+                      next === "CLASSIFY" ||
+                      next === "ALWAYS"
+                    ) {
+                      setMergePolicy(next)
+                    }
+                  }}
+                >
+                  <option value="OFF">Off — human merge</option>
+                  <option value="CLASSIFY">
+                    Classify — risk-assessed merge
+                  </option>
+                  <option value="ALWAYS">Always — skip classify</option>
+                </select>
+                <span className={ui.dialogFieldHint}>
+                  Off requires a human merge. Classify runs Decide PR Merge.
+                  Always skips Classify and treats missing CI as green after the
+                  Check-Start Deadline. This pin stays on the Work Item even if
+                  Repository Merge Policy later changes.
+                </span>
+              </label>
+              {target === "leaf" && (
+                <label className={ui.dialogCheck}>
+                  <input
+                    type="checkbox"
+                    className={ui.dialogCheckInput}
+                    name="implementLocally"
+                    checked={implementLocally}
+                    disabled={submitPending}
+                    onChange={(event) =>
+                      setImplementLocally(event.target.checked)
+                    }
+                  />
+                  Implement locally
+                  <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                    Pause after Review so you can inspect the worktree. Agent
+                    Turns and dependency installation keep their current
+                    capabilities. Start continues to Commit and PR creation. A
+                    No-Change Outcome pauses before Close Issue.
+                  </span>
+                </label>
+              )}
+            </section>
+
+            {submitError !== null && (
+              <Banner
+                className={ui.bannerCompact}
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
+                {submitError}
+              </Banner>
+            )}
+          </div>
+          <div className={ui.dialogFooter}>
+            <button
+              type="button"
+              className={ui.plateMini}
+              onClick={onCancel}
+              disabled={submitPending}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className={ui.platePrimary}
+              aria-busy={submitPending || undefined}
+              disabled={implementDisabled}
+            >
+              {submitPending ? "Starting..." : "Implement"}
+            </button>
+          </div>
+        </form>
+      )}
     </ImplementWithModalDialog>
   )
 }

--- a/apps/harness/src/implement-with-issue-dialog.tsx
+++ b/apps/harness/src/implement-with-issue-dialog.tsx
@@ -12,11 +12,7 @@ import {
   usablePreviewCatalog,
 } from "./execution-profile-draft.js"
 import { createHarnessGraphqlClient } from "./harness-graphql.js"
-import {
-  ImplementWithDialog,
-  ImplementWithModalDialog,
-} from "./implement-with-dialog.js"
-import { ui } from "./ui.js"
+import { ImplementWithDialog } from "./implement-with-dialog.js"
 
 const graphql = createHarnessGraphqlClient({ batch: true })
 
@@ -191,34 +187,6 @@ export function ImplementWithIssueDialog({
     backendId === initialBackendId &&
     harnessPrefs.isPending &&
     harnessPrefs.data === undefined
-  if (firstPrefsPending) {
-    const loadingTitleId = `implement-with-loading-${issueNumber}`
-    return (
-      <ImplementWithModalDialog labelledBy={loadingTitleId} onCancel={onCancel}>
-        <div className={ui.dialogHeader}>
-          <p className={ui.dialogKicker}>Implement With</p>
-          <h2 id={loadingTitleId} className={ui.dialogTitle}>
-            {target === "parent"
-              ? "Implement all with..."
-              : `Implement issue #${issueNumber} with...`}
-          </h2>
-          <p className={ui.dialogLede}>
-            {target === "parent"
-              ? "These choices apply to each new child Work Item. They never change Repository settings or Harness Config."
-              : "These choices apply only to this Work Item. They never change Repository settings or Harness Config."}
-          </p>
-        </div>
-        <div className={ui.dialogBody}>
-          <p className={ui.dialogLoading}>Loading current preferences...</p>
-        </div>
-        <div className={ui.dialogFooter}>
-          <button type="button" className={ui.plateMini} onClick={onCancel}>
-            Cancel
-          </button>
-        </div>
-      </ImplementWithModalDialog>
-    )
-  }
 
   const emptyPrefs: ExecutionProfilePrefSource = {
     defaultModel: null,
@@ -257,6 +225,7 @@ export function ImplementWithIssueDialog({
       initialDraft={initialDraft}
       catalog={catalog}
       prefsError={prefsError}
+      preferencesLoading={firstPrefsPending}
       initialMergePolicy={initialMergePolicy}
       submitPending={submitPending}
       submitError={submitError}

--- a/apps/harness/src/session-usage-dialog.tsx
+++ b/apps/harness/src/session-usage-dialog.tsx
@@ -428,7 +428,7 @@ function AgentTurnTailPanel({
     )
   }
   return (
-    <ol className="m-0 grid max-h-64 list-none gap-2 overflow-y-auto p-0">
+    <ol className="m-0 grid max-h-64 list-none gap-2 overflow-y-auto overscroll-y-contain p-0">
       {data.items.map((item) => (
         <li
           key={`${item.__typename}-${item.at}-${item.__typename === "AgentTurnTailTool" ? item.name : item.text}`}

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -847,3 +847,18 @@
     background: var(--scrim);
   }
 }
+
+/*
+ * Document scroll lock follows native modal state (`dialog:modal`), not
+ * route state, so first-run Settings and Implement With stay locked.
+ * UA already sizes modal dialogs (`max-height` + `overflow: auto`).
+ * Overscroll containment stops wheel chaining at the panel boundary.
+ */
+html:has(dialog:modal) {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+dialog:modal {
+  overscroll-behavior: contain;
+}

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -416,7 +416,7 @@ export const ui = {
    * styles.css (`::backdrop { background: var(--scrim) }`).
    */
   dialogPanel:
-    "dialog-backdrop m-auto w-[min(92vw,32rem)] border-2 border-ink bg-paper p-0 text-ink shadow-none",
+    "dialog-backdrop m-auto w-[min(92vw,32rem)] overflow-y-auto overscroll-y-contain border-2 border-ink bg-paper p-0 text-ink shadow-none",
 
   dialogPanelNarrow: "w-[min(92vw,28rem)]",
 

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -225,6 +225,17 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).toContain('value="high"')
   })
 
+  test("preference loading keeps the dialog chrome and hides the form", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog {...baseProps} preferencesLoading />,
+    )
+    expect(html).toContain("Implement issue #1034 with...")
+    expect(html).toContain("Loading current preferences...")
+    expect(html).toContain(">Cancel<")
+    expect(html).not.toContain('name="agentBackend"')
+    expect(html).not.toContain(">Implement<")
+  })
+
   test("shows a Harness preference load failure without hiding the form", () => {
     const html = renderToStaticMarkup(
       <ImplementWithDialog
@@ -961,5 +972,15 @@ describe("Implement With preview query contract", () => {
     expect(preview).toContain("gcTime: 0")
     expect(source).toContain("implementWithSessionPreview")
     expect(source).toContain("isFetchedAfterMount")
+  })
+
+  test("keeps one modal mounted from preference loading through the form", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/implement-with-issue-dialog.tsx"),
+      "utf8",
+    )
+    expect(source).toContain("preferencesLoading={firstPrefsPending}")
+    expect(source).not.toContain("ImplementWithModalDialog")
+    expect(source).not.toContain("implement-with-loading-")
   })
 })

--- a/apps/harness/test/live-harness-seed.test.ts
+++ b/apps/harness/test/live-harness-seed.test.ts
@@ -1,4 +1,8 @@
 import {
+  IMPLEMENT_WITH_ISSUE_FIXTURE,
+  implementWithIssueFixturesArePresent,
+} from "../e2e/support/implement-with-issue-fixture.ts"
+import {
   CONTROL_FILES,
   type LiveHarnessState,
 } from "../e2e/support/live-harness-control.ts"
@@ -154,6 +158,42 @@ describe("sessionTelemetryFixturesArePresent", () => {
           .filter((item) => item.id !== TELEMETRY_FIXTURE.completedWorkItemId)
           .concat(fillers),
       ),
+    ).toBe(false)
+  })
+})
+
+describe("implementWithIssueFixturesArePresent", () => {
+  const leaf = {
+    id: IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueId,
+    issueNumber: IMPLEMENT_WITH_ISSUE_FIXTURE.leafIssueNumber,
+    hasChildren: false,
+    parent: null,
+  }
+  const parent = {
+    id: IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueId,
+    issueNumber: IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber,
+    hasChildren: true,
+    parent: null,
+  }
+  const child = {
+    id: IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueId,
+    issueNumber: IMPLEMENT_WITH_ISSUE_FIXTURE.childIssueNumber,
+    hasChildren: false,
+    parent: { issueNumber: IMPLEMENT_WITH_ISSUE_FIXTURE.parentIssueNumber },
+  }
+
+  test("requires the leaf and supported parent/child pair", () => {
+    expect(implementWithIssueFixturesArePresent([])).toBe(false)
+    expect(implementWithIssueFixturesArePresent([leaf, parent])).toBe(false)
+    expect(implementWithIssueFixturesArePresent([leaf, parent, child])).toBe(
+      true,
+    )
+    expect(
+      implementWithIssueFixturesArePresent([
+        leaf,
+        { ...parent, hasChildren: false },
+        child,
+      ]),
     ).toBe(false)
   })
 })

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -414,7 +414,16 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(styles).toContain("::backdrop")
     expect(styles).toContain("background: var(--scrim)")
     expect(ui).toMatch(/dialogPanel:[\s\S]*?dialog-backdrop/)
+    expect(ui).toMatch(/dialogPanel:[\s\S]*?overscroll-y-contain/)
     expect(root).toContain("ui.dialogPanel")
+    // Modal-aware document lock follows native :modal, not route state.
+    expect(styles).toContain("html:has(dialog:modal)")
+    expect(styles).toMatch(
+      /html:has\(dialog:modal\) \{\n {2}overflow: hidden;\n {2}overscroll-behavior: none;\n\}/,
+    )
+    expect(styles).toMatch(
+      /^dialog:modal \{\n {2}overscroll-behavior: contain;/m,
+    )
     // Ledger oxblood / elevated paper-2 palette is gone after phase 5 teardown.
     expect(styles).not.toContain("--paper-2:")
     expect(styles).not.toContain("--color-oxblood")


### PR DESCRIPTION
Wheel and trackpad input could still move the Harness behind an open dialog. Only the active dialog (and nested lists such as Agent Turn Tail) should scroll until it closes.

The lock follows native modal state (`html:has(dialog:modal)`), not the route, so first-run Settings and Implement With stay locked even when they never get a URL. Overscroll is contained on the shared panel and on `dialog:modal`. Implement With keeps one dialog mounted from preference loading through the form so the lock is not dropped on that swap. Failed Save and pending Save (including Back blocked while Saving…) keep the page locked.

UI-history browser coverage uses real wheel input with pointer placement: overflowing background before open and after close, backdrop and short-dialog cases, long Settings including boundary overscroll, nested Agent Turn Tail, first-run, leaf and parent Implement With without submitting work, Failed Save, pending Save, Forward/reopen, and a narrow viewport. Layout width is asserted in Chromium.

Limitations: this is CSS-only, so iOS pan-behind-modal is not separately proven. Classic scrollbars may still shift layout slightly; always-on gutter would inset the full-bleed chrome. Close-path coverage is representative (Cancel, Close, Back), not every Escape/Save/unmount combination.

Closes #1279