### PR TITLE
refactor: route reconcile and Close Issue through one Forge contract

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -229,6 +229,8 @@
       "name": "@ready-for-agent/forge-contract",
       "version": "0.0.1",
       "dependencies": {
+        "@ready-for-agent/lifecycle-model": "workspace:*",
+        "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
       },
       "devDependencies": {

--- a/packages/azure-devops-service/src/lib/azure-devops-service.ts
+++ b/packages/azure-devops-service/src/lib/azure-devops-service.ts
@@ -2,6 +2,7 @@ import { Context, type Effect } from "effect"
 import type {
   CiGateCatalogEntry,
   CiGateObservation,
+  ForgeIssueOperations,
   MergePullRequestOptions,
   MergePullRequestResult,
   ObserveCiGateInput,
@@ -35,7 +36,8 @@ export type AzureDevOpsServiceError =
  * are local credential checks, and only `countOpenNonDraftPullRequests`
  * still fails with `AzureDevOpsNotImplementedError` (see method-level docs).
  */
-export interface AzureDevOpsServiceShape {
+export interface AzureDevOpsServiceShape
+  extends ForgeIssueOperations<AzureDevOpsServiceError> {
   /**
    * Verify Organization + Project against Azure DevOps before persistence
    * (`GET _apis/projects/{project}`), then the Git repository itself

--- a/packages/azure-devops-service/src/lib/types.ts
+++ b/packages/azure-devops-service/src/lib/types.ts
@@ -1,4 +1,7 @@
-import type { ReadyLabeledIssue } from "@ready-for-agent/forge-contract"
+import type {
+  ForgeRepository,
+  ReadyLabeledIssue,
+} from "@ready-for-agent/forge-contract"
 
 /**
  * Forge-neutral CI Gate catalog kind for an Azure DevOps build pipeline.
@@ -6,9 +9,7 @@ import type { ReadyLabeledIssue } from "@ready-for-agent/forge-contract"
  */
 export const AZURE_DEVOPS_CI_GATE_KIND = "build-pipeline"
 
-export interface AzureDevOpsRepository {
-  readonly forge: string
-  readonly forgeHost: string
+export interface AzureDevOpsRepository extends ForgeRepository {
   /**
    * `<organization>/<project>` or, when the Git repository name differs from
    * the ADO project name, `<organization>/<project>/<repository>` — Azure

--- a/packages/forge-contract/package.json
+++ b/packages/forge-contract/package.json
@@ -16,6 +16,8 @@
     }
   },
   "dependencies": {
+    "@ready-for-agent/lifecycle-model": "workspace:*",
+    "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/forge-contract/src/index.ts
+++ b/packages/forge-contract/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/error-cause-chain.js"
+export * from "./lib/issue-operations.js"
 export * from "./lib/types.js"
 export * from "./lib/user-facing-error.js"

--- a/packages/forge-contract/src/lib/issue-operations.ts
+++ b/packages/forge-contract/src/lib/issue-operations.ts
@@ -1,0 +1,168 @@
+import { Effect } from "effect"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
+import type {
+  ForgeRepository,
+  IssueAuthorScope,
+  ReadyLabeledIssue,
+} from "./types.js"
+
+/**
+ * Narrow internal view of existing Forge Issue operations. Callers must not
+ * treat any one provider as the contract, and must not pass GitHub
+ * operation-origin options through this surface.
+ */
+export interface ForgeIssueOperations<E> {
+  readonly getAuthenticatedUserLogin: (
+    repository: ForgeRepository,
+  ) => Effect.Effect<string, E>
+  readonly listReadyIssues: (
+    repository: ForgeRepository,
+  ) => Effect.Effect<readonly ReadyLabeledIssue[], E>
+  readonly ensureIssueCompletedWithSummary: (
+    repository: ForgeRepository,
+    issueNumber: number,
+    workItemId: string,
+    summaryMarkdown: string,
+  ) => Effect.Effect<void, E>
+}
+
+/**
+ * Issue operations plus the reconciliation fetch that hides GitHub's
+ * list-before-identity credential refresh without changing GitLab/Azure
+ * identity-then-list order.
+ */
+export interface ResolvedForgeIssueOperations<E>
+  extends ForgeIssueOperations<E> {
+  readonly listReadyIssuesWithAuthorScope: (
+    repository: ForgeRepository,
+    includeAllIssueAuthors: boolean,
+  ) => Effect.Effect<
+    {
+      readonly remoteIssues: readonly ReadyLabeledIssue[]
+      readonly authorScope: IssueAuthorScope
+    },
+    E
+  >
+}
+
+/**
+ * GitHub still accepts operation-origin options on identity and listing.
+ * {@link resolveForgeIssueOperations} binds those options so callers never
+ * see them.
+ */
+export interface ForgeGitHubIssueOperations<E, GitHubOptions = never> {
+  readonly getAuthenticatedUserLogin: (
+    repository: ForgeRepository,
+    options?: GitHubOptions,
+  ) => Effect.Effect<string, E>
+  readonly listReadyIssues: (
+    repository: ForgeRepository,
+    options?: GitHubOptions,
+  ) => Effect.Effect<readonly ReadyLabeledIssue[], E>
+  readonly ensureIssueCompletedWithSummary: (
+    repository: ForgeRepository,
+    issueNumber: number,
+    workItemId: string,
+    summaryMarkdown: string,
+  ) => Effect.Effect<void, E>
+}
+
+export interface ForgeIssueOperationProviders<
+  GitHubE,
+  GitLabE,
+  AzureE,
+  GitHubOptions = never,
+> {
+  readonly github: ForgeGitHubIssueOperations<GitHubE, GitHubOptions>
+  readonly gitlab: ForgeIssueOperations<GitLabE>
+  readonly azureDevOps: ForgeIssueOperations<AzureE>
+}
+
+const withAuthorScope = <E>(
+  operations: ForgeIssueOperations<E>,
+  listRefreshesCredentials: boolean,
+): ResolvedForgeIssueOperations<E> => ({
+  ...operations,
+  listReadyIssuesWithAuthorScope: (repository, includeAllIssueAuthors) =>
+    Effect.gen(function* () {
+      if (includeAllIssueAuthors) {
+        const remoteIssues = yield* operations.listReadyIssues(repository)
+        return { remoteIssues, authorScope: { includeAll: true } as const }
+      }
+      if (listRefreshesCredentials) {
+        const remoteIssues = yield* operations.listReadyIssues(repository)
+        const operatorLogin =
+          yield* operations.getAuthenticatedUserLogin(repository)
+        return {
+          remoteIssues,
+          authorScope: { includeAll: false as const, operatorLogin },
+        }
+      }
+      const operatorLogin =
+        yield* operations.getAuthenticatedUserLogin(repository)
+      const remoteIssues = yield* operations.listReadyIssues(repository)
+      return {
+        remoteIssues,
+        authorScope: { includeAll: false as const, operatorLogin },
+      }
+    }),
+})
+
+const bindGitHubOrigin = <E, GitHubOptions>(
+  github: ForgeGitHubIssueOperations<E, GitHubOptions>,
+  githubOperation: GitHubOptions | undefined,
+): ForgeIssueOperations<E> => ({
+  getAuthenticatedUserLogin: (repository) =>
+    github.getAuthenticatedUserLogin(repository, githubOperation),
+  listReadyIssues: (repository) =>
+    github.listReadyIssues(repository, githubOperation),
+  ensureIssueCompletedWithSummary: (
+    repository,
+    issueNumber,
+    workItemId,
+    summaryMarkdown,
+  ) =>
+    github.ensureIssueCompletedWithSummary(
+      repository,
+      issueNumber,
+      workItemId,
+      summaryMarkdown,
+    ),
+})
+
+/**
+ * Resolve the Repository's existing Forge to the shared Issue-operation
+ * interface. GitHub origin is bound here; listing order for author scope is
+ * GitHub list-then-identity, GitLab and Azure DevOps identity-then-list.
+ */
+export const resolveForgeIssueOperations = <
+  GitHubE,
+  GitLabE,
+  AzureE,
+  GitHubOptions = never,
+>(
+  forge: Forge,
+  providers: ForgeIssueOperationProviders<
+    GitHubE,
+    GitLabE,
+    AzureE,
+    GitHubOptions
+  >,
+  githubOperation?: GitHubOptions,
+): ResolvedForgeIssueOperations<GitHubE | GitLabE | AzureE> => {
+  switch (forge) {
+    case "github":
+      return withAuthorScope(
+        bindGitHubOrigin(providers.github, githubOperation),
+        true,
+      )
+    case "gitlab":
+      return withAuthorScope(providers.gitlab, false)
+    case "azure-devops":
+      return withAuthorScope(providers.azureDevOps, false)
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}

--- a/packages/forge-contract/src/lib/types.ts
+++ b/packages/forge-contract/src/lib/types.ts
@@ -171,6 +171,25 @@ export type PullRequestCheckStatus = (
   readonly isDraft: boolean | null
 }
 
+/**
+ * Identity a Repository uses to talk to its Forge. Shared by GitHub, GitLab,
+ * and Azure DevOps service methods.
+ */
+export interface ForgeRepository {
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+}
+
+/**
+ * How Issue reconciliation scopes Ready-labeled Issues by author. `includeAll`
+ * is the Include all Issue Authors setting; otherwise identity is the Operator
+ * Forge User resolved for this attempt.
+ */
+export type IssueAuthorScope =
+  | { readonly includeAll: true }
+  | { readonly includeAll: false; readonly operatorLogin: string }
+
 export type GitHubIssueState = "OPEN" | "CLOSED"
 
 export interface GitHubIssueReference {

--- a/packages/forge-contract/test/issue-operations.spec.ts
+++ b/packages/forge-contract/test/issue-operations.spec.ts
@@ -1,0 +1,215 @@
+import { Effect } from "effect"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
+import {
+  type ForgeIssueOperations,
+  type ForgeRepository,
+  type ReadyLabeledIssue,
+  resolveForgeIssueOperations,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const repository: ForgeRepository = {
+  forge: "github",
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+}
+
+const issue = (number: number): ReadyLabeledIssue => ({
+  number,
+  title: `Issue ${number}`,
+  body: "",
+  url: `https://github.com/acme/widgets/issues/${number}`,
+  createdAt: new Date("2026-07-01T00:00:00.000Z"),
+  state: "OPEN",
+  author: "operator",
+  parent: null,
+  parentPosition: null,
+  hasChildren: false,
+  hierarchySupported: true,
+  blockedBy: [],
+  closingPullRequests: [],
+})
+
+const recordingProvider = (
+  label: string,
+  actions: string[],
+  issues: readonly ReadyLabeledIssue[] = [issue(1)],
+): ForgeIssueOperations<string> => ({
+  getAuthenticatedUserLogin: () =>
+    Effect.sync(() => {
+      actions.push(`${label}:identity`)
+      return "operator"
+    }),
+  listReadyIssues: () =>
+    Effect.sync(() => {
+      actions.push(`${label}:list`)
+      return issues
+    }),
+  ensureIssueCompletedWithSummary: (
+    _repository,
+    issueNumber,
+    workItemId,
+    summaryMarkdown,
+  ) =>
+    Effect.sync(() => {
+      actions.push(
+        `${label}:complete:${issueNumber}:${workItemId}:${summaryMarkdown}`,
+      )
+    }),
+})
+
+const githubRecordingProvider = (
+  actions: string[],
+  issues: readonly ReadyLabeledIssue[] = [issue(1)],
+) => ({
+  getAuthenticatedUserLogin: (
+    _repository: ForgeRepository,
+    options?: { readonly origin: string },
+  ) =>
+    Effect.sync(() => {
+      actions.push(`github:identity:${options?.origin ?? "none"}`)
+      return "operator"
+    }),
+  listReadyIssues: (
+    _repository: ForgeRepository,
+    options?: { readonly origin: string },
+  ) =>
+    Effect.sync(() => {
+      actions.push(`github:list:${options?.origin ?? "none"}`)
+      return issues
+    }),
+  ensureIssueCompletedWithSummary: (
+    _repository: ForgeRepository,
+    issueNumber: number,
+    workItemId: string,
+    summaryMarkdown: string,
+  ) =>
+    Effect.sync(() => {
+      actions.push(
+        `github:complete:${issueNumber}:${workItemId}:${summaryMarkdown}`,
+      )
+    }),
+})
+
+const providersFor = (actions: string[]) => ({
+  github: githubRecordingProvider(actions),
+  gitlab: recordingProvider("gitlab", actions),
+  azureDevOps: recordingProvider("azure", actions),
+})
+
+const fetch = (
+  forge: Forge,
+  actions: string[],
+  includeAllIssueAuthors: boolean,
+  githubOperation?: { readonly origin: string },
+) =>
+  resolveForgeIssueOperations(
+    forge,
+    providersFor(actions),
+    githubOperation,
+  ).listReadyIssuesWithAuthorScope(repository, includeAllIssueAuthors)
+
+describe("resolveForgeIssueOperations", () => {
+  it("lists GitHub Ready Issues before resolving identity so author scope uses the refreshed credential", async () => {
+    const actions: string[] = []
+    const result = await Effect.runPromise(fetch("github", actions, false))
+
+    expect(actions).toEqual(["github:list:none", "github:identity:none"])
+    expect(result.authorScope).toEqual({
+      includeAll: false,
+      operatorLogin: "operator",
+    })
+    expect(result.remoteIssues).toEqual([issue(1)])
+  })
+
+  it("forwards GitHub operation origin to listing and identity", async () => {
+    const actions: string[] = []
+    await Effect.runPromise(
+      fetch("github", actions, false, { origin: "polling" }),
+    )
+
+    expect(actions).toEqual(["github:list:polling", "github:identity:polling"])
+  })
+
+  it("resolves GitLab identity before listing Ready Issues", async () => {
+    const actions: string[] = []
+    await Effect.runPromise(fetch("gitlab", actions, false))
+
+    expect(actions).toEqual(["gitlab:identity", "gitlab:list"])
+  })
+
+  it("resolves Azure DevOps identity before listing Ready Issues", async () => {
+    const actions: string[] = []
+    await Effect.runPromise(fetch("azure-devops", actions, false))
+
+    expect(actions).toEqual(["azure:identity", "azure:list"])
+  })
+
+  it("skips authenticated-user lookup when Include all Issue Authors is on", async () => {
+    for (const forge of ["github", "gitlab", "azure-devops"] as const) {
+      const actions: string[] = []
+      const result = await Effect.runPromise(fetch(forge, actions, true))
+      expect(result.authorScope).toEqual({ includeAll: true })
+      expect(actions.some((action) => action.includes("identity"))).toBe(false)
+      expect(actions.some((action) => action.includes("list"))).toBe(true)
+    }
+  })
+
+  it("completes the Issue through the selected Forge only", async () => {
+    const actions: string[] = []
+    const providers = providersFor(actions)
+
+    await Effect.runPromise(
+      resolveForgeIssueOperations(
+        "gitlab",
+        providers,
+      ).ensureIssueCompletedWithSummary(repository, 42, "wi-1", "Done."),
+    )
+    await Effect.runPromise(
+      resolveForgeIssueOperations(
+        "azure-devops",
+        providers,
+      ).ensureIssueCompletedWithSummary(repository, 7, "wi-2", "Closed."),
+    )
+    await Effect.runPromise(
+      resolveForgeIssueOperations(
+        "github",
+        providers,
+      ).ensureIssueCompletedWithSummary(repository, 9, "wi-3", "Summary."),
+    )
+
+    expect(actions).toEqual([
+      "gitlab:complete:42:wi-1:Done.",
+      "azure:complete:7:wi-2:Closed.",
+      "github:complete:9:wi-3:Summary.",
+    ])
+  })
+
+  it("does not list GitLab Issues when identity fails", async () => {
+    const actions: string[] = []
+    const error = "identity failed"
+    const result = await Effect.runPromise(
+      resolveForgeIssueOperations("gitlab", {
+        github: githubRecordingProvider(actions),
+        gitlab: {
+          getAuthenticatedUserLogin: () =>
+            Effect.sync(() => {
+              actions.push("gitlab:identity")
+            }).pipe(Effect.flatMap(() => Effect.fail(error))),
+          listReadyIssues: () =>
+            Effect.sync(() => {
+              actions.push("gitlab:list")
+              return []
+            }),
+          ensureIssueCompletedWithSummary: () => Effect.void,
+        },
+        azureDevOps: recordingProvider("azure", actions),
+      })
+        .listReadyIssuesWithAuthorScope(repository, false)
+        .pipe(Effect.flip),
+    )
+
+    expect(result).toBe(error)
+    expect(actions).toEqual(["gitlab:identity"])
+  })
+})

--- a/packages/forge-contract/tsconfig.lib.json
+++ b/packages/forge-contract/tsconfig.lib.json
@@ -9,5 +9,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../lifecycle-model/tsconfig.lib.json"
+    }
+  ]
 }

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -2,6 +2,7 @@ import { Context, type Effect } from "effect"
 import type {
   CiGateCatalogEntry,
   CiGateObservation,
+  ForgeIssueOperations,
   MergePullRequestOptions,
   MergePullRequestResult,
   ObserveCiGateInput,
@@ -35,7 +36,8 @@ export interface GitHubOperationOptions {
   readonly origin: GitHubOperationOrigin
 }
 
-export interface GitHubServiceShape {
+export interface GitHubServiceShape
+  extends ForgeIssueOperations<GitHubServiceError> {
   /**
    * Login of the authenticated principal for this Repository's credential
    * (Operator GitHub User). Same token path as other GitHub API calls.

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -1,8 +1,6 @@
-export interface GitHubRepository {
-  readonly forge: string
-  readonly forgeHost: string
-  readonly projectPath: string
-}
+import type { ForgeRepository } from "@ready-for-agent/forge-contract"
+
+export type GitHubRepository = ForgeRepository
 
 export const GITHUB_CI_GATE_KIND = "workflow"
 

--- a/packages/gitlab-service/src/lib/gitlab-service.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service.ts
@@ -2,6 +2,7 @@ import { Context, type Effect } from "effect"
 import type {
   CiGateCatalogEntry,
   CiGateObservation,
+  ForgeIssueOperations,
   MergePullRequestOptions,
   MergePullRequestResult,
   ObserveCiGateInput,
@@ -21,7 +22,8 @@ export type GitLabServiceError =
   | GitLabProjectUnavailableError
   | GitLabRequestError
 
-export interface GitLabServiceShape {
+export interface GitLabServiceShape
+  extends ForgeIssueOperations<GitLabServiceError> {
   /**
    * Verify Forge Host + Project Path against GitLab before persistence.
    * Returns the repository identity with the instance's canonical API/web host

--- a/packages/gitlab-service/src/lib/types.ts
+++ b/packages/gitlab-service/src/lib/types.ts
@@ -1,4 +1,7 @@
-import type { ReadyLabeledIssue } from "@ready-for-agent/forge-contract"
+import type {
+  ForgeRepository,
+  ReadyLabeledIssue,
+} from "@ready-for-agent/forge-contract"
 
 /**
  * Forge-neutral CI Gate kind for the synthesized GitLab Project pipeline.
@@ -6,11 +9,7 @@ import type { ReadyLabeledIssue } from "@ready-for-agent/forge-contract"
  */
 export const GITLAB_CI_GATE_KIND = "project-pipeline"
 
-export interface GitLabRepository {
-  readonly forge: string
-  readonly forgeHost: string
-  readonly projectPath: string
-}
+export type GitLabRepository = ForgeRepository
 
 export type GitLabReadyLabeledIssue = ReadyLabeledIssue
 

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -12,7 +12,10 @@ import {
   type RepositoryNotFoundError,
   type RepositoryRecord,
 } from "@ready-for-agent/db-service"
-import type { ReadyLabeledIssue } from "@ready-for-agent/forge-contract"
+import {
+  type ReadyLabeledIssue,
+  resolveForgeIssueOperations,
+} from "@ready-for-agent/forge-contract"
 import {
   type GitHubOperationOptions,
   type GitHubRepositoryUnavailableError,
@@ -150,63 +153,16 @@ export const IssueReconcilerLive = Layer.effect(
       }
       const localIssues = yield* db.listIssues(repository.id)
 
-      const fetchRemote = (() => {
-        switch (repository.forge) {
-          case "gitlab":
-            return Effect.gen(function* () {
-              const authorScope = repository.includeAllIssueAuthors
-                ? ({ includeAll: true } as const)
-                : ({
-                    includeAll: false,
-                    operatorLogin:
-                      yield* gitlab.getAuthenticatedUserLogin(forgeRepository),
-                  } as const)
-              const remoteIssues =
-                yield* gitlab.listReadyIssues(forgeRepository)
-              return { authorScope, remoteIssues }
-            })
-          case "azure-devops":
-            return Effect.gen(function* () {
-              const authorScope = repository.includeAllIssueAuthors
-                ? ({ includeAll: true } as const)
-                : ({
-                    includeAll: false,
-                    operatorLogin:
-                      yield* azureDevOps.getAuthenticatedUserLogin(
-                        forgeRepository,
-                      ),
-                  } as const)
-              const remoteIssues =
-                yield* azureDevOps.listReadyIssues(forgeRepository)
-              return { authorScope, remoteIssues }
-            })
-          case "github":
-            return Effect.gen(function* () {
-              // An authenticated GitHub list may refresh a stale credential.
-              // Resolve the operator afterwards so author scoping uses that
-              // credential's identity for this reconciliation.
-              const remoteIssues = yield* github.listReadyIssues(
-                forgeRepository,
-                options?.githubOperation,
-              )
-              const authorScope = repository.includeAllIssueAuthors
-                ? ({ includeAll: true } as const)
-                : ({
-                    includeAll: false,
-                    operatorLogin: yield* github.getAuthenticatedUserLogin(
-                      forgeRepository,
-                      options?.githubOperation,
-                    ),
-                  } as const)
-              return { authorScope, remoteIssues }
-            })
-          default: {
-            const _exhaustive: never = repository.forge
-            return Effect.die(_exhaustive)
-          }
-        }
-      })()
-      const { authorScope, remoteIssues } = yield* fetchRemote
+      const issueOperations = resolveForgeIssueOperations(
+        repository.forge,
+        { github, gitlab, azureDevOps },
+        options?.githubOperation,
+      )
+      const { authorScope, remoteIssues } =
+        yield* issueOperations.listReadyIssuesWithAuthorScope(
+          forgeRepository,
+          repository.includeAllIssueAuthors,
+        )
       const repositoryName = repository.projectPath.toLowerCase()
       const workItemPullRequests = yield* db.listWorkItemPullRequests(
         repository.id,

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -488,6 +488,45 @@ describe("IssueReconciler", () => {
     )
   })
 
+  it("resolves a scoped Azure DevOps author before fetching remote Issues", () => {
+    const azureDevOpsRepository = makeRepositoryRecord({
+      id: "repo-1",
+      forge: "azure-devops",
+      forgeHost: "dev.azure.com",
+      projectPath: "acme/widgets",
+      includeAllIssueAuthors: false,
+    })
+    const db = makeDbFixture({ issues: [] })
+    const azureDevOps = Layer.succeed(AzureDevOpsService, {
+      ...defaultAzureDevOpsShape,
+      getAuthenticatedUserLogin: ({ projectPath }) =>
+        Effect.sync(() => {
+          db.actions.push(`azure-identity:${projectPath}`)
+          return "operator"
+        }),
+      listReadyIssues: ({ projectPath }) =>
+        Effect.sync(() => {
+          db.actions.push(`azure:${projectPath}`)
+          return []
+        }),
+    } satisfies AzureDevOpsServiceShape)
+
+    return runReconciliation(
+      Effect.gen(function* () {
+        const reconciler = yield* IssueReconciler
+        yield* reconciler.reconcile(azureDevOpsRepository)
+
+        expect(db.actions.indexOf("azure-identity:acme/widgets")).toBeLessThan(
+          db.actions.indexOf("azure:acme/widgets"),
+        )
+      }),
+      db.layer,
+      makeGitHubLayer([], db.actions),
+      defaultGitLabLayer,
+      azureDevOps,
+    )
+  })
+
   it("classifies changes, writes by issue number, and records success", () => {
     const db = makeDbFixture({
       issues: [

--- a/packages/work-item-lifecycle/src/lib/close-issue.ts
+++ b/packages/work-item-lifecycle/src/lib/close-issue.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect"
 import { AzureDevOpsService } from "@ready-for-agent/azure-devops-service"
 import { DbService } from "@ready-for-agent/db-service"
+import { resolveForgeIssueOperations } from "@ready-for-agent/forge-contract"
 import { GitHubService } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
@@ -73,40 +74,17 @@ export const closeIssue = (context: LifecycleStepContext) =>
       forgeHost: repository.forgeHost,
       projectPath: repository.projectPath,
     }
-    switch (repository.forge) {
-      case "gitlab": {
-        const gitlab = yield* GitLabService
-        yield* gitlab.ensureIssueCompletedWithSummary(
-          forgeRepository,
-          context.issueNumber,
-          context.workItemId,
-          summary,
-        )
-        return
-      }
-      case "azure-devops": {
-        const azureDevOps = yield* AzureDevOpsService
-        yield* azureDevOps.ensureIssueCompletedWithSummary(
-          forgeRepository,
-          context.issueNumber,
-          context.workItemId,
-          summary,
-        )
-        return
-      }
-      case "github": {
-        const github = yield* GitHubService
-        yield* github.ensureIssueCompletedWithSummary(
-          forgeRepository,
-          context.issueNumber,
-          context.workItemId,
-          summary,
-        )
-        return
-      }
-      default: {
-        const _exhaustive: never = repository.forge
-        return _exhaustive
-      }
-    }
+    const github = yield* GitHubService
+    const gitlab = yield* GitLabService
+    const azureDevOps = yield* AzureDevOpsService
+    yield* resolveForgeIssueOperations(repository.forge, {
+      github,
+      gitlab,
+      azureDevOps,
+    }).ensureIssueCompletedWithSummary(
+      forgeRepository,
+      context.issueNumber,
+      context.workItemId,
+      summary,
+    )
   })

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -24,6 +24,8 @@ import {
   CloseIssueSummaryMissingError,
   closeIssue,
   makeWorkItemId,
+  stubAzureDevOpsServiceLayer,
+  stubGitLabServiceLayer,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
@@ -209,7 +211,11 @@ describe("closeIssue", () => {
       closeIssue({
         ...context,
         repositoryId: gitlabRepository.id,
-      }).pipe(Effect.provide(Layer.mergeAll(db, github, gitlab))),
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(db, github, gitlab, stubAzureDevOpsServiceLayer()),
+        ),
+      ),
     )
 
     expect(githubCalls).toBe(0)
@@ -276,7 +282,11 @@ describe("closeIssue", () => {
       closeIssue({
         ...context,
         repositoryId: azureDevOpsRepository.id,
-      }).pipe(Effect.provide(Layer.mergeAll(db, github, azureDevOps))),
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(db, github, stubGitLabServiceLayer(), azureDevOps),
+        ),
+      ),
     )
 
     expect(githubCalls).toBe(0)
@@ -331,7 +341,9 @@ describe("closeIssue", () => {
         ...context,
         repositoryId: azureDevOpsRepository.id,
       }).pipe(
-        Effect.provide(Layer.mergeAll(db, github, azureDevOps)),
+        Effect.provide(
+          Layer.mergeAll(db, github, stubGitLabServiceLayer(), azureDevOps),
+        ),
         Effect.flip,
       ),
     )
@@ -427,7 +439,16 @@ describe("closeIssue", () => {
         }),
     } satisfies GitHubServiceShape)
     await Effect.runPromise(
-      closeIssue(context).pipe(Effect.provide(Layer.merge(db, github))),
+      closeIssue(context).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            github,
+            stubGitLabServiceLayer(),
+            stubAzureDevOpsServiceLayer(),
+          ),
+        ),
+      ),
     )
     expect(calls).toEqual([
       {
@@ -457,7 +478,16 @@ describe("closeIssue", () => {
         }),
     } satisfies GitHubServiceShape)
     await Effect.runPromise(
-      closeIssue(context).pipe(Effect.provide(Layer.merge(db, github))),
+      closeIssue(context).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            github,
+            stubGitLabServiceLayer(),
+            stubAzureDevOpsServiceLayer(),
+          ),
+        ),
+      ),
     )
     expect(calls).toEqual(["Findings complete."])
   })


### PR DESCRIPTION
Issue reconciliation and Close Issue each switched on the Repository's Forge to call GitHub, GitLab, or Azure DevOps for the same three operations: authenticated-user lookup, Ready Issue listing, and idempotent completion-with-summary (#1288). GitHub-specific invocation details lived in those call sites — operation-origin scheduling, and listing before identity so author scope uses a credential that listing may have just refreshed — so the three-provider dispatch was duplicated and GitHub's extra arguments leaked into callers.

This change makes that existing contract explicit. All three implementations satisfy a provider-neutral issue-operation interface with their own result and error types; GitHub is not the source of the contract. One resolver selects the implementation from the Repository's Forge, binds GitHub origin, and hides list-versus-identity order: GitHub still lists first, GitLab and Azure DevOps still resolve identity first, and Include all Issue Authors still skips the identity lookup. Reconciliation and Close Issue use that resolver instead of their own switches.

Issue-store mutations, Relevant Issue membership, Close Issue eligibility, already-closed Issues, marked summaries, error tags, throttling, and retry behaviour are unchanged. No new tracker role, settings, or Forge kinds. Later children still own PR observation and mutation dispatch.

Verification: Nx typecheck, test, lint, and unused-export checks for the shared contract, all three Forge adapters, issue reconciliation, and Close Issue, plus downstream typecheck of the GraphQL API and harness. Focused coverage protects GitHub list-then-identity and origin forwarding, GitLab/Azure identity-then-list (including Azure author scope), Include-all skipping identity, and completion routing to the selected Forge only. Existing reconciliation and Close Issue suites exercise all three implementations through the new seam.

Review of the uncommitted change reported two low style nits (shared identity still types forge as a string, matching the existing adapters; new helpers stay positional like the Forge methods they wrap). Those were deferred; no runtime or operator-visible findings.

See #1288.

Closes #1288