### PR TITLE
refactor: resolve issue presentation and native PR-linking through one contract

### DIFF
--- a/packages/forge-contract/src/index.ts
+++ b/packages/forge-contract/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./lib/error-cause-chain.js"
 export * from "./lib/issue-operations.js"
+export * from "./lib/issue-presentation.js"
 export * from "./lib/mutation.js"
 export * from "./lib/observation.js"
 export * from "./lib/types.js"

--- a/packages/forge-contract/src/lib/issue-presentation.ts
+++ b/packages/forge-contract/src/lib/issue-presentation.ts
@@ -1,0 +1,282 @@
+import { Effect } from "effect"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
+import type { ResolvedForgePullRequestMutations } from "./mutation.js"
+import type { ForgeRepository } from "./types.js"
+
+/**
+ * Identity a prompt or publication path uses to name one Issue on one
+ * Repository. Numbers stay the existing positive integer Issue number.
+ */
+export type ForgeIssueIdentity = {
+  readonly forge: Forge
+  readonly forgeHost: string
+  readonly projectPath: string
+  readonly issueNumber: number
+}
+
+/**
+ * How Create PR associates an Issue with a pull/merge request after the
+ * open identity is known. GitHub and GitLab rely on the textual closing
+ * reference already in publication copy. Azure writes an ArtifactLink in
+ * addition; that write is not a textual `Closes #N` mention.
+ */
+export type ForgeNativePullRequestAssociation =
+  | { readonly kind: "closing_reference" }
+  | { readonly kind: "azure_artifact_link" }
+
+/**
+ * Closing-reference and placeholder rules used by publication copy.
+ * All three current Forges persist `Closes #<n>` today, including Azure.
+ */
+export type ForgeClosingReferenceRules = {
+  readonly formatLine: (issueNumber: number) => string
+  readonly strip: (body: string, issueNumber: number) => string
+  readonly isGenericPlaceholder: (body: string) => boolean
+  readonly genericPlaceholderExample: string
+  readonly genericPlaceholderBody: (issueNumber: number) => string
+  readonly mentionGuidance: (issueNumber: number) => string
+  readonly commitMustCloseGuidance: (issueNumber: number) => string
+}
+
+/**
+ * Existing Forge-specific Issue identity text, read/state-change guidance,
+ * publication closing-reference rules, and native PR association. Callers
+ * must not infer these from Forge names.
+ */
+export type ResolvedForgeIssuePresentation = {
+  readonly forge: Forge
+  readonly identityText: string
+  readonly issueNoun: string
+  readonly stayOpenGuidance: string
+  readonly includeCredentialGuidance: boolean
+  readonly implementAccessScope: string
+  readonly nativeCreateAccessScope: string
+  readonly closingReference: ForgeClosingReferenceRules
+  readonly nativePullRequestAssociation: ForgeNativePullRequestAssociation
+}
+
+const forgeDisplayName = (forge: Forge): string => {
+  switch (forge) {
+    case "github":
+      return "GitHub"
+    case "gitlab":
+      return "GitLab"
+    case "azure-devops":
+      return "Azure DevOps"
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Closing-reference patterns the harness normalizes to a single
+ * `Closes #<n>` line (issue keywords GitHub recognizes). All three current
+ * Forges share this stripping today.
+ */
+const CLOSING_REFERENCE_LINE =
+  /^(?:[-*]\s+)?(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\s*[.:]?\s*$/i
+
+const GENERIC_PLACEHOLDER_BODY =
+  /^Automated draft pull request for GitHub issue #\d+\.?$/i
+
+const formatClosingReferenceLine = (issueNumber: number): string =>
+  `Closes #${issueNumber}`
+
+const stripClosingReferences = (body: string, issueNumber: number): string => {
+  const kept: string[] = []
+  for (const line of body.split("\n")) {
+    const trimmed = line.trim()
+    const match = CLOSING_REFERENCE_LINE.exec(trimmed)
+    if (match !== null && Number(match[1]) === issueNumber) {
+      continue
+    }
+    kept.push(line)
+  }
+  while (kept.length > 0 && kept[kept.length - 1]?.trim() === "") {
+    kept.pop()
+  }
+  return kept.join("\n").trim()
+}
+
+const genericPlaceholderBody = (issueNumber: number): string =>
+  `Automated draft pull request for GitHub issue #${issueNumber}.`
+
+/**
+ * Today's shared native closing-reference rules. GitHub, GitLab, and Azure
+ * DevOps all persist `Closes #<n>` and reject the GitHub-worded generic
+ * placeholder; Azure association is a separate ArtifactLink write.
+ */
+export const currentNativeForgeClosingReferenceRules: ForgeClosingReferenceRules =
+  {
+    formatLine: formatClosingReferenceLine,
+    strip: stripClosingReferences,
+    isGenericPlaceholder: (body) => GENERIC_PLACEHOLDER_BODY.test(body),
+    genericPlaceholderExample:
+      "Automated draft pull request for GitHub issue #N",
+    genericPlaceholderBody,
+    mentionGuidance: (issueNumber) =>
+      `You may mention issue #${issueNumber}; the harness will ensure the body ends with exactly one Closes #${issueNumber} reference.`,
+    commitMustCloseGuidance: (issueNumber) =>
+      `The commit must still close GitHub issue #${issueNumber} (include Closes #${issueNumber} in the body unless policy forbids it — then mention the issue another accepted way).`,
+  }
+
+const closingReferenceRulesForForge = (
+  forge: Forge,
+): ForgeClosingReferenceRules => {
+  switch (forge) {
+    case "github":
+    case "gitlab":
+    case "azure-devops":
+      return currentNativeForgeClosingReferenceRules
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+const nativePullRequestAssociationForForge = (
+  forge: Forge,
+): ForgeNativePullRequestAssociation => {
+  switch (forge) {
+    case "github":
+    case "gitlab":
+      return { kind: "closing_reference" }
+    case "azure-devops":
+      return { kind: "azure_artifact_link" }
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+const identityTextFor = (identity: ForgeIssueIdentity): string => {
+  const displayName = forgeDisplayName(identity.forge)
+  const numbered = `${identity.projectPath}#${identity.issueNumber}`
+  switch (identity.forge) {
+    case "github":
+      return `${displayName} issue ${numbered}`
+    case "gitlab":
+    case "azure-devops":
+      return `${displayName} issue ${numbered} on ${identity.forgeHost}`
+    default: {
+      const _exhaustive: never = identity.forge
+      return _exhaustive
+    }
+  }
+}
+
+const stayOpenGuidanceFor = (forge: Forge): string => {
+  const leaveOpen =
+    "Leave the tracker Issue open; the harness closes it after merge."
+  switch (forge) {
+    case "github":
+      return `${leaveOpen} Do not close, complete, or change its state, including \`gh issue close\`.`
+    case "gitlab":
+      return `${leaveOpen} Do not close, complete, or change its state, including \`glab issue close\` or an API state change.`
+    case "azure-devops":
+      return `${leaveOpen} You may GET the Work Item to inspect it. Do not close, complete, or change its state, including PATCH of \`System.State\`.`
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+const implementAccessScopeFor = (forge: Forge): string => {
+  switch (forge) {
+    case "github":
+      return "read of the GitHub Issue"
+    case "gitlab":
+      return "read of the GitLab Issue"
+    case "azure-devops":
+      return "read of the Azure DevOps Issue"
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+const nativeCreateAccessScopeFor = (forge: Forge): string => {
+  switch (forge) {
+    case "github":
+      return "GitHub CLI or API access"
+    case "gitlab":
+      return "GitLab API or push access"
+    case "azure-devops":
+      return "Azure DevOps API or push access"
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+const includeCredentialGuidanceFor = (forge: Forge): boolean => {
+  switch (forge) {
+    case "github":
+      return false
+    case "gitlab":
+    case "azure-devops":
+      return true
+    default: {
+      const _exhaustive: never = forge
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Resolve existing Issue presentation and native PR-linking rules for one
+ * Forge identity. GitHub stays ambient (no host in identity, no Implement
+ * credential line); GitLab and Azure DevOps name the host.
+ */
+export const resolveForgeIssuePresentation = (
+  identity: ForgeIssueIdentity,
+): ResolvedForgeIssuePresentation => ({
+  forge: identity.forge,
+  identityText: identityTextFor(identity),
+  issueNoun: `${forgeDisplayName(identity.forge)} Issue`,
+  stayOpenGuidance: stayOpenGuidanceFor(identity.forge),
+  includeCredentialGuidance: includeCredentialGuidanceFor(identity.forge),
+  implementAccessScope: implementAccessScopeFor(identity.forge),
+  nativeCreateAccessScope: nativeCreateAccessScopeFor(identity.forge),
+  closingReference: closingReferenceRulesForForge(identity.forge),
+  nativePullRequestAssociation: nativePullRequestAssociationForForge(
+    identity.forge,
+  ),
+})
+
+/**
+ * Apply the existing native PR↔Issue association after Create PR has an
+ * open pull/merge request identity. GitHub and GitLab are no-ops (copy
+ * already carries `Closes #N`). Azure writes the ArtifactLink with today's
+ * identity and timing; retries and reused PRs call this again because the
+ * write is idempotent.
+ */
+export const associateNativePullRequestWithIssue = <E>(input: {
+  readonly mutations: ResolvedForgePullRequestMutations<E>
+  readonly repository: ForgeRepository
+  readonly pullRequestNumber: number
+  readonly issueNumber: number
+}): Effect.Effect<void, E> => {
+  switch (input.mutations.forge) {
+    case "github":
+    case "gitlab":
+      return Effect.void
+    case "azure-devops":
+      return input.mutations.ensurePullRequestLinkedToIssue(
+        input.repository,
+        input.pullRequestNumber,
+        input.issueNumber,
+      )
+    default: {
+      const _exhaustive: never = input.mutations
+      return _exhaustive
+    }
+  }
+}

--- a/packages/forge-contract/test/issue-presentation.spec.ts
+++ b/packages/forge-contract/test/issue-presentation.spec.ts
@@ -1,0 +1,300 @@
+import { Effect } from "effect"
+import type { Forge } from "@ready-for-agent/lifecycle-model"
+import {
+  type ForgeAzureDevOpsPullRequestMutations,
+  type ForgeGitHubPullRequestMutations,
+  type ForgeGitLabPullRequestMutations,
+  type ForgeIssueIdentity,
+  type ForgeRepository,
+  associateNativePullRequestWithIssue,
+  currentNativeForgeClosingReferenceRules,
+  resolveForgeIssuePresentation,
+  resolveForgePullRequestMutations,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const githubIdentity = {
+  forge: "github",
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+  issueNumber: 80,
+} satisfies ForgeIssueIdentity
+
+const gitlabIdentity = {
+  forge: "gitlab",
+  forgeHost: "git.drupalcode.org",
+  projectPath: "project/oauth_client",
+  issueNumber: 3601642,
+} satisfies ForgeIssueIdentity
+
+const azureIdentity = {
+  forge: "azure-devops",
+  forgeHost: "dev.azure.com",
+  projectPath: "acme/widgets",
+  issueNumber: 4021,
+} satisfies ForgeIssueIdentity
+
+const repository: ForgeRepository = {
+  forge: "azure-devops",
+  forgeHost: "dev.azure.com",
+  projectPath: "acme/widgets",
+}
+
+const githubProvider = (
+  actions: string[],
+): ForgeGitHubPullRequestMutations<string> => ({
+  createDraftPullRequest: () => Effect.succeed(11),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(11),
+  markPullRequestReadyForReview: () => Effect.void,
+  mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
+  closeOpenPullRequestsAndDeleteBranch: () =>
+    Effect.sync(() => {
+      actions.push("github:cleanup")
+    }),
+})
+
+const gitlabProvider = (
+  actions: string[],
+): ForgeGitLabPullRequestMutations<string> => ({
+  createDraftPullRequest: () => Effect.succeed(22),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(22),
+  markPullRequestReadyForReview: () => Effect.void,
+  mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
+  closeOpenPullRequestsForBranch: () =>
+    Effect.sync(() => {
+      actions.push("gitlab:close")
+    }),
+  deleteBranch: () =>
+    Effect.sync(() => {
+      actions.push("gitlab:delete")
+    }),
+})
+
+const azureProvider = (
+  actions: string[],
+  options: {
+    readonly link?: Effect.Effect<void, string>
+  } = {},
+): ForgeAzureDevOpsPullRequestMutations<string> => ({
+  createDraftPullRequest: () => Effect.succeed(33),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(33),
+  markPullRequestReadyForReview: () => Effect.void,
+  mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
+  ensurePullRequestLinkedToIssue: (
+    _repository,
+    pullRequestNumber,
+    issueNumber,
+  ) =>
+    options.link ??
+    Effect.sync(() => {
+      actions.push(`azure:link:${pullRequestNumber}:${issueNumber}`)
+    }),
+  ensureIssueCompletedWithSummary: () =>
+    Effect.sync(() => {
+      actions.push("azure:complete")
+    }),
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
+})
+
+const mutationsFor = (forge: Forge, actions: string[]) =>
+  resolveForgePullRequestMutations(forge, {
+    github: githubProvider(actions),
+    gitlab: gitlabProvider(actions),
+    azureDevOps: azureProvider(actions),
+  })
+
+describe("resolveForgeIssuePresentation", () => {
+  it("keeps GitHub identity ambient: no host and no Implement credential line", () => {
+    const presentation = resolveForgeIssuePresentation(githubIdentity)
+
+    expect(presentation.identityText).toBe("GitHub issue acme/widgets#80")
+    expect(presentation.issueNoun).toBe("GitHub Issue")
+    expect(presentation.includeCredentialGuidance).toBe(false)
+    expect(presentation.implementAccessScope).toBe("read of the GitHub Issue")
+    expect(presentation.nativeCreateAccessScope).toBe(
+      "GitHub CLI or API access",
+    )
+    expect(presentation.stayOpenGuidance).toBe(
+      "Leave the tracker Issue open; the harness closes it after merge. Do not close, complete, or change its state, including `gh issue close`.",
+    )
+    expect(presentation.nativePullRequestAssociation).toEqual({
+      kind: "closing_reference",
+    })
+  })
+
+  it("names the GitLab host and requires credential guidance without closing the Issue", () => {
+    const presentation = resolveForgeIssuePresentation(gitlabIdentity)
+
+    expect(presentation.identityText).toBe(
+      "GitLab issue project/oauth_client#3601642 on git.drupalcode.org",
+    )
+    expect(presentation.issueNoun).toBe("GitLab Issue")
+    expect(presentation.includeCredentialGuidance).toBe(true)
+    expect(presentation.implementAccessScope).toBe("read of the GitLab Issue")
+    expect(presentation.nativeCreateAccessScope).toBe(
+      "GitLab API or push access",
+    )
+    expect(presentation.stayOpenGuidance).toBe(
+      "Leave the tracker Issue open; the harness closes it after merge. Do not close, complete, or change its state, including `glab issue close` or an API state change.",
+    )
+    expect(presentation.nativePullRequestAssociation).toEqual({
+      kind: "closing_reference",
+    })
+  })
+
+  it("names the Azure DevOps host and forbids System.State changes while allowing GET", () => {
+    const presentation = resolveForgeIssuePresentation(azureIdentity)
+
+    expect(presentation.identityText).toBe(
+      "Azure DevOps issue acme/widgets#4021 on dev.azure.com",
+    )
+    expect(presentation.issueNoun).toBe("Azure DevOps Issue")
+    expect(presentation.includeCredentialGuidance).toBe(true)
+    expect(presentation.implementAccessScope).toBe(
+      "read of the Azure DevOps Issue",
+    )
+    expect(presentation.nativeCreateAccessScope).toBe(
+      "Azure DevOps API or push access",
+    )
+    expect(presentation.stayOpenGuidance).toBe(
+      "Leave the tracker Issue open; the harness closes it after merge. You may GET the Work Item to inspect it. Do not close, complete, or change its state, including PATCH of `System.State`.",
+    )
+    expect(presentation.nativePullRequestAssociation).toEqual({
+      kind: "azure_artifact_link",
+    })
+  })
+
+  it("uses Closes #N for every current Forge, including Azure", () => {
+    for (const identity of [githubIdentity, gitlabIdentity, azureIdentity]) {
+      const rules = resolveForgeIssuePresentation(identity).closingReference
+      expect(rules.formatLine(identity.issueNumber)).toBe(
+        `Closes #${identity.issueNumber}`,
+      )
+    }
+  })
+})
+
+describe("currentNativeForgeClosingReferenceRules", () => {
+  const rules = currentNativeForgeClosingReferenceRules
+
+  it("strips whole-line close/fix/resolve refs and trailing punctuation for the matching Issue", () => {
+    expect(rules.strip("Adds widgets.\n\nCloses #7.", 7)).toBe("Adds widgets.")
+    expect(rules.strip("Adds widgets.\n\n- Closes #7", 7)).toBe("Adds widgets.")
+    expect(rules.strip("Adds widgets.\n\nFixes #7", 7)).toBe("Adds widgets.")
+    expect(rules.strip("Adds widgets.\n\nResolved #7.", 7)).toBe(
+      "Adds widgets.",
+    )
+    expect(rules.strip("Adds widgets.\n\nCloses #8", 7)).toBe(
+      "Adds widgets.\n\nCloses #8",
+    )
+  })
+
+  it("rejects the existing GitHub-worded generic placeholder", () => {
+    expect(
+      rules.isGenericPlaceholder(
+        "Automated draft pull request for GitHub issue #1.",
+      ),
+    ).toBe(true)
+    expect(rules.genericPlaceholderBody(91)).toBe(
+      "Automated draft pull request for GitHub issue #91.",
+    )
+    expect(rules.genericPlaceholderExample).toBe(
+      "Automated draft pull request for GitHub issue #N",
+    )
+  })
+
+  it("keeps existing publication and commit-repair guidance wording", () => {
+    expect(rules.mentionGuidance(42)).toBe(
+      "You may mention issue #42; the harness will ensure the body ends with exactly one Closes #42 reference.",
+    )
+    expect(rules.commitMustCloseGuidance(42)).toBe(
+      "The commit must still close GitHub issue #42 (include Closes #42 in the body unless policy forbids it — then mention the issue another accepted way).",
+    )
+  })
+})
+
+describe("associateNativePullRequestWithIssue", () => {
+  it("does not write an association for GitHub or GitLab", async () => {
+    const actions: string[] = []
+    await Effect.runPromise(
+      associateNativePullRequestWithIssue({
+        mutations: mutationsFor("github", actions),
+        repository,
+        pullRequestNumber: 11,
+        issueNumber: 80,
+      }),
+    )
+    await Effect.runPromise(
+      associateNativePullRequestWithIssue({
+        mutations: mutationsFor("gitlab", actions),
+        repository,
+        pullRequestNumber: 22,
+        issueNumber: 3601642,
+      }),
+    )
+
+    expect(actions).toEqual([])
+  })
+
+  it("writes the Azure ArtifactLink with the open PR and Issue identity", async () => {
+    const actions: string[] = []
+    await Effect.runPromise(
+      associateNativePullRequestWithIssue({
+        mutations: mutationsFor("azure-devops", actions),
+        repository,
+        pullRequestNumber: 91,
+        issueNumber: 3601642,
+      }),
+    )
+
+    expect(actions).toEqual(["azure:link:91:3601642"])
+  })
+
+  it("retries the Azure ArtifactLink with the same identity when Create PR reuses a PR", async () => {
+    const actions: string[] = []
+    const mutations = mutationsFor("azure-devops", actions)
+
+    await Effect.runPromise(
+      associateNativePullRequestWithIssue({
+        mutations,
+        repository,
+        pullRequestNumber: 77,
+        issueNumber: 3601642,
+      }),
+    )
+    await Effect.runPromise(
+      associateNativePullRequestWithIssue({
+        mutations,
+        repository,
+        pullRequestNumber: 77,
+        issueNumber: 3601642,
+      }),
+    )
+
+    expect(actions).toEqual(["azure:link:77:3601642", "azure:link:77:3601642"])
+  })
+
+  it("surfaces Azure association failure so Create PR can fail the step", async () => {
+    const actions: string[] = []
+    const error = await Effect.runPromise(
+      associateNativePullRequestWithIssue({
+        mutations: resolveForgePullRequestMutations("azure-devops", {
+          github: githubProvider(actions),
+          gitlab: gitlabProvider(actions),
+          azureDevOps: azureProvider(actions, {
+            link: Effect.sync(() => {
+              actions.push("azure:link")
+            }).pipe(Effect.flatMap(() => Effect.fail("link failed"))),
+          }),
+        }),
+        repository,
+        pullRequestNumber: 33,
+        issueNumber: 7,
+      }).pipe(Effect.flip),
+    )
+
+    expect(error).toBe("link failed")
+    expect(actions).toEqual(["azure:link"])
+  })
+})

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -15,8 +15,11 @@ import {
 } from "@ready-for-agent/azure-devops-service"
 import { DbService, type RepositoryRecord } from "@ready-for-agent/db-service"
 import {
+  associateNativePullRequestWithIssue,
+  currentNativeForgeClosingReferenceRules,
   formatUserFacingError,
   logErrorAnnotations,
+  resolveForgeIssuePresentation,
 } from "@ready-for-agent/forge-contract"
 import {
   type GitHubService,
@@ -72,24 +75,6 @@ import { workItemBranchName } from "./worktree-names.js"
 
 const DIAGNOSTIC_CHAR_LIMIT = 4_000
 const NATIVE_PUSH_TIMEOUT_MS = 60_000
-
-/** Agent Turn credential-guidance access-scope phrase, per Forge. */
-const nativeCredentialAccessScope = (
-  forge: RepositoryRecord["forge"],
-): string => {
-  switch (forge) {
-    case "github":
-      return "GitHub CLI or API access"
-    case "gitlab":
-      return "GitLab API or push access"
-    case "azure-devops":
-      return "Azure DevOps API or push access"
-    default: {
-      const _exhaustive: never = forge
-      return _exhaustive
-    }
-  }
-}
 
 export type CreatePrResult = {
   readonly pullRequestNumber: number
@@ -225,9 +210,9 @@ export const buildDeterministicPullRequestBody = (
   issueNumber: number,
 ): string =>
   [
-    `Automated draft pull request for GitHub issue #${issueNumber}.`,
+    currentNativeForgeClosingReferenceRules.genericPlaceholderBody(issueNumber),
     "",
-    `Closes #${issueNumber}`,
+    currentNativeForgeClosingReferenceRules.formatLine(issueNumber),
   ].join("\n")
 
 /**
@@ -913,6 +898,12 @@ export const createPr = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveWorktreePath(context)
     const repository = yield* resolveRepositoryRecord(context)
+    const presentation = resolveForgeIssuePresentation({
+      forge: repository.forge,
+      forgeHost: repository.forgeHost,
+      projectPath: repository.projectPath,
+      issueNumber: context.issueNumber,
+    })
     const branch = workItemBranchName({
       projectPath: repository.projectPath,
       issueNumber: context.issueNumber,
@@ -1032,7 +1023,7 @@ export const createPr = (context: LifecycleStepContext) =>
                 credentialGuidance: agentTurnForgeCredentialGuidance(
                   repository,
                   prepared.auth,
-                  nativeCredentialAccessScope(repository.forge),
+                  presentation.nativeCreateAccessScope,
                 ),
                 diagnostics,
               }),
@@ -1096,24 +1087,21 @@ export const createPr = (context: LifecycleStepContext) =>
     })
 
     const mutations = yield* forgePullRequestMutations(repository)
-    if (mutations.forge === "azure-devops") {
-      yield* mutations
-        .ensurePullRequestLinkedToIssue(
-          toForgeRepository(repository),
-          outcome.value,
-          context.issueNumber,
-        )
-        .pipe(
-          Effect.mapError(
-            (cause) =>
-              new CreatePrPostconditionError({
-                repositoryId: context.repositoryId,
-                message: `Failed to associate Azure Boards Issue #${context.issueNumber} with pull request ${outcome.value}`,
-                diagnostics: boundDiagnostics(errorMessage(cause)),
-              }),
-          ),
-        )
-    }
+    yield* associateNativePullRequestWithIssue({
+      mutations,
+      repository: toForgeRepository(repository),
+      pullRequestNumber: outcome.value,
+      issueNumber: context.issueNumber,
+    }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new CreatePrPostconditionError({
+            repositoryId: context.repositoryId,
+            message: `Failed to associate Azure Boards Issue #${context.issueNumber} with pull request ${outcome.value}`,
+            diagnostics: boundDiagnostics(errorMessage(cause)),
+          }),
+      ),
+    )
 
     return toCreatePrResult(outcome.value, outcome.completion, copy)
   })

--- a/packages/work-item-lifecycle/src/lib/implement.ts
+++ b/packages/work-item-lifecycle/src/lib/implement.ts
@@ -2,6 +2,7 @@ import { Effect, FileSystem } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { AgentBackend, agentBackendLabel } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
+import { resolveForgeIssuePresentation } from "@ready-for-agent/forge-contract"
 import {
   type AgentTurnForgeAuth,
   AgentTurnForgeCredentialMissingError,
@@ -115,44 +116,8 @@ const resolveIssueNumber = (context: LifecycleStepContext) => {
   return Effect.succeed(context.issueNumber)
 }
 
-/** Per-Forge access scope for the Implement credential guidance line. */
-const implementAccessScope = (repository: AgentTurnForgeRepository): string => {
-  switch (repository.forge) {
-    case "gitlab":
-      return "read of the GitLab Issue"
-    case "azure-devops":
-      return "read of the Azure DevOps Issue"
-    case "github":
-      return "read of the GitHub Issue"
-    default: {
-      const _exhaustive: never = repository.forge
-      return _exhaustive
-    }
-  }
-}
-
 const implementTheIssuePromptLine =
   "Do not merely propose a plan; implement the requested changes in this worktree for that exact issue."
-
-/** Implement may inspect the tracker Issue; the harness closes it after merge. */
-const trackerIssueStayOpenPromptLine = (
-  forge: AgentTurnForgeRepository["forge"],
-): string => {
-  const leaveOpen =
-    "Leave the tracker Issue open; the harness closes it after merge."
-  switch (forge) {
-    case "github":
-      return `${leaveOpen} Do not close, complete, or change its state, including \`gh issue close\`.`
-    case "gitlab":
-      return `${leaveOpen} Do not close, complete, or change its state, including \`glab issue close\` or an API state change.`
-    case "azure-devops":
-      return `${leaveOpen} You may GET the Work Item to inspect it. Do not close, complete, or change its state, including PATCH of \`System.State\`.`
-    default: {
-      const _exhaustive: never = forge
-      return _exhaustive
-    }
-  }
-}
 
 const visualEvidencePromptLines = (workItemId: string): readonly string[] => {
   const attachmentDirectory = workItemAttachmentDirectory({ workItemId })
@@ -172,60 +137,48 @@ const buildImplementPrompt = (
   issueNumber: number,
   workItemId: string,
   forgeAuth: AgentTurnForgeAuth,
-) =>
-  repository.forge === "github"
+  mode: "start" | "continue",
+) => {
+  const presentation = resolveForgeIssuePresentation({
+    forge: repository.forge,
+    forgeHost: repository.forgeHost,
+    projectPath: repository.projectPath,
+    issueNumber,
+  })
+  const identityLine =
+    mode === "start"
+      ? `Implement ${presentation.identityText}.`
+      : `Continue implementing ${presentation.identityText}.`
+  const inspectLine =
+    mode === "start"
+      ? `Inspect the current ${presentation.issueNoun} and this Repository's agent/project instructions.`
+      : `Inspect the current ${presentation.issueNoun}, this Repository's agent/project instructions, and any partial work already present.`
+  const credentialLine = presentation.includeCredentialGuidance
     ? [
-        `Implement GitHub issue ${repository.projectPath}#${issueNumber}.`,
-        "Inspect the current GitHub Issue and this Repository's agent/project instructions.",
-        trackerIssueStayOpenPromptLine(repository.forge),
-        "Make the implementation in this worktree and run appropriate verification.",
-        implementTheIssuePromptLine,
-        ...visualEvidencePromptLines(workItemId),
-      ].join("\n")
-    : [
-        `Implement ${forgeDisplayName(repository.forge)} issue ${repository.projectPath}#${issueNumber} on ${repository.forgeHost}.`,
-        `Inspect the current ${forgeDisplayName(repository.forge)} Issue and this Repository's agent/project instructions.`,
         agentTurnForgeCredentialGuidance(
           repository,
           forgeAuth,
-          implementAccessScope(repository),
+          presentation.implementAccessScope,
         ),
-        trackerIssueStayOpenPromptLine(repository.forge),
-        "Make the implementation in this worktree and run appropriate verification.",
-        implementTheIssuePromptLine,
-        ...visualEvidencePromptLines(workItemId),
-      ].join("\n")
-
-const buildContinueImplementPrompt = (
-  repository: AgentTurnForgeRepository,
-  issueNumber: number,
-  workItemId: string,
-  forgeAuth: AgentTurnForgeAuth,
-) =>
-  repository.forge === "github"
-    ? [
-        `Continue implementing GitHub issue ${repository.projectPath}#${issueNumber}.`,
-        "A previous Implement attempt was interrupted or failed; resume from the existing session and worktree state.",
-        "Inspect the current GitHub Issue, this Repository's agent/project instructions, and any partial work already present.",
-        trackerIssueStayOpenPromptLine(repository.forge),
-        "Finish the implementation in this worktree and run appropriate verification.",
-        implementTheIssuePromptLine,
-        ...visualEvidencePromptLines(workItemId),
-      ].join("\n")
-    : [
-        `Continue implementing ${forgeDisplayName(repository.forge)} issue ${repository.projectPath}#${issueNumber} on ${repository.forgeHost}.`,
-        "A previous Implement attempt was interrupted or failed; resume from the existing session and worktree state.",
-        `Inspect the current ${forgeDisplayName(repository.forge)} Issue, this Repository's agent/project instructions, and any partial work already present.`,
-        agentTurnForgeCredentialGuidance(
-          repository,
-          forgeAuth,
-          implementAccessScope(repository),
-        ),
-        trackerIssueStayOpenPromptLine(repository.forge),
-        "Finish the implementation in this worktree and run appropriate verification.",
-        implementTheIssuePromptLine,
-        ...visualEvidencePromptLines(workItemId),
-      ].join("\n")
+      ]
+    : []
+  return [
+    identityLine,
+    ...(mode === "continue"
+      ? [
+          "A previous Implement attempt was interrupted or failed; resume from the existing session and worktree state.",
+        ]
+      : []),
+    inspectLine,
+    ...credentialLine,
+    presentation.stayOpenGuidance,
+    mode === "start"
+      ? "Make the implementation in this worktree and run appropriate verification."
+      : "Finish the implementation in this worktree and run appropriate verification.",
+    implementTheIssuePromptLine,
+    ...visualEvidencePromptLines(workItemId),
+  ].join("\n")
+}
 
 const priorSessionId = (context: LifecycleStepContext): string | null => {
   const sessionId = context.sessionId
@@ -266,20 +219,13 @@ export const implement = (context: LifecycleStepContext) =>
     )
 
     const existingSessionId = priorSessionId(context)
-    const prompt =
-      existingSessionId === null
-        ? buildImplementPrompt(
-            repository,
-            issueNumber,
-            context.workItemId,
-            forgeAuth,
-          )
-        : buildContinueImplementPrompt(
-            repository,
-            issueNumber,
-            context.workItemId,
-            forgeAuth,
-          )
+    const prompt = buildImplementPrompt(
+      repository,
+      issueNumber,
+      context.workItemId,
+      forgeAuth,
+      existingSessionId === null ? "start" : "continue",
+    )
 
     const agentBackend = yield* AgentBackend
     const sql = yield* SqlClient.SqlClient

--- a/packages/work-item-lifecycle/src/lib/publication-copy.ts
+++ b/packages/work-item-lifecycle/src/lib/publication-copy.ts
@@ -4,11 +4,14 @@
  */
 
 import { basename, extname, isAbsolute, relative, resolve } from "node:path"
+import { currentNativeForgeClosingReferenceRules } from "@ready-for-agent/forge-contract"
 import {
   classifyUnparsedResult,
   normalizeResultCandidateLine,
 } from "./result-line.js"
 import { promptUserContentSection } from "./sanitize-prompt-user-content.js"
+
+const closingReference = currentNativeForgeClosingReferenceRules
 
 /** GitHub pull request title limit. */
 export const PUBLICATION_TITLE_MAX_LENGTH = 256
@@ -28,17 +31,6 @@ const RESULT_LINE =
   /^READY_FOR_AGENT_RESULT:\s*PUBLICATION_COPY(?:\s+(\{[\s\S]*\}))?\s*$/i
 
 const PUBLICATION_COPY_NAMES = new Set(["PUBLICATION_COPY"])
-
-/**
- * Closing-reference patterns that the harness normalizes to a single
- * `Closes #<n>` line (issue keywords GitHub recognizes).
- */
-// Whole-line close/fix/resolve refs (optional list marker / trailing punctuation).
-const CLOSING_REFERENCE_LINE =
-  /^(?:[-*]\s+)?(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\s*[.:]?\s*$/i
-
-const GENERIC_PLACEHOLDER_BODY =
-  /^Automated draft pull request for GitHub issue #\d+\.?$/i
 
 const decodePublicationCopyJson = (
   jsonText: string,
@@ -153,23 +145,6 @@ export const inspectPublicationCopyResult = (output: string) => {
   } as const
 }
 
-const stripClosingReferences = (body: string, issueNumber: number): string => {
-  const kept: string[] = []
-  for (const line of body.split("\n")) {
-    const trimmed = line.trim()
-    const match = CLOSING_REFERENCE_LINE.exec(trimmed)
-    if (match !== null && Number(match[1]) === issueNumber) {
-      continue
-    }
-    kept.push(line)
-  }
-  // Collapse trailing blank lines left by stripped closing refs.
-  while (kept.length > 0 && kept[kept.length - 1]?.trim() === "") {
-    kept.pop()
-  }
-  return kept.join("\n").trim()
-}
-
 /**
  * Normalize agent copy: trim, enforce length bounds, require substantive body,
  * and ensure exactly one `Closes #<issue>` line. Returns null when invalid.
@@ -183,11 +158,11 @@ export const normalizePublicationCopy = (
     return null
   }
 
-  const withoutCloses = stripClosingReferences(raw.body, issueNumber)
+  const withoutCloses = closingReference.strip(raw.body, issueNumber)
   if (withoutCloses === "") {
     return null
   }
-  if (GENERIC_PLACEHOLDER_BODY.test(withoutCloses)) {
+  if (closingReference.isGenericPlaceholder(withoutCloses)) {
     return null
   }
   // Substantive: more than a single trivial token/line of punctuation.
@@ -195,8 +170,7 @@ export const normalizePublicationCopy = (
     return null
   }
 
-  const closesLine = `Closes #${issueNumber}`
-  const body = `${withoutCloses}\n\n${closesLine}`
+  const body = `${withoutCloses}\n\n${closingReference.formatLine(issueNumber)}`
   if (body.length > PUBLICATION_BODY_MAX_LENGTH) {
     return null
   }
@@ -237,7 +211,7 @@ export const buildHarnessPublicationFallbackCopy = (input: {
     `${HARNESS_FALLBACK_BODY_PREFIX} for Work Item ${input.workItemId}.`,
     "The agent did not emit valid publication copy. Review the linked Issue and this commit diff.",
     "",
-    `Closes #${input.issueNumber}`,
+    closingReference.formatLine(input.issueNumber),
   ].join("\n")
   return { title, body }
 }
@@ -411,12 +385,10 @@ export const publicationCopyFromCommitMessage = (
   // Prefer equality with the actual commit: strip duplicate closing refs and
   // re-append exactly one. Do not invent prose when the body was empty or only
   // closes (legacy `title\n\nCloses #N` → body is just `Closes #N`).
-  const stripped = body === "" ? "" : stripClosingReferences(body, issueNumber)
+  const stripped = body === "" ? "" : closingReference.strip(body, issueNumber)
   const prose = stripped.trim()
-  const normalizedBody =
-    prose === ""
-      ? `Closes #${issueNumber}`
-      : `${prose}\n\nCloses #${issueNumber}`
+  const closesLine = closingReference.formatLine(issueNumber)
+  const normalizedBody = prose === "" ? closesLine : `${prose}\n\n${closesLine}`
   if (title.length > PUBLICATION_TITLE_MAX_LENGTH) {
     return {
       title: title.slice(0, PUBLICATION_TITLE_MAX_LENGTH).trimEnd(),
@@ -446,8 +418,8 @@ export const buildPublicationCopyPrompt = (input: {
     "- title: a concise title describing the actual net change; follow this repository's conventions (for example Conventional Commits when the repo uses them).",
     "- body: useful reviewer-facing Markdown explaining why the change was needed, what changed, and meaningful verification or limitations.",
     "Do not use the Issue title alone as the publication title.",
-    'Do not write a generic body such as "Automated draft pull request for GitHub issue #N".',
-    `You may mention issue #${input.issueNumber}; the harness will ensure the body ends with exactly one Closes #${input.issueNumber} reference.`,
+    `Do not write a generic body such as "${closingReference.genericPlaceholderExample}".`,
+    closingReference.mentionGuidance(input.issueNumber),
     "End your final response with exactly one machine-readable result line. Prefer putting the JSON on that line:",
     `READY_FOR_AGENT_RESULT: PUBLICATION_COPY {"title":"...","body":"..."}`,
     "The body value must be a JSON string (use \\n for newlines). The result line must be the final non-empty line.",
@@ -504,7 +476,7 @@ export const buildCommitFallbackPromptWithCopy = (input: {
     "Prefer this exact commit message (subject + body). Only change the message if repository policy (for example commitlint) requires a different form:",
     promptUserContentSection("publication_title", input.title),
     promptUserContentSection("publication_body", input.body),
-    `The commit must still close GitHub issue #${input.issueNumber} (include Closes #${input.issueNumber} in the body unless policy forbids it — then mention the issue another accepted way).`,
+    closingReference.commitMustCloseGuidance(input.issueNumber),
     "Stage only the relevant implementation changes, then commit.",
     "Exclude harness-owned diagnostic artifacts such as `.ready-for-agent/`.",
     "If there is nothing left to commit because a valid commit already exists for this work, succeed without creating an empty commit.",


### PR DESCRIPTION
Implement, publication, and Create PR each inferred how to name the Issue, whether the agent may close it, how to normalize `Closes #N`, and whether to write an Azure ArtifactLink from the Repository Forge name.

Those existing three-Forge rules now live on one contract. Callers take identity text, stay-open and credential guidance, closing-reference strip/insert, and native PR association from that owner instead of switching on Forge names themselves.

GitHub stays ambient (no host, no Implement credential line). GitLab and Azure DevOps still name the host. Agents are still forbidden from closing or completing the Issue. Publication copy stays `Closes #N` for all three Forges, including Azure, which still writes the ArtifactLink at the same Create PR point (create, reuse, and retry). No new Forge kinds, settings, or domain roles.

Verification: Nx typecheck, lint, unused-export checks, and tests on the contract and lifecycle packages; pre-commit after a type-only exhaustive-check fix on the association helper.

See #1291.

Closes #1291