### PR TITLE
refactor: generate the three Forge kinds from the ontology

### DIFF
--- a/.agents/skills/ontology-change/SKILL.md
+++ b/.agents/skills/ontology-change/SKILL.md
@@ -15,6 +15,8 @@ Read `ontology/README.md` for the full model and diagrams before editing.
 
 - `packages/lifecycle-model/src/generated/work-item-state.ts`
   (state space, transition relation, and the complete `STEP_RUN_REASON` table)
+- `packages/lifecycle-model/src/generated/forge.ts`
+  (the three supported Forge kinds and `isForge`)
 - `packages/graphql-schema/src/type-defs.gen.ts`
 - Any state enum in `db-schema` or SDL that lists Work Item states — they
   import from `@ready-for-agent/lifecycle-model`.
@@ -38,6 +40,12 @@ Read `ontology/README.md` for the full model and diagrams before editing.
      (the runtime snake_case or kebab-case string) and one English
      `skos:definition`. `STEP_RUN_REASON` is generated from these
      individuals.
+   - Supported Forge kinds: declare each kind as an `rfa:Forge` individual
+     in `rfa.ttl` with one `skos:notation` (the runtime spelling) and one
+     English `skos:definition`. Keep `rfa:Forge owl:equivalentClass / owl:oneOf`
+     and `owl:AllDifferent` in exact parity with those individuals. Do not
+     add Repository selection properties. `FORGES` is generated from the
+     `owl:oneOf` list order. GraphQL `forge` stays a string.
 2. **Keep the glossary in parity.** If the term is (or becomes) a CONTEXT.md
    glossary entry, update the glossary in `CONTEXT.md` and mirror it in
    `ontology/context.ttl` (`rfa:ContextTerm` with matching

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,9 +48,10 @@ glossary are derived from a versioned ontology under `ontology/` (see
 `ontology/README.md`, `docs/adr/0044-ontology-derived-lifecycle-model.md`,
 and `docs/adr/0058-ontology-owns-step-run-reason-codes.md`). Domain changes
 start with an ontology edit and flow through codegen — never edit
-`packages/lifecycle-model/src/generated/work-item-state.ts` or the state
+`packages/lifecycle-model/src/generated/work-item-state.ts`,
+`packages/lifecycle-model/src/generated/forge.ts`, or the state
 enums directly. Use the `ontology-change` skill when adding or changing
-lifecycle states, transitions, Step Run reason codes, or glossary terms.
+lifecycle states, transitions, Step Run reason codes, Forge kinds, or glossary terms.
 
 <!-- effect-solutions:start -->
 

--- a/apps/harness/src/forge-change-request.ts
+++ b/apps/harness/src/forge-change-request.ts
@@ -3,7 +3,9 @@
  * Used on archive legs, PR badges, and aria-labels.
  */
 
-export type ForgeId = "github" | "gitlab" | "azure-devops"
+import { type Forge, isForge } from "@ready-for-agent/lifecycle-model"
+
+export type ForgeId = Forge
 
 /**
  * Azure DevOps uses GitHub's "pull request" terminology, so it maps onto the
@@ -11,14 +13,7 @@ export type ForgeId = "github" | "gitlab" | "azure-devops"
  * of silently inheriting the wrong noun.
  */
 export function normalizeForge(forge: string | undefined | null): ForgeId {
-  switch (forge) {
-    case "gitlab":
-      return "gitlab"
-    case "azure-devops":
-      return "azure-devops"
-    default:
-      return "github"
-  }
+  return isForge(forge) ? forge : "github"
 }
 
 /** Compact chip / badge token: "PR" (GitHub) or "MR" (GitLab). */

--- a/apps/harness/src/repositories-query.ts
+++ b/apps/harness/src/repositories-query.ts
@@ -6,6 +6,7 @@
  * without importing the home route.
  */
 
+import { type Forge, isForge } from "@ready-for-agent/lifecycle-model"
 import { createHarnessGraphqlClient } from "./harness-graphql.js"
 
 const graphql = createHarnessGraphqlClient({ batch: true })
@@ -17,7 +18,7 @@ type RepositoryCredential = {
   githubTokenCreationUrl: string
 }
 
-export type Forge = "github" | "gitlab" | "azure-devops"
+export type { Forge }
 
 const FORGE_DISPLAY_NAMES: Record<Forge, string> = {
   github: "GitHub",
@@ -42,14 +43,10 @@ export const ciGateStatusLabel = (status: RepositoryCiGateStatus): string => {
 }
 
 export const decodeForge = (value: unknown): Forge => {
-  switch (value) {
-    case "github":
-    case "gitlab":
-    case "azure-devops":
-      return value
-    default:
-      throw new Error(`Unsupported Forge: ${String(value)}`)
+  if (isForge(value)) {
+    return value
   }
+  throw new Error(`Unsupported Forge: ${String(value)}`)
 }
 
 type CiGateDefinition = {

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -1,4 +1,5 @@
 import { isKeymaxxerAvailable } from "@ready-for-agent/keymaxxer-service"
+import { FORGES, type Forge, isForge } from "@ready-for-agent/lifecycle-model"
 
 type HostTool = {
   readonly name: string
@@ -37,7 +38,7 @@ const AZURE_DEVOPS_ENV_REQUIREMENT: HostTool = {
     "Set the AZURE_DEVOPS_EXT_PAT environment variable to an Azure DevOps Personal Access Token: https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate — required scopes (Merge PR needs more than git + Create PR): https://github.com/berenddeboer/ready-for-agent/blob/main/docs/forge-token-scopes.md",
 }
 
-type RepositoryForge = "github" | "gitlab" | "azure-devops"
+type RepositoryForge = Forge
 
 export type HostToolsPreflightOptions = {
   /**
@@ -66,17 +67,12 @@ export type HostToolsPreflightResult =
       readonly message: string
     }
 
-const isRepositoryForge = (value: string): value is RepositoryForge =>
-  value === "github" || value === "gitlab" || value === "azure-devops"
-
 const resolveRepositoryForges = (
   options: HostToolsPreflightOptions,
 ): ReadonlyArray<RepositoryForge> => {
   const raw = options.repositoryForges ?? ["github"]
-  const selected = new Set(raw.filter(isRepositoryForge))
-  return (["github", "gitlab", "azure-devops"] as const).filter((forge) =>
-    selected.has(forge),
-  )
+  const selected = new Set(raw.filter(isForge))
+  return FORGES.filter((forge) => selected.has(forge))
 }
 
 const cliToolForForge = (forge: RepositoryForge): HostTool | undefined => {

--- a/apps/ready-for-agent/src/peek-repository-forges.ts
+++ b/apps/ready-for-agent/src/peek-repository-forges.ts
@@ -1,3 +1,4 @@
+import { FORGES, type Forge, isForge } from "@ready-for-agent/lifecycle-model"
 import { Database } from "bun:sqlite"
 
 const resolveFilePath = (databasePath: string): string | undefined => {
@@ -16,16 +17,7 @@ const resolveFilePath = (databasePath: string): string | undefined => {
       : databasePath
 }
 
-export type RepositoryForge = "github" | "gitlab" | "azure-devops"
-
-const REPOSITORY_FORGES: ReadonlyArray<RepositoryForge> = [
-  "github",
-  "gitlab",
-  "azure-devops",
-]
-
-const isRepositoryForge = (value: string): value is RepositoryForge =>
-  value === "github" || value === "gitlab" || value === "azure-devops"
+export type RepositoryForge = Forge
 
 /** HTTPS endpoint a cold-start TLS preflight should probe. */
 export type ForgeApiEndpoint = {
@@ -90,11 +82,11 @@ export const peekRepositoryForges = (
           .values()
         const found = new Set<RepositoryForge>()
         for (const [forge] of rows) {
-          if (typeof forge === "string" && isRepositoryForge(forge)) {
+          if (typeof forge === "string" && isForge(forge)) {
             found.add(forge)
           }
         }
-        return REPOSITORY_FORGES.filter((forge) => found.has(forge))
+        return FORGES.filter((candidate) => found.has(candidate))
       } catch {
         const count = db
           .query(`SELECT COUNT(*) AS count FROM repository`)
@@ -164,9 +156,11 @@ export const peekForgeApiEndpoints = (
         const gitlabHosts = new Set<string>()
         for (const [forge, forgeHost] of rows) {
           // `forge` is untyped external data (a raw distinct DB column
-          // value); unrecognized/legacy values are safely ignored rather
-          // than exhaustively type-checked (that guard lives at
-          // isRepositoryForge, the boundary parser above).
+          // value). Unrecognized/legacy values are ignored by isForge;
+          // the switch is exhaustive over the remaining supported kinds.
+          if (typeof forge !== "string" || !isForge(forge)) {
+            continue
+          }
           switch (forge) {
             case "github":
               hasGitHub = true
@@ -182,8 +176,10 @@ export const peekForgeApiEndpoints = (
             case "azure-devops":
               hasAzureDevOps = true
               break
-            default:
-              break
+            default: {
+              const _exhaustive: never = forge
+              throw new Error(`Unsupported Forge: ${String(_exhaustive)}`)
+            }
           }
         }
         if (hasGitHub) {

--- a/bun.lock
+++ b/bun.lock
@@ -214,6 +214,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@ready-for-agent/agent-backend": "workspace:*",
+        "@ready-for-agent/lifecycle-model": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
         "ulidx": "^2.4.1",
@@ -364,6 +365,7 @@
       "name": "@ready-for-agent/local-git",
       "version": "0.0.1",
       "dependencies": {
+        "@ready-for-agent/lifecycle-model": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
       },

--- a/ontology/README.md
+++ b/ontology/README.md
@@ -43,7 +43,7 @@ flowchart LR
 
   subgraph lm["packages/lifecycle-model"]
     gen["scripts/generate-lifecycle-state.ts<br/>(n3 Turtle parser)"]
-    generated["src/generated/work-item-state.ts<br/>Effect Schema literals +<br/>STEP_RUN_REASON +<br/>LIFECYCLE_TRANSITIONS +<br/>isDeclaredLifecycleTransition"]
+    generated["src/generated/work-item-state.ts<br/>+ forge.ts<br/>Effect Schema literals +<br/>STEP_RUN_REASON +<br/>FORGES +<br/>LIFECYCLE_TRANSITIONS"]
     tests["test/ontology.test.ts<br/>SHACL validation, OWL consistency,<br/>CONTEXT.md parity"]
   end
 
@@ -65,7 +65,8 @@ flowchart LR
 ```
 
 The generator (`bunx nx run lifecycle-model:generate`) parses `rfa.ttl` and
-emits `packages/lifecycle-model/src/generated/work-item-state.ts`:
+emits `packages/lifecycle-model/src/generated/work-item-state.ts` and
+`packages/lifecycle-model/src/generated/forge.ts`:
 
 - `OPERATIONAL_LIFECYCLE_STEPS` and `TERMINAL_WORK_ITEM_STATES` — the state
   space, keyed by each term's `skos:notation` (the runtime string, e.g.
@@ -73,6 +74,9 @@ emits `packages/lifecycle-model/src/generated/work-item-state.ts`:
 - `WorkItemState` — an Effect `Schema.Literals` union over both.
 - `STEP_RUN_REASONS` / `STEP_RUN_REASON` — every `rfa:StepRunReason`
   (`skos:notation` plus camelCase accessor), the complete harness vocabulary.
+- `FORGES` / `Forge` / `isForge` — the three supported Forge kinds
+  (`github`, `gitlab`, `azure-devops`) from `rfa:Forge` `owl:oneOf`, in
+  declared order. GraphQL keeps the existing string wire contract.
 - `LIFECYCLE_TRANSITIONS` — every declared `rfa:Transition` as queryable data
   (`from`, `to`, `guard`, `reasonCode`).
 - `isDeclaredLifecycleTransition(from, to)` — membership in the declared

--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -14,7 +14,7 @@
     "The Ready for Agent domain vocabulary and Work Item lifecycle model."@en ;
   dcterms:source
     <https://github.com/berenddeboer/ready-for-agent/blob/main/CONTEXT.md> ;
-  owl:versionInfo "0.6.0" .
+  owl:versionInfo "0.7.0" .
 
 rfa:ContextTerm
   a owl:Class ;
@@ -890,6 +890,36 @@ rfa:MergeModeAlways
   a owl:Class ;
   rdfs:subClassOf rfa:MergeMode ;
   owl:equivalentClass rfa:MergePolicyAlways .
+
+# Existing supported Forge kinds. Runtime spellings are skos:notation.
+# Completeness is owl:oneOf in this order; kinds are pairwise distinct.
+# Do not add Repository selection properties here — a Repository still
+# selects exactly one Forge in the existing application model.
+rfa:Forge
+  owl:equivalentClass [
+    owl:oneOf ( rfa:GitHub rfa:GitLab rfa:AzureDevOps )
+  ] .
+
+rfa:GitHub
+  a rfa:Forge ;
+  skos:notation "github" ;
+  skos:definition
+    "The GitHub Forge kind: git hosting, Issues, and Pull Requests for a Repository. Runtime spelling github."@en .
+
+rfa:GitLab
+  a rfa:Forge ;
+  skos:notation "gitlab" ;
+  skos:definition
+    "The GitLab Forge kind: git hosting, Issues, and Pull Requests for a Repository. Runtime spelling gitlab."@en .
+
+rfa:AzureDevOps
+  a rfa:Forge ;
+  skos:notation "azure-devops" ;
+  skos:definition
+    "The Azure DevOps Forge kind: git hosting, Issues, and Pull Requests for a Repository. Runtime spelling azure-devops."@en .
+
+[] a owl:AllDifferent ;
+  owl:distinctMembers ( rfa:GitHub rfa:GitLab rfa:AzureDevOps ) .
 
 rfa:StepRun
   rdfs:subClassOf

--- a/ontology/shapes.ttl
+++ b/ontology/shapes.ttl
@@ -131,6 +131,26 @@ rfa:StepRunReasonShape
     sh:message "A Step Run reason must have one English definition."@en ;
   ] .
 
+rfa:ForgeKindShape
+  a sh:NodeShape ;
+  sh:targetClass rfa:Forge ;
+  sh:property [
+    sh:path skos:notation ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+    sh:minLength 1 ;
+    sh:message "A Forge kind must have one runtime notation."@en ;
+  ] ;
+  sh:property [
+    sh:path skos:definition ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:languageIn ("en") ;
+    sh:uniqueLang true ;
+    sh:message "A Forge kind must have one English definition."@en ;
+  ] .
+
 rfa:OperationalLifecycleStepShape
   a sh:NodeShape ;
   sh:targetClass rfa:OperationalLifecycleStep ;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -8,6 +8,7 @@ import {
 } from "drizzle-orm/sqlite-core"
 import { ulid } from "ulidx"
 import {
+  FORGES,
   OPERATIONAL_LIFECYCLE_STEPS,
   WORK_ITEM_STATES,
 } from "@ready-for-agent/lifecycle-model"
@@ -18,9 +19,7 @@ export const repository = snakeCase.table(
     id: text()
       .primaryKey()
       .$defaultFn(() => `repo-${ulid()}`),
-    forge: text({ enum: ["github", "gitlab", "azure-devops"] })
-      .notNull()
-      .default("github"),
+    forge: text({ enum: FORGES }).notNull().default("github"),
     forgeHost: text().notNull().default("github.com"),
     projectPath: text().notNull(),
     localPath: text().notNull().unique(),

--- a/packages/db-service/package.json
+++ b/packages/db-service/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@ready-for-agent/agent-backend": "workspace:*",
+    "@ready-for-agent/lifecycle-model": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0",
     "ulidx": "^2.4.1"

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -1,4 +1,7 @@
 import { Schema } from "effect"
+import { Forge } from "@ready-for-agent/lifecycle-model"
+
+export { Forge }
 
 export const RepositoryId = Schema.String.pipe(
   Schema.check(Schema.isPattern(/^repo-[0-9A-HJKMNP-TV-Z]{26}$/)),
@@ -11,9 +14,6 @@ const SqlBoolean = Schema.Union([Schema.Boolean, Schema.BooleanFromBit])
 
 export const IssueState = Schema.Literals(["OPEN", "CLOSED"])
 export type IssueState = typeof IssueState.Type
-
-export const Forge = Schema.Literals(["github", "gitlab", "azure-devops"])
-export type Forge = typeof Forge.Type
 
 export const MergePolicy = Schema.Literals(["off", "classify", "always"])
 export type MergePolicy = typeof MergePolicy.Type

--- a/packages/db-service/tsconfig.lib.json
+++ b/packages/db-service/tsconfig.lib.json
@@ -14,6 +14,9 @@
       "path": "../agent-backend/tsconfig.lib.json"
     },
     {
+      "path": "../lifecycle-model/tsconfig.lib.json"
+    },
+    {
       "path": "../db/tsconfig.lib.json"
     }
   ]

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -555,7 +555,7 @@ const resolveRepositoryCiGateSelection = Effect.fn(
 const verifyRepositoryIdentity = Effect.fn(
   "graphql-api.verifyRepositoryIdentity",
 )(function* (identity: {
-  readonly forge: "github" | "gitlab" | "azure-devops"
+  readonly forge: Forge
   readonly forgeHost: string
   readonly projectPath: string
 }) {

--- a/packages/lifecycle-model/project.json
+++ b/packages/lifecycle-model/project.json
@@ -14,6 +14,7 @@
       "inputs": ["default", "{workspaceRoot}/ontology/rfa.ttl"],
       "outputs": [
         "{projectRoot}/src/generated/work-item-state.ts",
+        "{projectRoot}/src/generated/forge.ts",
         "{projectRoot}/src/generated/predicate-expressions.ts"
       ],
       "cache": false

--- a/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
+++ b/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
@@ -22,12 +22,14 @@ const owlEquivalentClass = iri(`${namespace.owl}equivalentClass`)
 const owlHasValue = iri(`${namespace.owl}hasValue`)
 const owlIntersectionOf = iri(`${namespace.owl}intersectionOf`)
 const owlOnProperty = iri(`${namespace.owl}onProperty`)
+const owlOneOf = iri(`${namespace.owl}oneOf`)
 const owlSomeValuesFrom = iri(`${namespace.owl}someValuesFrom`)
 const owlUnionOf = iri(`${namespace.owl}unionOf`)
 const skosNotation = iri(`${namespace.skos}notation`)
 const skosDefinition = iri(`${namespace.skos}definition`)
 const operationalLifecycleStep = term("OperationalLifecycleStep")
 const terminalWorkItemState = term("TerminalWorkItemState")
+const forgeClass = term("Forge")
 const stepRunReasonClass = term("StepRunReason")
 const transitionClass = term("Transition")
 const fromStep = term("fromStep")
@@ -43,6 +45,7 @@ const xsdDayTimeDuration = iri(`${namespace.xsd}dayTimeDuration`)
 const packageRoot = resolve(import.meta.dir, "..")
 const ontologyPath = resolve(packageRoot, "../../ontology/rfa.ttl")
 const generatedPath = resolve(packageRoot, "src/generated/work-item-state.ts")
+const generatedForgePath = resolve(packageRoot, "src/generated/forge.ts")
 const generatedPredicatePath = resolve(
   packageRoot,
   "src/generated/predicate-expressions.ts",
@@ -431,6 +434,50 @@ const notationsForClass = (
   return values
 }
 
+const forgeKinds = (store: Store): readonly string[] => {
+  const equivalent = onlyObject(store, forgeClass, owlEquivalentClass)
+  const listHead = onlyObject(store, equivalent, owlOneOf)
+  const members = rdfList(store, listHead)
+  if (members.length === 0) {
+    throw new Error("rfa:Forge owl:oneOf must declare at least one kind")
+  }
+
+  const memberIris = members.map((member) => {
+    if (member.termType !== "NamedNode") {
+      throw new Error(
+        `rfa:Forge owl:oneOf member must be an IRI: ${member.value}`,
+      )
+    }
+    if (store.countQuads(member, rdfType, forgeClass, null) !== 1) {
+      throw new Error(
+        `${member.value} is in rfa:Forge owl:oneOf but is not typed as rfa:Forge`,
+      )
+    }
+    return member
+  })
+
+  const typed = store.getSubjects(rdfType, forgeClass, null)
+  const expected = new Set(memberIris.map((member) => member.value))
+  const actual = new Set(typed.map((subject) => subject.value))
+  if (
+    expected.size !== actual.size ||
+    [...expected].some((iriValue) => !actual.has(iriValue))
+  ) {
+    throw new Error(
+      "rfa:Forge individuals must be exactly the owl:oneOf members",
+    )
+  }
+
+  const values = memberIris.map((member) => onlyNotation(store, member))
+  const sorted = [...values].sort()
+  const duplicate = sorted.find((value, index) => value === sorted[index - 1])
+  if (duplicate !== undefined) {
+    throw new Error(`Duplicate Forge notation: ${duplicate}`)
+  }
+
+  return values
+}
+
 interface GeneratedStepRunReason {
   readonly key: string
   readonly notation: string
@@ -601,6 +648,20 @@ ${values.map((value) => `  ${JSON.stringify(value)},`).join("\n")}
 ] as const
 `
 
+const renderForgeSource = (values: readonly string[]) => `\
+// This file is generated from ontology/rfa.ttl.
+// Run \`bunx nx run lifecycle-model:generate\` to update it.
+
+import { Schema } from "effect"
+
+${renderTuple("FORGES", values)}
+export const Forge = Schema.Literals(FORGES)
+export type Forge = typeof Forge.Type
+
+export const isForge = (value: unknown): value is Forge =>
+  FORGES.some((forge) => forge === value)
+`
+
 const renderTransitions = (values: readonly GeneratedTransition[]) => `\
 export interface LifecycleTransition {
   readonly from: WorkItemState
@@ -739,6 +800,7 @@ const generate = async () => {
       ),
       lifecycleStepProperties,
     ),
+    forgeSource: renderForgeSource(forgeKinds(ontology)),
     predicateSource: renderPredicateExpressions(predicateExpressions(ontology)),
   }
 }
@@ -755,12 +817,15 @@ if (unknownArguments.length > 0) {
 const generated = await generate()
 
 if (check) {
-  const [checkedInStateSource, checkedInPredicateSource] = await Promise.all([
-    readFile(generatedPath, "utf8").catch(() => ""),
-    readFile(generatedPredicatePath, "utf8").catch(() => ""),
-  ])
+  const [checkedInStateSource, checkedInForgeSource, checkedInPredicateSource] =
+    await Promise.all([
+      readFile(generatedPath, "utf8").catch(() => ""),
+      readFile(generatedForgePath, "utf8").catch(() => ""),
+      readFile(generatedPredicatePath, "utf8").catch(() => ""),
+    ])
   if (
     checkedInStateSource !== generated.stateSource ||
+    checkedInForgeSource !== generated.forgeSource ||
     checkedInPredicateSource !== generated.predicateSource
   ) {
     console.error(
@@ -771,10 +836,12 @@ if (check) {
 } else {
   await Promise.all([
     mkdir(dirname(generatedPath), { recursive: true }),
+    mkdir(dirname(generatedForgePath), { recursive: true }),
     mkdir(dirname(generatedPredicatePath), { recursive: true }),
   ])
   await Promise.all([
     writeFile(generatedPath, generated.stateSource),
+    writeFile(generatedForgePath, generated.forgeSource),
     writeFile(generatedPredicatePath, generated.predicateSource),
   ])
 }

--- a/packages/lifecycle-model/src/generated/forge.ts
+++ b/packages/lifecycle-model/src/generated/forge.ts
@@ -1,0 +1,16 @@
+// This file is generated from ontology/rfa.ttl.
+// Run `bunx nx run lifecycle-model:generate` to update it.
+
+import { Schema } from "effect"
+
+export const FORGES = [
+  "github",
+  "gitlab",
+  "azure-devops",
+] as const
+
+export const Forge = Schema.Literals(FORGES)
+export type Forge = typeof Forge.Type
+
+export const isForge = (value: unknown): value is Forge =>
+  FORGES.some((forge) => forge === value)

--- a/packages/lifecycle-model/src/index.ts
+++ b/packages/lifecycle-model/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./generated/forge.js"
 export * from "./generated/work-item-state.js"
 export * from "./intake-candidates.js"
 export * from "./predicates.js"

--- a/packages/lifecycle-model/src/predicates.ts
+++ b/packages/lifecycle-model/src/predicates.ts
@@ -1,3 +1,4 @@
+import type { Forge } from "./generated/forge.js"
 import {
   type LifecyclePredicateName,
   matchesLifecyclePredicateExpression,
@@ -48,7 +49,7 @@ export interface PendingSelfOwnership {
 }
 
 export interface RelevantIssuePredicateContext {
-  readonly forge: string
+  readonly forge: Forge
   readonly repositoryName: string
   readonly workItemPullRequestNumbers: ReadonlySet<number>
   readonly pendingSelfOwnership?: readonly PendingSelfOwnership[]
@@ -60,11 +61,10 @@ export interface RelevantIssuePredicateContext {
 /**
  * Forges with no native sub-Issue hierarchy queried by this harness, so a
  * Ready Issue reporting `hierarchySupported: false` is expected rather than
- * anomalous. `forge` stays `string` here (this module has no Forge union of
- * its own to stay decoupled from `db-service`); kept as a Set so a third
- * such Forge is a one-line addition instead of another inline comparison.
+ * anomalous. Kept as a Set so a third such Forge is a one-line addition
+ * instead of another inline comparison.
  */
-const FORGES_WITHOUT_HIERARCHY_SUPPORT: ReadonlySet<string> = new Set([
+const FORGES_WITHOUT_HIERARCHY_SUPPORT: ReadonlySet<Forge> = new Set([
   "gitlab",
   "azure-devops",
 ])
@@ -304,7 +304,7 @@ export const evaluateActionableIssue = (
 
 const activeClosingPullRequest = (
   pullRequest: ClosingPullRequestPredicateShape,
-  forge: string,
+  forge: Forge,
   issueState: string,
 ): boolean => {
   if (pullRequest.state === "OPEN") {

--- a/packages/lifecycle-model/test/forge.test.ts
+++ b/packages/lifecycle-model/test/forge.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { FORGES, isForge } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("generated Forge vocabulary", () => {
+  it("exports exactly the existing three runtime spellings in declared order", () => {
+    expect([...FORGES]).toEqual(["github", "gitlab", "azure-devops"])
+  })
+
+  it("accepts the supported kinds and rejects unknown spellings", () => {
+    expect(isForge("github")).toBe(true)
+    expect(isForge("gitlab")).toBe(true)
+    expect(isForge("azure-devops")).toBe(true)
+    expect(isForge("bitbucket")).toBe(false)
+    expect(isForge("GitHub")).toBe(false)
+    expect(isForge("")).toBe(false)
+    expect(isForge(undefined)).toBe(false)
+  })
+
+  it("keeps generated runtime free of RDF tooling", () => {
+    const source = readFileSync(
+      resolve(import.meta.dir, "../src/generated/forge.ts"),
+      "utf8",
+    )
+    expect(source.includes('from "n3"')).toBe(false)
+    expect(source.includes("rdf-validate-shacl")).toBe(false)
+  })
+})

--- a/packages/lifecycle-model/test/ontology.test.ts
+++ b/packages/lifecycle-model/test/ontology.test.ts
@@ -36,6 +36,9 @@ const owlAnnotatedTarget = iri(`${namespace.owl}annotatedTarget`)
 const owlAxiom = iri(`${namespace.owl}Axiom`)
 const owlDisjointWith = iri(`${namespace.owl}disjointWith`)
 const owlEquivalentClass = iri(`${namespace.owl}equivalentClass`)
+const owlOneOf = iri(`${namespace.owl}oneOf`)
+const owlAllDifferent = iri(`${namespace.owl}AllDifferent`)
+const owlDistinctMembers = iri(`${namespace.owl}distinctMembers`)
 const owlMembers = iri(`${namespace.owl}members`)
 const owlNamedIndividual = iri(`${namespace.owl}NamedIndividual`)
 const owlObjectProperty = iri(`${namespace.owl}ObjectProperty`)
@@ -53,6 +56,7 @@ const shPath = iri(`${namespace.sh}path`)
 
 const operationalClass = term("OperationalLifecycleStep")
 const terminalClass = term("TerminalWorkItemState")
+const forgeClass = term("Forge")
 const contextTermClass = term("ContextTerm")
 const avoidanceRationale = term("avoidanceRationale")
 const maximumDuration = term("maximumDuration")
@@ -175,6 +179,16 @@ const expectedStateIris = [
   ...Object.keys(expectedOperationalTerms),
   ...Object.keys(expectedTerminalTerms),
 ].map((localName) => `${namespace.rfa}${localName}`)
+
+const expectedForgeTerms = {
+  GitHub: "github",
+  GitLab: "gitlab",
+  AzureDevOps: "azure-devops",
+} as const
+
+const expectedForgeIris = Object.keys(expectedForgeTerms).map(
+  (localName) => `${namespace.rfa}${localName}`,
+)
 
 const parseTurtle = (path: string) => {
   const source = readFileSync(path, "utf8")
@@ -656,6 +670,46 @@ describe("full vocabulary semantic distinctions", () => {
         null,
       ),
     ).toBe(1)
+  })
+
+  it("declares exactly the three supported Forge kinds with stable runtime notations", () => {
+    const actualTerms = ontology.getSubjects(rdfType, forgeClass, null)
+    expectExactIris(actualTerms, expectedForgeIris)
+
+    for (const [localName, notation] of Object.entries(expectedForgeTerms)) {
+      const subject = term(localName)
+      expect(ontology.countQuads(subject, rdfType, forgeClass, null)).toBe(1)
+
+      const actualNotation = getOnlyLiteral(ontology, subject, skosNotation)
+      expect(actualNotation.value).toBe(notation)
+
+      const definition = getOnlyLiteral(ontology, subject, skosDefinition)
+      expect(definition.language).toBe("en")
+      expect(definition.value.length).toBeGreaterThan(20)
+    }
+  })
+
+  it("proves the Forge kind vocabulary is complete and pairwise distinct", () => {
+    const equivalent = getOnlyObject(ontology, forgeClass, owlEquivalentClass)
+    const oneOf = getOnlyObject(ontology, equivalent, owlOneOf)
+    expectExactIris(readRdfList(ontology, oneOf), expectedForgeIris)
+
+    const oneOfOrder = readRdfList(ontology, oneOf).map(({ value }) => value)
+    expect(oneOfOrder).toEqual(expectedForgeIris)
+
+    const hasExactAllDifferent = ontology
+      .getSubjects(rdfType, owlAllDifferent, null)
+      .some((axiom) => {
+        const members = getOnlyObject(ontology, axiom, owlDistinctMembers)
+        const actual = readRdfList(ontology, members)
+          .map(({ value }) => value)
+          .sort()
+        return (
+          JSON.stringify(actual) ===
+          JSON.stringify([...expectedForgeIris].sort())
+        )
+      })
+    expect(hasExactAllDifferent).toBe(true)
   })
 
   it("attributes outcomes to an Agent Backend or the Harness", () => {

--- a/packages/local-git/package.json
+++ b/packages/local-git/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
+    "@ready-for-agent/lifecycle-model": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0"
   },

--- a/packages/local-git/src/lib/types.ts
+++ b/packages/local-git/src/lib/types.ts
@@ -1,5 +1,7 @@
+import type { Forge } from "@ready-for-agent/lifecycle-model"
+
 export interface LocalRepository {
-  readonly forge: "github" | "gitlab" | "azure-devops"
+  readonly forge: Forge
   readonly forgeHost: string
   readonly projectPath: string
   readonly localPath: string
@@ -13,7 +15,7 @@ export type GitHubRemote = {
 }
 
 export type ForgeRemote = {
-  readonly forge: "github" | "gitlab" | "azure-devops"
+  readonly forge: Forge
   readonly forgeHost: string
   readonly projectPath: string
 }

--- a/packages/local-git/tsconfig.lib.json
+++ b/packages/local-git/tsconfig.lib.json
@@ -9,5 +9,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../lifecycle-model/tsconfig.lib.json"
+    }
+  ]
 }

--- a/packages/work-item-lifecycle/src/lib/agent-turn-forge-auth.ts
+++ b/packages/work-item-lifecycle/src/lib/agent-turn-forge-auth.ts
@@ -18,6 +18,7 @@ import {
   gitlabVaultAccount,
 } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
 import {
   CurrentCapturedAgentBackendId,
   CurrentStepRun,
@@ -36,9 +37,7 @@ export type AgentTurnForgeAuth =
  * the three Forges so a new Forge fails to compile here instead of silently
  * mislabeling itself as one of the other two.
  */
-export const forgeDisplayName = (
-  forge: "github" | "gitlab" | "azure-devops",
-): string => {
+export const forgeDisplayName = (forge: Forge): string => {
   switch (forge) {
     case "github":
       return "GitHub"
@@ -54,7 +53,7 @@ export const forgeDisplayName = (
 }
 
 export type AgentTurnForgeRepository = {
-  readonly forge: "github" | "gitlab" | "azure-devops"
+  readonly forge: Forge
   readonly forgeHost: string
   readonly projectPath: string
 }
@@ -110,7 +109,7 @@ export const isAgentTurnKeymaxxerEffective = (
 ): boolean => keymaxxerMcpSupported && keymaxxerEnabled !== false
 
 const resolveAgentTurnKeymaxxerAuth = (input: {
-  readonly provider: "github" | "gitlab" | "azure-devops"
+  readonly provider: Forge
   readonly account: string
   readonly credentialDescription: string
   /**

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -18,6 +18,7 @@ import {
   workflowNameFromCheckName,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
 import {
   AgentTurnForgeCredentialMissingError,
   InvalidCapturedAgentBackendError,
@@ -721,7 +722,7 @@ export const formatDiagnosticBlock = (
 }
 
 const buildInvestigationWorkPrompt = (
-  forge: "github" | "gitlab" | "azure-devops",
+  forge: Forge,
   checks: readonly ObservedPrStatusCheckRow[],
   diagnostics: readonly PrStatusCheckDiagnostic[],
 ): string => {
@@ -786,7 +787,7 @@ const buildInvestigationWorkPrompt = (
 
 /** Shared outcome contract for status-check work, recovery, and fallback. */
 const investigationOutcomeContractLines = (
-  forge: "github" | "gitlab" | "azure-devops" = "github",
+  forge: Forge = "github",
 ): readonly string[] => [
   "You may include a concise work and verification summary before the result line.",
   "End your final response with exactly one machine-readable result line:",
@@ -810,7 +811,7 @@ const investigationOutcomeContractLines = (
 ]
 
 const buildInvestigationOutcomeFallbackPrompt = (
-  forge: "github" | "gitlab" | "azure-devops" = "github",
+  forge: Forge = "github",
 ): string =>
   [
     "Based only on the PR status-check work you just did in this session, report the outcome.",
@@ -821,7 +822,7 @@ const buildInvestigationOutcomeFallbackPrompt = (
 /** Recovery prompt after a FAILED investigation outcome (exported for tests). */
 export const buildInvestigationRecoveryPrompt = (
   reason: string,
-  forge: "github" | "gitlab" | "azure-devops" = "github",
+  forge: Forge = "github",
 ): string =>
   [
     "Make one focused recovery attempt to process the PR Status Check Handoff.",

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -1,6 +1,7 @@
 import { Effect, Schema } from "effect"
 import { AgentBackend, agentBackendLabel } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
 import {
   type AgentTurnForgeAuth,
   AgentTurnForgeCredentialMissingError,
@@ -75,9 +76,7 @@ const mergeConflictOutcomeContractLines = (): readonly string[] => [
   "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <concise reason>",
 ]
 
-const forgeFetchPushAccessScope = (
-  forge: "github" | "gitlab" | "azure-devops",
-): string => {
+const forgeFetchPushAccessScope = (forge: Forge): string => {
   switch (forge) {
     case "github":
       return "GitHub CLI, API, fetch, or push access"


### PR DESCRIPTION
The three supported Forge kinds (`github`, `gitlab`, `azure-devops`) were copied independently across the database schema, Effect schemas, CLI preflight, UI decode, local-git types, and lifecycle code. Those lists could drift while the ontology only described them in glossary prose.

This change makes the ontology the single source of those runtime spellings and generates the shared type, schema, and membership check from them. Production consumers now use that generated vocabulary instead of repeating the three-kind union. GraphQL still exposes Forge as a string. Repository identity, case handling, host/project validation, available providers, UI labels, and persisted values are unchanged. This does not introduce Code Host, Issue Source, Workspace, or any other split of Forge into new roles.

Ontology checks prove the vocabulary is exactly those three kinds and pairwise distinct; codegen drift detection covers the generated artifact. Nx checks for lifecycle-model, local-git, and db-service passed, along with CLI preflight/peek, UI decode/labels, GraphQL API, issue reconciliation, and PR status-check suites.

See #1286.

Closes #1286